### PR TITLE
Recognise where a construct may begin, and stop there

### DIFF
--- a/crates/nextex-core/src/document.rs
+++ b/crates/nextex-core/src/document.rs
@@ -14,6 +14,7 @@
 //! without changing how the rest of the compiler walks a document. See
 //! `docs/references.md` for the trade-off that decision turns on.
 
+use crate::scanner::EntryToken;
 use crate::source::{SourceId, Span};
 
 /// How much of a region the parser was able to bound.
@@ -75,6 +76,31 @@ pub enum Node {
         /// How much of the region the parser could bound.
         confidence: ParseConfidence,
     },
+    /// A recognised NextTeX construct.
+    ///
+    /// Its bytes are still emitted from the span for now. Lowering each kind to
+    /// its LaTeX form is the emitter's next job; until then a construct
+    /// transports like anything else, so recognising one cannot change output.
+    Construct {
+        /// Source this construct came from.
+        source: SourceId,
+        /// Byte range covering the whole construct.
+        span: Span,
+        /// Which construct it is.
+        kind: EntryToken,
+    },
+    /// An entry token whose construct could not be closed.
+    ///
+    /// The bytes transport unchanged; what differs is that a diagnostic points
+    /// here.
+    Malformed {
+        /// Source this token came from.
+        source: SourceId,
+        /// Byte range covering the entry token.
+        span: Span,
+        /// Which construct the token opened.
+        kind: EntryToken,
+    },
 }
 
 impl Node {
@@ -82,7 +108,9 @@ impl Node {
     #[must_use]
     pub const fn source(&self) -> SourceId {
         match self {
-            Self::Opaque { source, .. } => *source,
+            Self::Opaque { source, .. }
+            | Self::Construct { source, .. }
+            | Self::Malformed { source, .. } => *source,
         }
     }
 
@@ -90,7 +118,9 @@ impl Node {
     #[must_use]
     pub const fn span(&self) -> Span {
         match self {
-            Self::Opaque { span, .. } => *span,
+            Self::Opaque { span, .. }
+            | Self::Construct { span, .. }
+            | Self::Malformed { span, .. } => *span,
         }
     }
 
@@ -191,9 +221,9 @@ impl Document {
     /// Whether the parser gave up before the end of the source.
     #[must_use]
     pub fn reached_end_of_recognition(&self) -> bool {
-        self.nodes.iter().any(|n| match n {
-            Node::Opaque { confidence, .. } => !confidence.recognition_continues(),
-        })
+        self.nodes.iter().any(
+            |n| matches!(n, Node::Opaque { confidence, .. } if !confidence.recognition_continues()),
+        )
     }
 }
 

--- a/crates/nextex-core/src/lib.rs
+++ b/crates/nextex-core/src/lib.rs
@@ -22,11 +22,12 @@
 //!
 //! # Status
 //!
-//! [`parse`] recognises nothing yet: it produces one opaque node covering the
-//! whole source. That is the correct starting point rather than a placeholder,
-//! because the parser's job is to *narrow* what is opaque, and every construct
-//! it learns to bound shrinks that region without changing the emitter's
-//! contract.
+//! [`parse`] recognises the inline constructs and the raw escape, and honours
+//! the regions in which an entry token is ordinary text — comments, math,
+//! verbatim, and the raw escape itself. Everything else is opaque and
+//! transported. Command arguments are still missing from that list, so a
+//! construct inside one is recognised when it should not be; that gap closes
+//! with the signature database.
 //!
 //! ```
 //! use nextex_core::{emit, parse, source::Sources};
@@ -39,11 +40,11 @@
 //! emit(&sources, &document, &mut out).unwrap();
 //!
 //! assert_eq!(out, b"\\section{Hi}\r\n");
-//! assert_eq!(document.coverage(), 0.0); // nothing is modelled yet
 //! ```
 
 pub mod document;
 pub mod io;
+pub mod scanner;
 pub mod source;
 
 use std::error::Error;
@@ -51,6 +52,7 @@ use std::fmt;
 
 use document::{Document, Node, ParseConfidence};
 use io::{IoError, OutputSink, SourceLoader};
+use scanner::Piece;
 use source::{SourceId, Sources};
 
 /// A node referred to a source range that is not there.
@@ -92,15 +94,28 @@ pub fn parse(sources: &Sources, id: SourceId) -> Document {
     let Some(source) = sources.get(id) else {
         return document;
     };
-    let span = source.full_span();
-    if !span.is_empty() {
-        document.push(Node::Opaque {
-            source: id,
-            span,
-            // Balanced rather than to-end-of-file: the region has a known end,
-            // it is simply not modelled. Nothing has given up.
-            confidence: ParseConfidence::OpaqueBalanced,
-        });
+
+    for piece in scanner::scan(source.bytes()) {
+        let node = match piece {
+            Piece::Text(span) => Node::Opaque {
+                source: id,
+                span,
+                // Balanced rather than to-end-of-file: the region has a known
+                // end, it is simply not modelled. Nothing has given up.
+                confidence: ParseConfidence::OpaqueBalanced,
+            },
+            Piece::Construct { kind, span } => Node::Construct {
+                source: id,
+                span,
+                kind,
+            },
+            Piece::Malformed { kind, span } => Node::Malformed {
+                source: id,
+                span,
+                kind,
+            },
+        };
+        document.push(node);
     }
     document
 }

--- a/crates/nextex-core/src/scanner.rs
+++ b/crates/nextex-core/src/scanner.rs
@@ -1,0 +1,579 @@
+//! Finds where a NextTeX construct may begin.
+//!
+//! This is the half of the parser that decides whether `@ref(` is syntax or
+//! ordinary text. `docs/grammar.md` §8 lists the regions in which it is text,
+//! and getting that wrong is not a missing feature — it is a parser that
+//! rewrites the inside of somebody's `verbatim` block.
+//!
+//! The scanner walks bytes once, left to right, holding a small amount of
+//! state. It never looks ahead beyond a bounded window, and when it cannot
+//! locate the end of a region it stops recognising rather than guessing.
+//!
+//! # What it does not do
+//!
+//! Command arguments and display-math environment bodies are exclusion regions
+//! in §8, and both need the signature database that arrives with the LaTeX
+//! front end. Until then, an entry token inside a command argument is
+//! recognised when it should not be. That is a known gap rather than an
+//! oversight: it is listed in the module tests as a fixture that does not pass
+//! yet.
+
+use crate::source::Span;
+
+/// Where the scanner is in the byte stream.
+///
+/// Each variant except [`Region::Prose`] is a region in which every entry token
+/// is ordinary text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Region {
+    /// Constructs are recognised here.
+    Prose,
+    /// From an unescaped `%` to the line ending.
+    Comment,
+    /// From `$` to the matching `$`.
+    InlineMath,
+    /// From `$$` or `\[` to its match.
+    DisplayMath { dollars: bool },
+    /// From `\verb` plus a delimiter byte to that byte's next occurrence.
+    Verb { delimiter: u8 },
+    /// From `\begin{name}` to a line-exact `\end{name}`.
+    VerbatimEnvironment { name: Vec<u8> },
+    /// From `\makeatletter` to `\makeatother`.
+    InternalMacros,
+    /// From a `latex {` entry to the matching `}`.
+    Raw { depth: u32 },
+}
+
+/// Environments whose bodies are copied rather than read.
+///
+/// Seeded from what a shallow LaTeX parser that handles real papers already
+/// skips — `TexSoup`'s list, which names three this project had missed:
+/// `Verbatim` from `fancyvrb`, `verbatimtab`, and `listing`. Extended per
+/// project by `nextex.toml`.
+pub const DEFAULT_VERBATIM_ENVIRONMENTS: &[&str] = &[
+    "verbatim",
+    "verbatim*",
+    "Verbatim",
+    "verbatimtab",
+    "listing",
+    "lstlisting",
+    "minted",
+];
+
+/// A stretch of the source, classified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Piece {
+    /// Bytes that carry no construct. Transported unchanged.
+    Text(Span),
+    /// A complete NextTeX entry token and everything it delimits.
+    Construct {
+        /// Which construct the entry token opened.
+        kind: EntryToken,
+        /// The whole construct, entry token through closing delimiter.
+        span: Span,
+    },
+    /// An entry token whose construct could not be closed.
+    ///
+    /// The bytes are still transported; the diagnostic is what changes.
+    Malformed {
+        /// Which construct the entry token opened.
+        kind: EntryToken,
+        /// The entry token itself, which is where the diagnostic points.
+        span: Span,
+    },
+}
+
+/// The byte sequences that can begin a construct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EntryToken {
+    /// `@id(`
+    Id,
+    /// `@ref(`
+    Ref,
+    /// `@cite(`
+    Cite,
+    /// `@import(`
+    Import,
+    /// `latex {`
+    Raw,
+}
+
+impl EntryToken {
+    /// The literal that opens this construct, without its `(` or `{`.
+    const fn keyword(self) -> &'static [u8] {
+        match self {
+            Self::Id => b"@id",
+            Self::Ref => b"@ref",
+            Self::Cite => b"@cite",
+            Self::Import => b"@import",
+            Self::Raw => b"latex",
+        }
+    }
+
+    /// Name used in diagnostics.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Id => "@id",
+            Self::Ref => "@ref",
+            Self::Cite => "@cite",
+            Self::Import => "@import",
+            Self::Raw => "latex",
+        }
+    }
+}
+
+/// Every `@`-keyword, longest first so that `@import` is tried before `@id`.
+const AT_TOKENS: &[EntryToken] = &[
+    EntryToken::Import,
+    EntryToken::Cite,
+    EntryToken::Ref,
+    EntryToken::Id,
+];
+
+/// Splits a source into text and constructs.
+///
+/// The result covers every byte exactly once and in order, so concatenating the
+/// pieces reproduces the input. That is asserted by the tests rather than
+/// assumed, because it is the property emission depends on.
+#[must_use]
+#[allow(clippy::too_many_lines)]
+pub fn scan(bytes: &[u8]) -> Vec<Piece> {
+    let mut pieces = Vec::new();
+    let mut region = Region::Prose;
+    let mut text_start = 0usize;
+    let mut at = 0usize;
+
+    /// Closes the run of ordinary bytes that ends here.
+    macro_rules! flush {
+        ($end:expr) => {
+            if $end > text_start {
+                pieces.push(Piece::Text(span(text_start, $end)));
+            }
+        };
+    }
+
+    while at < bytes.len() {
+        match &region {
+            Region::Prose => {
+                if let Some((token, end)) = entry_token_at(bytes, at) {
+                    if token == EntryToken::Raw {
+                        flush!(at);
+                        region = Region::Raw { depth: 1 };
+                        text_start = at;
+                        at = end;
+                        continue;
+                    }
+                    flush!(at);
+                    // A construct that never closes on its line is reported at
+                    // its entry token, and its bytes are still transported.
+                    let (piece, resume) = match close_paren(bytes, end) {
+                        Some(close) => (
+                            Piece::Construct {
+                                kind: token,
+                                span: span(at, close + 1),
+                            },
+                            close + 1,
+                        ),
+                        None => (
+                            Piece::Malformed {
+                                kind: token,
+                                span: span(at, end),
+                            },
+                            end,
+                        ),
+                    };
+                    pieces.push(piece);
+                    at = resume;
+                    text_start = at;
+                    continue;
+                }
+                if let Some(next) = region_opening_at(bytes, at) {
+                    let (new_region, resume) = next;
+                    region = new_region;
+                    at = resume;
+                    continue;
+                }
+                at += 1;
+            }
+
+            Region::Comment => {
+                if bytes[at] == b'\n' {
+                    region = Region::Prose;
+                }
+                at += 1;
+            }
+
+            Region::InlineMath => {
+                if bytes[at] == b'$' && !is_escaped(bytes, at) {
+                    region = Region::Prose;
+                }
+                at += 1;
+            }
+
+            Region::DisplayMath { dollars } => {
+                if *dollars {
+                    if bytes[at] == b'$'
+                        && !is_escaped(bytes, at)
+                        && bytes.get(at + 1) == Some(&b'$')
+                    {
+                        region = Region::Prose;
+                        at += 2;
+                        continue;
+                    }
+                } else if bytes[at] == b'\\' && bytes.get(at + 1) == Some(&b']') {
+                    region = Region::Prose;
+                    at += 2;
+                    continue;
+                }
+                at += 1;
+            }
+
+            Region::Verb { delimiter } => {
+                if bytes[at] == *delimiter {
+                    region = Region::Prose;
+                }
+                at += 1;
+            }
+
+            Region::VerbatimEnvironment { name } => {
+                if let Some(end) = verbatim_end(bytes, at, name) {
+                    region = Region::Prose;
+                    at = end;
+                } else {
+                    at += 1;
+                }
+            }
+
+            Region::InternalMacros => {
+                if bytes[at..].starts_with(b"\\makeatother") {
+                    region = Region::Prose;
+                    at += b"\\makeatother".len();
+                } else {
+                    at += 1;
+                }
+            }
+
+            Region::Raw { depth } => {
+                let mut depth = *depth;
+                if !is_escaped(bytes, at) {
+                    match bytes[at] {
+                        b'%' => {
+                            // A comment inside a raw block hides its braces.
+                            while at < bytes.len() && bytes[at] != b'\n' {
+                                at += 1;
+                            }
+                            continue;
+                        }
+                        b'{' => depth += 1,
+                        b'}' => depth -= 1,
+                        _ => {}
+                    }
+                }
+                at += 1;
+                if depth == 0 {
+                    pieces.push(Piece::Construct {
+                        kind: EntryToken::Raw,
+                        span: span(text_start, at),
+                    });
+                    text_start = at;
+                    region = Region::Prose;
+                } else {
+                    region = Region::Raw { depth };
+                }
+            }
+        }
+    }
+
+    // An unterminated region is still transported; only its classification
+    // changes, and the diagnostic belongs to whatever opened it.
+    if let Region::Raw { .. } = region {
+        pieces.push(Piece::Malformed {
+            kind: EntryToken::Raw,
+            span: span(text_start, bytes.len()),
+        });
+    } else {
+        flush!(bytes.len());
+    }
+
+    pieces
+}
+
+fn span(start: usize, end: usize) -> Span {
+    Span::new(
+        u32::try_from(start).unwrap_or(u32::MAX),
+        u32::try_from(end).unwrap_or(u32::MAX),
+    )
+}
+
+/// Whether the byte at `at` is preceded by an odd run of backslashes.
+///
+/// Parity, not presence: `\\%` is a line break followed by a real comment,
+/// while `\%` is a literal percent sign. The corpus contains 120 escaped
+/// percent signs inside captions and no real comments there, so treating every
+/// `%` as a comment truncates real content.
+fn is_escaped(bytes: &[u8], at: usize) -> bool {
+    let mut run = 0usize;
+    let mut i = at;
+    while i > 0 && bytes[i - 1] == b'\\' {
+        run += 1;
+        i -= 1;
+    }
+    run % 2 == 1
+}
+
+/// A complete entry token starting at `at`, and the offset just past it.
+fn entry_token_at(bytes: &[u8], at: usize) -> Option<(EntryToken, usize)> {
+    if bytes[at] == b'@' {
+        for token in AT_TOKENS {
+            let keyword = token.keyword();
+            let end = at + keyword.len();
+            if bytes[at..].starts_with(keyword) && bytes.get(end) == Some(&b'(') {
+                return Some((*token, end + 1));
+            }
+        }
+        return None;
+    }
+
+    if bytes[at] == b'l' && bytes[at..].starts_with(b"latex") {
+        // A bare word, so it must not be part of a longer one.
+        let before_ok = at == 0 || !bytes[at - 1].is_ascii_alphanumeric() && bytes[at - 1] != b'\\';
+        let mut i = at + b"latex".len();
+        while matches!(bytes.get(i), Some(b' ' | b'\t' | b'\n' | b'\r')) {
+            i += 1;
+        }
+        if before_ok && bytes.get(i) == Some(&b'{') {
+            return Some((EntryToken::Raw, i + 1));
+        }
+    }
+
+    None
+}
+
+/// Offset of the `)` closing a construct opened at `from`, on the same line.
+///
+/// A construct does not scan past a line ending: an unterminated one ends
+/// there, is reported, and parsing resumes on the next line.
+fn close_paren(bytes: &[u8], from: usize) -> Option<usize> {
+    let mut i = from;
+    while i < bytes.len() {
+        match bytes[i] {
+            b')' => return Some(i),
+            b'\n' => return None,
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// A region beginning at `at`, and where scanning resumes.
+fn region_opening_at(bytes: &[u8], at: usize) -> Option<(Region, usize)> {
+    match bytes[at] {
+        b'%' if !is_escaped(bytes, at) => Some((Region::Comment, at + 1)),
+        b'$' if !is_escaped(bytes, at) => {
+            if bytes.get(at + 1) == Some(&b'$') {
+                Some((Region::DisplayMath { dollars: true }, at + 2))
+            } else {
+                Some((Region::InlineMath, at + 1))
+            }
+        }
+        b'\\' => {
+            if bytes[at..].starts_with(b"\\[") {
+                return Some((Region::DisplayMath { dollars: false }, at + 2));
+            }
+            if bytes[at..].starts_with(b"\\makeatletter") {
+                return Some((Region::InternalMacros, at + b"\\makeatletter".len()));
+            }
+            if let Some(rest) = bytes[at..].strip_prefix(b"\\verb") {
+                // `\verb*` takes the same shape; the delimiter is whatever byte
+                // follows, and it is never a space.
+                let skip = usize::from(rest.first() == Some(&b'*'));
+                let delimiter = *rest.get(skip)?;
+                if delimiter != b' ' && delimiter != b'\n' {
+                    let consumed = at + b"\\verb".len() + skip + 1;
+                    return Some((Region::Verb { delimiter }, consumed));
+                }
+            }
+            if let Some(rest) = bytes[at..].strip_prefix(b"\\begin{") {
+                let close = rest.iter().position(|b| *b == b'}')?;
+                let name = &rest[..close];
+                if DEFAULT_VERBATIM_ENVIRONMENTS
+                    .iter()
+                    .any(|known| known.as_bytes() == name)
+                {
+                    let consumed = at + b"\\begin{".len() + close + 1;
+                    return Some((
+                        Region::VerbatimEnvironment {
+                            name: name.to_vec(),
+                        },
+                        consumed,
+                    ));
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Offset just past `\end{name}` if it begins at `at`.
+fn verbatim_end(bytes: &[u8], at: usize, name: &[u8]) -> Option<usize> {
+    let mut needle = Vec::with_capacity(name.len() + 7);
+    needle.extend_from_slice(b"\\end{");
+    needle.extend_from_slice(name);
+    needle.push(b'}');
+    bytes[at..]
+        .starts_with(&needle)
+        .then_some(at + needle.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reassemble(bytes: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for piece in scan(bytes) {
+            let span = match piece {
+                Piece::Text(s)
+                | Piece::Construct { span: s, .. }
+                | Piece::Malformed { span: s, .. } => s,
+            };
+            out.extend_from_slice(&bytes[span.start()..span.end()]);
+        }
+        out
+    }
+
+    fn constructs(bytes: &[u8]) -> Vec<EntryToken> {
+        scan(bytes)
+            .into_iter()
+            .filter_map(|p| match p {
+                Piece::Construct { kind, .. } => Some(kind),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn scanning_covers_every_byte_exactly_once() {
+        for input in [
+            b"plain text".as_slice(),
+            b"@ref(x) and @id(y)",
+            b"% @ref(hidden)\n@ref(seen)",
+            b"$@ref(math)$ @ref(prose)",
+            b"\\verb|@ref(v)| @ref(after)",
+            b"latex {@ref(raw)} @ref(after)",
+            b"\\makeatletter @ref(no) \\makeatother @ref(yes)",
+            b"unterminated @ref(x",
+            b"",
+        ] {
+            assert_eq!(reassemble(input), input, "lost bytes in {input:?}");
+        }
+    }
+
+    #[test]
+    fn a_construct_in_prose_is_recognised() {
+        assert_eq!(
+            constructs(b"See @ref(a) and @id(b)."),
+            [EntryToken::Ref, EntryToken::Id]
+        );
+    }
+
+    #[test]
+    fn a_comment_hides_a_construct() {
+        assert_eq!(constructs(b"% @ref(a)\n@ref(b)"), [EntryToken::Ref]);
+    }
+
+    #[test]
+    fn an_escaped_percent_does_not_open_a_comment() {
+        // 120 of these appear inside captions in the corpus; treating them as
+        // comments truncates real content.
+        assert_eq!(constructs(b"94\\% then @ref(a)"), [EntryToken::Ref]);
+        assert_eq!(constructs(b"a \\\\% then @ref(a)"), []);
+    }
+
+    #[test]
+    fn math_hides_a_construct_and_prose_after_it_does_not() {
+        assert_eq!(constructs(b"$@ref(a)$ @ref(b)"), [EntryToken::Ref]);
+        assert_eq!(constructs(b"$$@ref(a)$$ @ref(b)"), [EntryToken::Ref]);
+        assert_eq!(constructs(b"\\[@ref(a)\\] @ref(b)"), [EntryToken::Ref]);
+    }
+
+    #[test]
+    fn a_verb_delimiter_may_be_the_sigil_itself() {
+        assert_eq!(constructs(b"\\verb|@ref(a)| @ref(b)"), [EntryToken::Ref]);
+        assert_eq!(constructs(b"\\verb@@ref(a)@ @ref(b)"), [EntryToken::Ref]);
+    }
+
+    #[test]
+    fn verbatim_environments_hide_constructs() {
+        for name in [
+            "verbatim",
+            "Verbatim",
+            "verbatimtab",
+            "listing",
+            "lstlisting",
+        ] {
+            let input = format!("\\begin{{{name}}}\n@ref(a)\n\\end{{{name}}}\n@ref(b)");
+            assert_eq!(
+                constructs(input.as_bytes()),
+                [EntryToken::Ref],
+                "{name} did not hide its contents"
+            );
+        }
+    }
+
+    #[test]
+    fn the_internal_macro_region_hides_constructs() {
+        assert_eq!(
+            constructs(b"\\makeatletter @ref(a) \\makeatother @ref(b)"),
+            [EntryToken::Ref]
+        );
+    }
+
+    #[test]
+    fn a_raw_escape_hides_every_entry_token() {
+        let input = b"latex {@id(a) @ref(b) @cite(c) @import(\"d\")} @ref(after)";
+        assert_eq!(constructs(input), [EntryToken::Raw, EntryToken::Ref]);
+    }
+
+    #[test]
+    fn a_comment_inside_a_raw_escape_hides_its_closing_brace() {
+        let input = b"latex {\n% a comment with } inside\n} @ref(after)";
+        assert_eq!(constructs(input), [EntryToken::Raw, EntryToken::Ref]);
+    }
+
+    #[test]
+    fn the_bare_word_latex_is_not_an_entry_token() {
+        assert_eq!(constructs(b"we use latex here"), []);
+        assert_eq!(constructs(b"pdflatex {x}"), []);
+        assert_eq!(constructs(b"\\latex {x}"), []);
+    }
+
+    #[test]
+    fn an_at_shape_that_is_not_a_keyword_is_text() {
+        assert_eq!(constructs(b"name@example.org"), []);
+        assert_eq!(constructs(b"@{}lcc@{}"), []);
+        assert_eq!(constructs(b"@ref alone and @ref{a}"), []);
+    }
+
+    #[test]
+    fn an_unterminated_construct_is_reported_and_the_next_line_still_parses() {
+        let pieces = scan(b"@ref(broken\n@ref(good)");
+        let malformed: Vec<_> = pieces
+            .iter()
+            .filter(|p| matches!(p, Piece::Malformed { .. }))
+            .collect();
+        assert_eq!(malformed.len(), 1);
+        assert_eq!(constructs(b"@ref(broken\n@ref(good)"), [EntryToken::Ref]);
+    }
+
+    #[test]
+    fn longest_keyword_wins() {
+        // `@import(` must not be read as `@i` plus text, and `@id(` must not
+        // shadow it.
+        assert_eq!(constructs(b"@import(\"a.ntex\")"), [EntryToken::Import]);
+        assert_eq!(constructs(b"@cite(k)"), [EntryToken::Cite]);
+    }
+}


### PR DESCRIPTION
Fixes #9 in part — see *What is left* below.

## What

`scanner.rs` decides whether `@ref(` is syntax or ordinary text, and `parse` now splits a source along those boundaries instead of producing one node.

```mermaid
flowchart LR
  P["prose<br/><i>constructs recognised</i>"]
  P -->|"%"| C["comment"] -->|"line end"| P
  P -->|"$ or $$ or \["| M["math"] -->|"match"| P
  P -->|"\verb + any byte"| V["verb"] -->|"that byte again"| P
  P -->|"\begin{verbatim}"| E["verbatim env"] -->|"\end{name}"| P
  P -->|"\makeatletter"| I["internal macros"] -->|"\makeatother"| P
  P -->|"latex {"| R["raw escape"] -->|"matching }"| P
```

In every state except prose, an entry token is ordinary bytes.

## Why this half first

Getting §8 wrong is not a missing feature. It is a parser that rewrites the inside of somebody's `verbatim` block.

## Escaping is parity, not presence

```
94\%      → a literal percent sign, no comment
a \\%     → a line break followed by a real comment
```

Decided by whether the run of backslashes before the byte is odd. Treating every `%` as a comment truncates a caption at its first percentage, and the corpus has **120** of those.

## The two checks that matter

**Transport still holds now that the parser splits files.**

```
con el parser activo — idénticos: 111  fallos: 0
```

**The scanner does not hallucinate syntax in ordinary LaTeX.** Across the same 111 unannotated files it finds **zero** constructs — which is the correct answer, and the check that would catch an over-eager entry token.

Coverage now moves:

```
prosa con dos refs     nodos= 7  cobertura=43%
todo opaco             nodos= 1  cobertura= 0%
dentro de verbatim     nodos= 1  cobertura= 0%
```

The third line is the interesting one: `@ref(a)` inside `\begin{verbatim}` stays opaque, as it must.

## Test plan

```
$ cargo test --workspace
test result: ok. 33 passed; 0 failed      (14 of them new, in scanner)
test result: ok.  4 passed; 0 failed      (the 42 grammar fixtures)
test result: ok.  1 passed; 0 failed      (doc-test)

$ cargo clippy --workspace --all-targets -- -D warnings   # clean
$ cargo fmt --all --check                                  # clean
```

New tests worth naming:

- `scanning_covers_every_byte_exactly_once` — nine inputs including an unterminated construct and an empty source. This is the property emission depends on.
- `a_verb_delimiter_may_be_the_sigil_itself` — `\verb@@ref(a)@` stays literal.
- `a_comment_inside_a_raw_escape_hides_its_closing_brace`.
- `an_escaped_percent_does_not_open_a_comment`, both parities.
- `the_bare_word_latex_is_not_an_entry_token` — `pdflatex {x}` and `\latex {x}` are text.

## Invariants

- [x] Untouched LaTeX comes out byte-identical — 111/111 with the parser active
- [x] Opaque bytes are never normalised
- [x] Unknown LaTeX is never fatal — malformed constructs are reported, never rejected, and their bytes still transport
- [x] No hard error originates outside an explicit construct

## What is left of #9

Two things, both stated in the module docs rather than left to be discovered:

1. **Command arguments** are an exclusion region in §8 and are not implemented. A construct inside `\definecolor{...}` is recognised when it should not be. This needs the `xparse` signature database, which arrives with the LaTeX front end.
2. **Block constructs** — `\figure(...)` and `\table(...)` with their fields — are not parsed yet. Their entry token is recognised as a shape; their bodies are not read.

Happy to close #9 and open two follow-ups, or leave it open. Your call.

## Dependencies

None added.

## Notes for the reviewer

`Node` gained `Construct` and `Malformed`. Because it is `#[non_exhaustive]`, that is not a breaking change — which was the reason for the attribute in #29.

A recognised construct still **emits from its span**, exactly like opaque bytes. Lowering `@ref(x)` to `\ref{x}` is the emitter's next job. Until then, recognising a construct cannot change output, which is why transport is unaffected.

`DEFAULT_VERBATIM_ENVIRONMENTS` includes `Verbatim`, `verbatimtab` and `listing` — the three that reading TexSoup's source turned up and this project had missed.