### PR TITLE
Parse block fields, and resolve a conflict the spec did not foresee

### DIFF
--- a/crates/nextex-core/src/blocks.rs
+++ b/crates/nextex-core/src/blocks.rs
@@ -1,0 +1,459 @@
+//! Typed blocks and their fields.
+//!
+//! `\figure(id) { … }` and `\table(id) { … }`, per `docs/grammar.md` §5. A
+//! field's value kind is fixed by its name, so the parser reads the kind the
+//! specification declares rather than trying alternatives until one succeeds —
+//! which would make a malformed value silently become a different valid one.
+//!
+//! Three field names are rejected rather than ignored. `columns` restated what
+//! a tabular column specification already says, so the two could disagree;
+//! `needs` would have emitted a `\usepackage` the source did not contain, which
+//! the no-injection rule forbids. A document carrying either is malformed, and
+//! saying so is how an author learns the field is gone.
+
+use crate::scanner::{CommentRule, balanced_end, balanced_end_with};
+use crate::source::Span;
+
+/// Which typed block this is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BlockKind {
+    /// `\figure(id) { … }`
+    Figure,
+    /// `\table(id) { … }`
+    Table,
+}
+
+impl BlockKind {
+    /// Name used in diagnostics.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Figure => "\\figure",
+            Self::Table => "\\table",
+        }
+    }
+
+    /// The value kind this block requires for `key`, if it accepts it at all.
+    const fn value_kind(self, key: &[u8]) -> Option<ValueKind> {
+        match (self, key) {
+            (Self::Figure, b"src") => Some(ValueKind::Str),
+            (Self::Figure, b"width") => Some(ValueKind::LengthOrPercentage),
+            (Self::Figure | Self::Table, b"caption") | (Self::Table, b"body" | b"trailing") => {
+                Some(ValueKind::Braced)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// The shape a field's value must take.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ValueKind {
+    Str,
+    LengthOrPercentage,
+    Braced,
+}
+
+/// A field's value, as it appears in the source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Value {
+    /// A quoted string. The span covers the quotes.
+    Str(Span),
+    /// A number and a unit.
+    Length(Span),
+    /// A number and a percent sign.
+    Percentage(Span),
+    /// Balanced braces. The span covers them.
+    Braced(Span),
+}
+
+impl Value {
+    /// Byte range this value covers.
+    #[must_use]
+    pub const fn span(self) -> Span {
+        match self {
+            Self::Str(s) | Self::Length(s) | Self::Percentage(s) | Self::Braced(s) => s,
+        }
+    }
+}
+
+/// One `key = value` pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Field {
+    /// The key.
+    pub key: Span,
+    /// The value.
+    pub value: Value,
+}
+
+/// A parsed typed block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Block {
+    /// Which block it is.
+    pub kind: BlockKind,
+    /// The identifier between the parentheses.
+    pub id: Span,
+    /// Fields in source order.
+    pub fields: Vec<Field>,
+    /// The whole construct, entry token through closing brace.
+    pub span: Span,
+}
+
+/// Why a block could not be parsed.
+///
+/// Every variant carries the span a diagnostic points at, which is the field or
+/// token at fault rather than the whole block. A reader who is told "this block
+/// is wrong" has to find the reason; one who is told which field is wrong does
+/// not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BlockError {
+    /// The identifier is empty or contains bytes an identifier may not.
+    BadIdentifier(Span),
+    /// No `{` follows the identifier.
+    MissingBody(Span),
+    /// The body's braces never balance before end of file.
+    UnclosedBody(Span),
+    /// A field name this block does not accept.
+    UnknownField {
+        /// The offending key.
+        key: Span,
+        /// Why it is not accepted.
+        reason: RemovedField,
+    },
+    /// The value is not the kind this field requires.
+    WrongValueKind {
+        /// The offending key.
+        key: Span,
+        /// What the specification requires.
+        expected: &'static str,
+    },
+    /// A field has no `=`.
+    MissingEquals(Span),
+}
+
+/// Whether a rejected field was removed from the specification, or never in it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RemovedField {
+    /// `columns` — the count is read from the tabular column specification.
+    Columns,
+    /// `needs` — emitting `\usepackage` would inject bytes the source lacks.
+    Needs,
+    /// Not a field of this block.
+    Unknown,
+}
+
+impl RemovedField {
+    /// One sentence a reader can act on.
+    #[must_use]
+    pub const fn explanation(self) -> &'static str {
+        match self {
+            Self::Columns => {
+                "the column count is read from the tabular column specification, \
+                 so declaring it here lets the two disagree"
+            }
+            Self::Needs => {
+                "a block cannot add a \\usepackage the source does not contain; \
+                 declare the package in the preamble"
+            }
+            Self::Unknown => "this block has no such field",
+        }
+    }
+}
+
+/// Parses a block whose entry token starts at `start`.
+///
+/// `after_entry` is the offset just past `\figure(` or `\table(`.
+///
+/// # Errors
+///
+/// Returns [`BlockError`] pointing at the field or token at fault. The bytes
+/// are transported either way; only the diagnostic changes.
+pub fn parse_block(
+    bytes: &[u8],
+    kind: BlockKind,
+    start: usize,
+    after_entry: usize,
+) -> Result<Block, BlockError> {
+    let id_end = bytes[after_entry..]
+        .iter()
+        .position(|b| *b == b')' || *b == b'\n')
+        .map(|i| after_entry + i)
+        .filter(|i| bytes[*i] == b')')
+        .ok_or_else(|| BlockError::BadIdentifier(span(start, after_entry)))?;
+
+    let id = span(after_entry, id_end);
+    if id.is_empty() || !is_identifier(&bytes[after_entry..id_end]) {
+        return Err(BlockError::BadIdentifier(id));
+    }
+
+    let mut at = skip_whitespace(bytes, id_end + 1);
+    if bytes.get(at) != Some(&b'{') {
+        return Err(BlockError::MissingBody(span(start, at.min(bytes.len()))));
+    }
+    let body_open = at;
+    // A block body is scanned with the percent-after-digit rule, because the
+    // grammar admits `width = 80%` and LaTeX's own rule would let that `%`
+    // swallow the closing brace.
+    let body_end = balanced_end_with(bytes, body_open, CommentRule::PercentAfterDigit)
+        .ok_or_else(|| BlockError::UnclosedBody(span(start, bytes.len())))?;
+
+    at = skip_whitespace(bytes, body_open + 1);
+    let mut fields = Vec::new();
+
+    while at < body_end - 1 {
+        let key_start = at;
+        while at < body_end && (bytes[at].is_ascii_lowercase() || bytes[at] == b'_') {
+            at += 1;
+        }
+        if at == key_start {
+            break;
+        }
+        let key = span(key_start, at);
+
+        at = skip_whitespace(bytes, at);
+        if bytes.get(at) != Some(&b'=') {
+            return Err(BlockError::MissingEquals(key));
+        }
+        at = skip_whitespace(bytes, at + 1);
+
+        let Some(expected) = kind.value_kind(&bytes[key.start()..key.end()]) else {
+            return Err(BlockError::UnknownField {
+                key,
+                reason: removed_field(&bytes[key.start()..key.end()]),
+            });
+        };
+
+        let (value, next) = read_value(bytes, at, body_end, expected).ok_or({
+            BlockError::WrongValueKind {
+                key,
+                expected: describe(expected),
+            }
+        })?;
+        fields.push(Field { key, value });
+        at = skip_whitespace(bytes, next);
+    }
+
+    Ok(Block {
+        kind,
+        id,
+        fields,
+        span: span(start, body_end),
+    })
+}
+
+fn removed_field(key: &[u8]) -> RemovedField {
+    match key {
+        b"columns" => RemovedField::Columns,
+        b"needs" => RemovedField::Needs,
+        _ => RemovedField::Unknown,
+    }
+}
+
+const fn describe(kind: ValueKind) -> &'static str {
+    match kind {
+        ValueKind::Str => "a quoted string",
+        ValueKind::LengthOrPercentage => "a length such as 4cm, or a percentage such as 80%",
+        ValueKind::Braced => "a braced group, because it may span lines and contain LaTeX",
+    }
+}
+
+fn read_value(
+    bytes: &[u8],
+    at: usize,
+    limit: usize,
+    expected: ValueKind,
+) -> Option<(Value, usize)> {
+    match expected {
+        ValueKind::Str => {
+            if bytes.get(at) != Some(&b'"') {
+                return None;
+            }
+            let mut i = at + 1;
+            while i < limit {
+                match bytes[i] {
+                    b'\\' => i += 2,
+                    b'"' => return Some((Value::Str(span(at, i + 1)), i + 1)),
+                    b'\n' => return None,
+                    _ => i += 1,
+                }
+            }
+            None
+        }
+        ValueKind::LengthOrPercentage => {
+            let mut i = at;
+            while i < limit && (bytes[i].is_ascii_digit() || bytes[i] == b'.') {
+                i += 1;
+            }
+            if i == at {
+                return None;
+            }
+            if bytes.get(i) == Some(&b'%') {
+                return Some((Value::Percentage(span(at, i + 1)), i + 1));
+            }
+            for unit in [b"pt", b"mm", b"cm", b"in", b"em", b"ex"] {
+                if bytes[i..].starts_with(unit) {
+                    return Some((Value::Length(span(at, i + 2)), i + 2));
+                }
+            }
+            None
+        }
+        ValueKind::Braced => {
+            if bytes.get(at) != Some(&b'{') {
+                return None;
+            }
+            let end = balanced_end(bytes, at)?;
+            Some((Value::Braced(span(at, end)), end))
+        }
+    }
+}
+
+fn is_identifier(bytes: &[u8]) -> bool {
+    matches!(bytes.first(), Some(b) if b.is_ascii_alphabetic())
+        && bytes
+            .iter()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b':' | b'.' | b'-'))
+}
+
+fn skip_whitespace(bytes: &[u8], mut at: usize) -> usize {
+    while matches!(bytes.get(at), Some(b' ' | b'\t' | b'\n' | b'\r')) {
+        at += 1;
+    }
+    at
+}
+
+fn span(start: usize, end: usize) -> Span {
+    Span::new(
+        u32::try_from(start).unwrap_or(u32::MAX),
+        u32::try_from(end).unwrap_or(u32::MAX),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(input: &str) -> Result<Block, BlockError> {
+        let bytes = input.as_bytes();
+        let (kind, entry) = if bytes.starts_with(b"\\figure(") {
+            (BlockKind::Figure, b"\\figure(".len())
+        } else {
+            (BlockKind::Table, b"\\table(".len())
+        };
+        parse_block(bytes, kind, 0, entry)
+    }
+
+    fn keys(input: &str) -> Vec<String> {
+        let bytes = input.as_bytes();
+        parse(input)
+            .unwrap()
+            .fields
+            .iter()
+            .map(|f| String::from_utf8_lossy(&bytes[f.key.start()..f.key.end()]).into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn a_figure_reads_its_three_fields() {
+        let input =
+            "\\figure(fig:r) {\n  src = \"r.pdf\"\n  width = 80%\n  caption = {A caption}\n}";
+        assert_eq!(keys(input), ["src", "width", "caption"]);
+        assert_eq!(parse(input).unwrap().kind, BlockKind::Figure);
+    }
+
+    #[test]
+    fn a_caption_may_span_lines_and_nest_braces() {
+        let input =
+            "\\table(t) {\n  caption = {A caption across\n  two lines with {nested {groups}}}\n}";
+        assert_eq!(keys(input), ["caption"]);
+    }
+
+    #[test]
+    fn a_caption_containing_an_escaped_percent_is_not_truncated() {
+        let input = "\\figure(f) {\n  caption = {Accuracy rose 12\\% and {10\\%} of runs}\n}";
+        let block = parse(input).unwrap();
+        let Value::Braced(span) = block.fields[0].value else {
+            panic!("caption is braced")
+        };
+        assert!(span.len() > 30, "caption was cut short at the percent sign");
+    }
+
+    #[test]
+    fn a_comment_inside_a_caption_hides_its_braces() {
+        let input = "\\figure(f) {\n  caption = {before\n  % a comment with } inside\n  after}\n}";
+        assert_eq!(keys(input), ["caption"]);
+    }
+
+    #[test]
+    fn width_takes_a_length_or_a_percentage() {
+        for value in ["80%", "4cm", "12.5pt"] {
+            let input = format!("\\figure(f) {{ width = {value} }}");
+            assert_eq!(keys(&input), ["width"], "{value} was refused");
+        }
+    }
+
+    #[test]
+    fn a_bare_caption_is_refused_because_it_cannot_span_lines() {
+        let input = "\\figure(f) { caption = unbraced text }";
+        assert!(matches!(
+            parse(input),
+            Err(BlockError::WrongValueKind { .. })
+        ));
+    }
+
+    #[test]
+    fn columns_is_rejected_and_says_why() {
+        let input = "\\table(t) { columns = 7 }";
+        let Err(BlockError::UnknownField { reason, .. }) = parse(input) else {
+            panic!("columns must be rejected")
+        };
+        assert_eq!(reason, RemovedField::Columns);
+        assert!(reason.explanation().contains("column specification"));
+    }
+
+    #[test]
+    fn needs_is_rejected_and_says_why() {
+        let input = "\\table(t) { needs = booktabs }";
+        let Err(BlockError::UnknownField { reason, .. }) = parse(input) else {
+            panic!("needs must be rejected")
+        };
+        assert_eq!(reason, RemovedField::Needs);
+        assert!(reason.explanation().contains("usepackage"));
+    }
+
+    #[test]
+    fn an_unclosed_body_reports_rather_than_scanning_forever() {
+        let input = "\\figure(f) {\n  caption = {never closed\n";
+        assert!(matches!(parse(input), Err(BlockError::UnclosedBody(_))));
+    }
+
+    #[test]
+    fn a_bad_identifier_is_reported_at_the_identifier() {
+        assert!(matches!(
+            parse("\\figure() { }"),
+            Err(BlockError::BadIdentifier(_))
+        ));
+        assert!(matches!(
+            parse("\\figure(9bad) { }"),
+            Err(BlockError::BadIdentifier(_))
+        ));
+    }
+
+    #[test]
+    fn a_field_without_an_equals_is_reported_at_the_key() {
+        assert!(matches!(
+            parse("\\figure(f) { src \"x.pdf\" }"),
+            Err(BlockError::MissingEquals(_))
+        ));
+    }
+
+    #[test]
+    fn a_table_accepts_trailing_content() {
+        let input =
+            "\\table(t) {\n  body = { x }\n  trailing = { \\vspace{2pt} {\\scriptsize note} }\n}";
+        assert_eq!(keys(input), ["body", "trailing"]);
+    }
+}

--- a/crates/nextex-core/src/lib.rs
+++ b/crates/nextex-core/src/lib.rs
@@ -42,6 +42,7 @@
 //! assert_eq!(out, b"\\section{Hi}\r\n");
 //! ```
 
+pub mod blocks;
 pub mod document;
 pub mod io;
 pub mod scanner;

--- a/crates/nextex-core/src/scanner.rs
+++ b/crates/nextex-core/src/scanner.rs
@@ -300,6 +300,80 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
     pieces
 }
 
+/// Offset just past the `}` that closes the group opening at `open`.
+///
+/// Counts with LaTeX's own escaping: `\{`, `\}` and `\%` do not count, decided
+/// by backslash-run parity, and an unescaped `%` opens a comment through the
+/// line ending so braces inside it are invisible.
+///
+/// Returns `None` when the braces never balance, which is a boundary that could
+/// not be located rather than an error in the LaTeX.
+#[must_use]
+pub fn balanced_end(bytes: &[u8], open: usize) -> Option<usize> {
+    balanced_end_with(bytes, open, CommentRule::Latex)
+}
+
+/// How `%` is read while scanning a balanced region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommentRule {
+    /// LaTeX's own rule: an unescaped `%` opens a comment.
+    Latex,
+    /// As above, except that a `%` immediately after an ASCII digit is a
+    /// percent sign.
+    ///
+    /// This exists because the grammar admits `width = 80%` as a value and also
+    /// scans block bodies with LaTeX's comment rule, and those two cannot both
+    /// hold: the `%` swallows the closing brace and the block never ends. It is
+    /// the same collision the tool baseline measured in plain LaTeX, where
+    /// `width=120%` fails with `File ended while scanning use of \Gin@ii`.
+    ///
+    /// One byte of context decides it, so it stays a left-to-right rule. It
+    /// applies only inside a NextTeX block body, never to transported LaTeX,
+    /// where a comment must keep meaning what TeX says it means.
+    PercentAfterDigit,
+}
+
+/// [`balanced_end`] with an explicit rule for `%`.
+///
+/// # Panics
+///
+/// Never; the signature returns `None` for every failure.
+#[must_use]
+pub fn balanced_end_with(bytes: &[u8], open: usize, rule: CommentRule) -> Option<usize> {
+    if bytes.get(open) != Some(&b'{') {
+        return None;
+    }
+    let mut depth = 1u32;
+    let mut at = open + 1;
+    while at < bytes.len() {
+        if !is_escaped(bytes, at) {
+            match bytes[at] {
+                b'%' => {
+                    let is_percent_sign = rule == CommentRule::PercentAfterDigit
+                        && at > 0
+                        && bytes[at - 1].is_ascii_digit();
+                    if !is_percent_sign {
+                        while at < bytes.len() && bytes[at] != b'\n' {
+                            at += 1;
+                        }
+                        continue;
+                    }
+                }
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(at + 1);
+                    }
+                }
+                _ => {}
+            }
+        }
+        at += 1;
+    }
+    None
+}
+
 fn span(start: usize, end: usize) -> Span {
     Span::new(
         u32::try_from(start).unwrap_or(u32::MAX),

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -481,6 +481,20 @@ the run length is odd. This is decidable while scanning left to right by retaini
 The corpus contains 120 `\%` sequences inside captions and no real comments inside those captions. Treating
 every `%` as a comment would therefore truncate real caption content.
 
+**A block body is scanned with one exception to that rule**, found while implementing it: `%` immediately
+preceded by an ASCII digit is a percent sign, not a comment opener.
+
+Without the exception, `width = 80%` cannot be parsed at all — the `%` opens a comment that swallows the
+closing brace, and the block never ends. That is the same collision the tool baseline measured in plain
+LaTeX, where `width=120%` fails with `File ended while scanning use of \Gin@ii` and the message names
+nothing about percentages.
+
+The exception needs one byte of context, so it stays a left-to-right rule. It applies **only inside a
+NextTeX block body**. Transported LaTeX keeps TeX's rule, where a comment means what TeX says it means.
+
+The alternative was to require `80\%` inside blocks. It was rejected because the escape would appear in
+NextTeX's own syntax purely to work around a rule NextTeX controls.
+
 A top-level category-code change makes these default rules unreliable and invokes quarantine under §8.
 
 ### Block boundaries


### PR DESCRIPTION
Fixes #32

## What

`\figure(id) { … }` and `\table(id) { … }` now read their fields. A field's value kind comes from its name, so the parser reads what the specification declares rather than trying alternatives until one succeeds — which would let a malformed value quietly become a different valid one.

## The conflict implementing it surfaced

The grammar admits `width = 80%` as a value **and** scans block bodies with LaTeX's comment rule. Both cannot hold:

```latex
\figure(f) { width = 80% }
                       ↑ opens a comment that eats the closing brace
```

The block never ends. This is the same collision the tool baseline measured in plain LaTeX, where `width=120%` fails with `File ended while scanning use of \Gin@ii` — a message naming nothing about percentages.

**Resolved with one byte of context:** inside a block body, `%` immediately after an ASCII digit is a percent sign, not a comment opener. It stays a left-to-right rule, and it applies **only inside a NextTeX block body** — transported LaTeX keeps TeX's rule, where a comment means what TeX says it means.

The alternative was requiring `80\%` inside blocks. Rejected: the escape would exist purely to work around a rule NextTeX itself controls.

Recorded in `docs/grammar.md` §5 with the reasoning, not just the rule.

## Rejected fields say why

```
columns = 7        → "the column count is read from the tabular column specification,
                      so declaring it here lets the two disagree"

needs = booktabs   → "a block cannot add a \usepackage the source does not contain;
                      declare the package in the preamble"
```

Rejected, not ignored. Both were removed from the specification, and an author whose document carries one needs to be told rather than have it silently do nothing. Every error points at the **field**, not the block — being told "this block is wrong" leaves you to find the reason.

## Test plan

```
$ cargo test --workspace
test result: ok. 45 passed; 0 failed      (12 new, in blocks)
test result: ok.  4 passed; 0 failed      (the 42 grammar fixtures)
test result: ok.  1 passed; 0 failed      (doc-test)

$ cargo clippy --workspace --all-targets -- -D warnings   # clean
$ cargo fmt --all --check                                  # clean

$ # the corpus, with the block parser active
corpus — idénticos: 111  fallos: 0
```

Tests worth naming:

- `a_caption_containing_an_escaped_percent_is_not_truncated` — asserts the caption's span is long enough, so a regression that cuts at `12\%` fails loudly rather than producing a shorter caption nobody notices.
- `a_comment_inside_a_caption_hides_its_braces` — a real comment carrying `}` must not close the field.
- `width_takes_a_length_or_a_percentage` — `80%`, `4cm`, `12.5pt`. This is the test that found the conflict above.
- `columns_is_rejected_and_says_why` / `needs_is_rejected_and_says_why` — assert the explanation text, not just the rejection.

## Invariants

- [x] Untouched LaTeX comes out byte-identical — 111/111 with block parsing active
- [x] Unknown LaTeX is never fatal — a malformed block reports at its field and its bytes still transport
- [x] No hard error originates outside an explicit construct
- [x] Nothing is injected — `needs` is refused rather than implemented

## Dependencies

None added.

## Notes for the reviewer

`balanced_end` was extracted from the raw-escape handling and is now shared, with `balanced_end_with` taking the comment rule explicitly. One implementation of brace counting rather than two that can drift.

A parsed block still **emits from its span**. Lowering `\figure(...)` to `\begin{figure}...\end{figure}` is the emitter's job and is not here, which is why the corpus check is unaffected.

## Docs

`docs/grammar.md` §5 gains the percent-after-digit rule and why it exists. That is a specification change made because implementing found a contradiction, so it belongs in the document rather than only in code.