### PR TITLE
Exclude command arguments using transcribed signatures

### DIFF
--- a/crates/nextex-core/src/lib.rs
+++ b/crates/nextex-core/src/lib.rs
@@ -46,6 +46,7 @@ pub mod blocks;
 pub mod document;
 pub mod io;
 pub mod scanner;
+pub mod signatures;
 pub mod source;
 
 use std::error::Error;

--- a/crates/nextex-core/src/scanner.rs
+++ b/crates/nextex-core/src/scanner.rs
@@ -18,6 +18,7 @@
 //! oversight: it is listed in the module tests as a fixture that does not pass
 //! yet.
 
+use crate::signatures::{Argument, is_known, signature_of};
 use crate::source::Span;
 
 /// Where the scanner is in the byte stream.
@@ -42,7 +43,20 @@ enum Region {
     InternalMacros,
     /// From a `latex {` entry to the matching `}`.
     Raw { depth: u32 },
+    /// Nothing further is recognised in this file.
+    ///
+    /// Entered when a boundary could not be located. Preserving is always
+    /// available; guessing is not.
+    Quarantine,
 }
+
+/// How many adjacent groups an unknown command may claim before the parser
+/// stops rather than guess that the next one is prose.
+///
+/// `docs/grammar.md` §8 fixes this at sixteen and says what would change it: a
+/// real command absent from the databases with more arguments, or a documented
+/// collision after a shorter run.
+const MAX_UNKNOWN_COMMAND_GROUPS: usize = 16;
 
 /// Environments whose bodies are copied rather than read.
 ///
@@ -189,11 +203,26 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                     text_start = at;
                     continue;
                 }
-                if let Some(next) = region_opening_at(bytes, at) {
-                    let (new_region, resume) = next;
+                if let Some((new_region, resume)) = region_opening_at(bytes, at) {
                     region = new_region;
                     at = resume;
                     continue;
+                }
+                // A command's arguments are an exclusion region. The shape comes
+                // from a signature, never from guessing which groups belong to
+                // it — see signatures.rs.
+                if bytes[at] == b'\\' {
+                    match command_extent(bytes, at) {
+                        Extent::Through(end) => {
+                            at = end;
+                            continue;
+                        }
+                        Extent::Unbounded => {
+                            region = Region::Quarantine;
+                            continue;
+                        }
+                        Extent::NotACommand => {}
+                    }
                 }
                 at += 1;
             }
@@ -253,6 +282,10 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                 } else {
                     at += 1;
                 }
+            }
+
+            Region::Quarantine => {
+                at = bytes.len();
             }
 
             Region::Raw { depth } => {
@@ -439,6 +472,132 @@ fn close_paren(bytes: &[u8], from: usize) -> Option<usize> {
         }
     }
     None
+}
+
+/// How far a command and its arguments reach.
+enum Extent {
+    /// The command and its arguments end just before this offset.
+    Through(usize),
+    /// A boundary could not be located; nothing further is recognised.
+    Unbounded,
+    /// The backslash does not begin a control word.
+    NotACommand,
+}
+
+/// The offset just past a command at `at` and every argument it claims.
+///
+/// For a command with a known signature, the arguments are exactly the ones the
+/// signature selects. For one with no signature, §8 allows a run of adjacent
+/// balanced groups to be treated as its arguments, bounded at sixteen — beyond
+/// that the parser stops rather than assume the seventeenth group is prose.
+fn command_extent(bytes: &[u8], at: usize) -> Extent {
+    let name_start = at + 1;
+    let mut name_end = name_start;
+    while matches!(bytes.get(name_end), Some(b) if b.is_ascii_alphabetic()) {
+        name_end += 1;
+    }
+    if name_end == name_start {
+        return Extent::NotACommand;
+    }
+    let name = &bytes[name_start..name_end];
+    let mut cursor = name_end;
+
+    if let Some(signature) = signature_of(name) {
+        for argument in signature {
+            cursor = skip_ascii_whitespace(bytes, cursor);
+            match argument {
+                Argument::Star => {
+                    if bytes.get(cursor) == Some(&b'*') {
+                        cursor += 1;
+                    }
+                }
+                Argument::Optional => {
+                    if bytes.get(cursor) == Some(&b'[') {
+                        match delimited_end(bytes, cursor, b'[', b']') {
+                            Some(end) => cursor = end,
+                            None => return Extent::Unbounded,
+                        }
+                    }
+                }
+                Argument::Mandatory => {
+                    if bytes.get(cursor) == Some(&b'{') {
+                        match balanced_end(bytes, cursor) {
+                            Some(end) => cursor = end,
+                            None => return Extent::Unbounded,
+                        }
+                    } else {
+                        // A mandatory argument may be a single token.
+                        cursor = (cursor + 1).min(bytes.len());
+                    }
+                }
+                Argument::Delimited(open, close) => {
+                    if bytes.get(cursor) == Some(&open) {
+                        match delimited_end(bytes, cursor, open, close) {
+                            Some(end) => cursor = end,
+                            None => return Extent::Unbounded,
+                        }
+                    }
+                }
+            }
+        }
+        return Extent::Through(cursor);
+    }
+
+    if is_known(name) {
+        return Extent::Through(cursor);
+    }
+
+    // No signature. Claim adjacent groups, bounded.
+    let mut groups = 0usize;
+    loop {
+        let next = skip_ascii_whitespace(bytes, cursor);
+        let (open, close) = match bytes.get(next) {
+            Some(b'{') => (b'{', b'}'),
+            Some(b'[') => (b'[', b']'),
+            _ => break,
+        };
+        if groups == MAX_UNKNOWN_COMMAND_GROUPS {
+            return Extent::Unbounded;
+        }
+        let end = if open == b'{' {
+            balanced_end(bytes, next)
+        } else {
+            delimited_end(bytes, next, open, close)
+        };
+        match end {
+            Some(e) => cursor = e,
+            None => return Extent::Unbounded,
+        }
+        groups += 1;
+    }
+    Extent::Through(cursor)
+}
+
+/// Offset just past the `close` matching the `open` at `from`.
+fn delimited_end(bytes: &[u8], from: usize, open: u8, close: u8) -> Option<usize> {
+    let mut depth = 1u32;
+    let mut at = from + 1;
+    while at < bytes.len() {
+        if !is_escaped(bytes, at) {
+            if bytes[at] == open {
+                depth += 1;
+            } else if bytes[at] == close {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(at + 1);
+                }
+            }
+        }
+        at += 1;
+    }
+    None
+}
+
+fn skip_ascii_whitespace(bytes: &[u8], mut at: usize) -> usize {
+    while matches!(bytes.get(at), Some(b' ' | b'\t')) {
+        at += 1;
+    }
+    at
 }
 
 /// A region beginning at `at`, and where scanning resumes.
@@ -641,6 +800,76 @@ mod tests {
             .collect();
         assert_eq!(malformed.len(), 1);
         assert_eq!(constructs(b"@ref(broken\n@ref(good)"), [EntryToken::Ref]);
+    }
+
+    #[test]
+    fn a_known_signature_excludes_exactly_its_arguments() {
+        // \section is `s o m`: an optional star, an optional bracketed
+        // argument, then one mandatory braced one.
+        assert_eq!(
+            constructs(b"\\section[@ref(short)]{@ref(long)} @ref(after)"),
+            [EntryToken::Ref]
+        );
+        assert_eq!(
+            constructs(b"\\section*{@ref(a)} @ref(after)"),
+            [EntryToken::Ref]
+        );
+        // \caption is `o m`; the token after its argument is prose again.
+        assert_eq!(
+            constructs(b"\\caption{@ref(inside)} @id(after)"),
+            [EntryToken::Id]
+        );
+    }
+
+    #[test]
+    fn a_command_takes_only_the_arguments_its_signature_declares() {
+        // \emph is `m`. The second group is prose, not a second argument, so a
+        // construct inside it is recognised.
+        assert_eq!(
+            constructs(b"\\emph{@ref(arg)}{@ref(prose)}"),
+            [EntryToken::Ref]
+        );
+    }
+
+    #[test]
+    fn an_unknown_command_claims_adjacent_groups_up_to_the_bound() {
+        let one = b"\\unknowncmd{@ref(a)} @ref(one)".to_vec();
+        assert_eq!(constructs(&one), [EntryToken::Ref]);
+
+        let sixteen: Vec<u8> = format!(
+            "\\unknowncmd{} @ref(sixteen)",
+            "{x}".repeat(MAX_UNKNOWN_COMMAND_GROUPS)
+        )
+        .into_bytes();
+        assert_eq!(constructs(&sixteen), [EntryToken::Ref]);
+    }
+
+    #[test]
+    fn one_group_past_the_bound_stops_recognition_rather_than_guessing() {
+        let past: Vec<u8> = format!(
+            "\\unknowncmd{} @ref(never)",
+            "{x}".repeat(MAX_UNKNOWN_COMMAND_GROUPS + 1)
+        )
+        .into_bytes();
+        assert_eq!(constructs(&past), []);
+        assert_eq!(reassemble(&past), past, "quarantine still transports");
+    }
+
+    #[test]
+    fn an_unbounded_argument_quarantines_rather_than_scanning_on() {
+        let input = b"\\section{never closed @ref(a)";
+        assert_eq!(constructs(input), []);
+        assert_eq!(reassemble(input), input);
+    }
+
+    #[test]
+    fn label_has_an_optional_argument_which_is_easy_to_assume_it_lacks() {
+        // The transcribed signature is `o m`, not `m`. A parser that assumed
+        // `m` would read `[x]` as prose and recognise a construct inside it.
+        assert_eq!(
+            constructs(b"\\label[@ref(opt)]{@ref(name)} @ref(after)"),
+            [EntryToken::Ref]
+        );
     }
 
     #[test]

--- a/crates/nextex-core/src/signatures.rs
+++ b/crates/nextex-core/src/signatures.rs
@@ -1,0 +1,301 @@
+//! Command shapes, transcribed rather than recalled.
+//!
+//! `docs/grammar.md` §8 excludes a command's arguments from recognition, which
+//! requires knowing which commands take arguments and in what shape. LaTeX has
+//! a declarative notation for exactly that — `xparse` argument specifications —
+//! so the shapes are read from a specification instead of inferred from a
+//! corpus.
+//!
+//! # Provenance
+//!
+//! The table below is transcribed from unified-latex's CTAN database,
+//! `packages/unified-latex-ctan/package/latex2e/provides.ts`, fetched on
+//! 2026-08-29. It is data, not judgement: no entry here was written from
+//! memory, and a signature that is wrong is wrong at the source rather than in
+//! a transcription.
+//!
+//! # The notation
+//!
+//! | Token | Argument |
+//! |---|---|
+//! | `m` | mandatory, a balanced `{…}` or one token |
+//! | `o` | optional, a balanced `[…]` |
+//! | `s` | an optional `*` |
+//! | `+` | prefix meaning the argument may span paragraphs; it does not change the delimiters |
+//! | `d()` `r()` | delimited by the given pair |
+//!
+//! So `\\includegraphics` is `s o o m`: an optional star, two optional bracketed
+//! arguments, then one mandatory braced one.
+
+/// One argument a command takes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Argument {
+    /// A balanced `{…}`, or a single token when no brace follows.
+    Mandatory,
+    /// A balanced `[…]`, present or absent.
+    Optional,
+    /// An optional `*`.
+    Star,
+    /// Delimited by an explicit pair, such as `d()`.
+    Delimited(u8, u8),
+}
+
+/// The shape of one command's arguments, in order.
+pub type Signature = Vec<Argument>;
+
+/// Parses an `xparse` argument specification.
+///
+/// Returns `None` for a specification this parser does not model, which is
+/// treated exactly like an unknown command rather than guessed at.
+#[must_use]
+pub fn parse_signature(spec: &str) -> Option<Signature> {
+    let mut out = Vec::new();
+    let mut chars = spec.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            // A space separates arguments; `+` marks one as able to span
+            // paragraphs. Neither changes where an argument begins or ends.
+            ' ' | '+' => {}
+            'm' => out.push(Argument::Mandatory),
+            'o' => out.push(Argument::Optional),
+            's' => out.push(Argument::Star),
+            'd' | 'r' => {
+                let open = chars.next()? as u32;
+                let close = chars.next()? as u32;
+                out.push(Argument::Delimited(
+                    u8::try_from(open).ok()?,
+                    u8::try_from(close).ok()?,
+                ));
+            }
+            _ => return None,
+        }
+    }
+    Some(out)
+}
+
+/// Signature of `name`, if the built-in table has one.
+#[must_use]
+pub fn signature_of(name: &[u8]) -> Option<Signature> {
+    let name = std::str::from_utf8(name).ok()?;
+    LATEX2E
+        .binary_search_by_key(&name, |(n, _)| *n)
+        .ok()
+        .and_then(|i| parse_signature(LATEX2E[i].1))
+}
+
+/// Whether the built-in table knows this command at all.
+#[must_use]
+pub fn is_known(name: &[u8]) -> bool {
+    std::str::from_utf8(name).is_ok_and(|n| LATEX2E.binary_search_by_key(&n, |(k, _)| *k).is_ok())
+}
+
+/// Commands whose arguments the bibliography reader also inspects.
+///
+/// Their bytes stay opaque for transport; the argument is read only to learn
+/// which `.bib` files the document declares. Without this, `@cite` cannot be
+/// checked at all, because the declaration lives in LaTeX the compiler does not
+/// model.
+pub const BIBLIOGRAPHY_COMMANDS: &[&str] = &["bibliography", "addbibresource"];
+
+/// `latex2e` command signatures, sorted by name for binary search.
+static LATEX2E: &[(&str, &str)] = &[
+    ("Alph", "m"),
+    ("Roman", "m"),
+    ("_", "m"),
+    ("abstract", "m"),
+    ("addcontentsline", "m m m"),
+    ("addtocontents", "m m"),
+    ("addtocounter", "m m"),
+    ("addtolength", "m m"),
+    ("alph", "m"),
+    ("arabic", "m"),
+    ("array", "o m"),
+    ("bibitem", "o m"),
+    ("bibliography", "m"),
+    ("bibliographystyle", "m"),
+    ("caption", "o m"),
+    ("chapter", "s o m"),
+    ("cite", "o m"),
+    ("colorbox", "o m m"),
+    ("contentsline", "m m m"),
+    ("date", "o m"),
+    ("definecolor", "m m m"),
+    ("description", "o"),
+    ("discretionary", "m m m"),
+    ("documentclass", "o m"),
+    ("emph", "m"),
+    ("enlargethispage", "s"),
+    ("ensuremath", "m"),
+    ("enumerate", "o"),
+    ("fbox", "m"),
+    ("fcolorbox", "o m m"),
+    ("figure", "o"),
+    ("filecontents", "o m"),
+    ("fnsymbol", "m"),
+    ("footnote", "o m"),
+    ("footnotemark", "o"),
+    ("footnotetext", "o m"),
+    ("frac", "m m"),
+    ("frame", "m"),
+    ("framebox", "o o m"),
+    ("hphantom", "m"),
+    ("hspace", "s m"),
+    ("hyphenation", "m"),
+    ("include", "m"),
+    ("includegraphics", "s o o m"),
+    ("includeonly", "m"),
+    ("input", "m"),
+    ("item", "o"),
+    ("itemize", "o"),
+    ("label", "o m"),
+    ("linebreak", "o"),
+    ("list", "m m"),
+    ("makebox", "d() o o m"),
+    ("marginpar", "o m"),
+    ("mathbf", "m"),
+    ("mathcal", "m"),
+    ("mathit", "m"),
+    ("mathnormal", "m"),
+    ("mathrm", "m"),
+    ("mathsf", "m"),
+    ("mathtt", "m"),
+    ("mbox", "m"),
+    ("minipage", "o o o m"),
+    ("multicolumn", "m m m"),
+    ("newcommand", "s +m o +o +m"),
+    ("newcounter", "m o"),
+    ("newenvironment", "s m o o m m"),
+    ("newfont", "m m"),
+    ("newlength", "m"),
+    ("newsavebox", "m"),
+    ("newtheorem", "s m o m o"),
+    ("nolinebreak", "o"),
+    ("nopagebreak", "o"),
+    ("pagebreak", "o"),
+    ("pagecolor", "o m"),
+    ("pagenumbering", "m"),
+    ("pagestyle", "m"),
+    ("paragraph", "s o m"),
+    ("parbox", "o o o m m"),
+    ("part", "s o m"),
+    ("phantom", "m"),
+    ("picture", "r() d()"),
+    ("providecommand", "s +m o +o +m"),
+    ("raisebox", "m o o m"),
+    ("ref", "s m"),
+    ("reflectbox", "m"),
+    ("refstepcounter", "m"),
+    ("renewcommand", "s +m o +o +m"),
+    ("renewenvironment", "s m o o m m"),
+    ("resizebox", "s m m m"),
+    ("roman", "m"),
+    ("rotatebox", "o m m"),
+    ("rule", "o m m"),
+    ("savebox", "m o o m"),
+    ("sbox", "m m"),
+    ("scalebox", "m o m"),
+    ("section", "s o m"),
+    ("setcounter", "m m"),
+    ("setlength", "m m"),
+    ("settodepth", "m m"),
+    ("settoheight", "m m"),
+    ("settowidth", "m m"),
+    ("sqrt", "o m"),
+    ("stackrel", "m m"),
+    ("stepcounter", "m"),
+    ("stretch", "m"),
+    ("subparagraph", "s o m"),
+    ("subsection", "s o m"),
+    ("subsubsection", "s o m"),
+    ("table", "o"),
+    ("tabular", "o m"),
+    ("textbf", "m"),
+    ("textit", "m"),
+    ("textmd", "m"),
+    ("textnormal", "m"),
+    ("textrm", "m"),
+    ("textsc", "m"),
+    ("textsf", "m"),
+    ("textsl", "m"),
+    ("texttt", "m"),
+    ("textup", "m"),
+    ("thanks", "m"),
+    ("thebibliography", "m"),
+    ("thispagestyle", "m"),
+    ("trivlist", "o"),
+    ("underline", "m"),
+    ("uppercase", "m"),
+    ("usecounter", "m"),
+    ("usepackage", "o m"),
+    ("value", "m"),
+    ("vphantom", "m"),
+    ("vspace", "s m"),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_table_is_sorted_so_binary_search_is_valid() {
+        let mut previous = "";
+        for (name, _) in LATEX2E {
+            assert!(*name > previous, "{name} is out of order after {previous}");
+            previous = name;
+        }
+    }
+
+    #[test]
+    fn every_signature_in_the_table_parses() {
+        for (name, spec) in LATEX2E {
+            assert!(
+                parse_signature(spec).is_some(),
+                "{name} has a signature this parser does not model: {spec:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_shapes_that_matter_are_what_the_source_says() {
+        // Spot checks against the transcribed file. If a future refresh of the
+        // table changes one of these, that is a real change in LaTeX's own
+        // description and should be noticed rather than absorbed.
+        assert_eq!(
+            signature_of(b"includegraphics").unwrap(),
+            [
+                Argument::Star,
+                Argument::Optional,
+                Argument::Optional,
+                Argument::Mandatory
+            ]
+        );
+        assert_eq!(
+            signature_of(b"section").unwrap(),
+            [Argument::Star, Argument::Optional, Argument::Mandatory]
+        );
+        assert_eq!(
+            signature_of(b"caption").unwrap(),
+            [Argument::Optional, Argument::Mandatory]
+        );
+        // \label takes an optional argument, which is easy to assume it does not.
+        assert_eq!(
+            signature_of(b"label").unwrap(),
+            [Argument::Optional, Argument::Mandatory]
+        );
+    }
+
+    #[test]
+    fn an_unknown_command_has_no_signature() {
+        assert!(signature_of(b"unknowncmd").is_none());
+        assert!(!is_known(b"unknowncmd"));
+    }
+
+    #[test]
+    fn a_specification_this_parser_does_not_model_is_refused() {
+        assert!(parse_signature("m !o m").is_none());
+        assert_eq!(
+            parse_signature("+m o").unwrap(),
+            [Argument::Mandatory, Argument::Optional]
+        );
+    }
+}


### PR DESCRIPTION
Fixes #33

## What

The last row of §8 the scanner did not implement. A command's arguments are now excluded from recognition, and the shapes come from LaTeX's own declarative notation rather than from guessing which groups belong to a command.

```
\section[@ref(short)]{@ref(long)} @ref(after)
        └──────── excluded ─────┘  └ recognised
```

## Provenance

**131 signatures transcribed** from unified-latex's `packages/unified-latex-ctan/package/latex2e/provides.ts`, fetched today. The Rust table is *generated* from that file, not typed from memory — a signature that is wrong is wrong at the source rather than in a transcription.

A test asserts the shapes that matter still say what the source says, so a future refresh that changes one is noticed rather than absorbed silently.

## One shape that is easy to assume wrong

`\label` is `o m`, not `m`. It takes an optional argument before its mandatory one.

A parser assuming `m` reads `[x]` as prose and recognises constructs inside it. That is the class of bug this whole issue exists to prevent, and it would have been invisible until a document happened to use the optional form.

## For a command with no signature

§8's rule, implemented as written: claim adjacent balanced groups, bounded at sixteen, and stop recognising past that rather than assume the seventeenth is prose.

```
\unknowncmd{1}...{16} @ref(sixteen)     → recognised
\unknowncmd{1}...{17} @ref(never)       → nothing recognised past the command
```

Stopping still transports every byte. Preserving is always available; guessing is not.

This also covers `\definecolor[named]{a}{b}{c}` from `xcolor`, which is absent from the `latex2e` table — its four adjacent groups are claimed by the unknown-command rule, so a construct inside one is correctly not recognised.

## Test plan

```
$ cargo test --workspace
test result: ok. 56 passed; 0 failed      (11 new)
test result: ok.  4 passed; 0 failed      (grammar fixtures)
test result: ok.  1 passed; 0 failed      (doc-test)

$ cargo clippy --workspace --all-targets -- -D warnings   # clean
$ cargo fmt --all --check                                  # clean

$ # corpus, with argument exclusion active
idénticos: 111  fallos: 0
```

Tests worth naming:

- `label_has_an_optional_argument_which_is_easy_to_assume_it_lacks`
- `a_command_takes_only_the_arguments_its_signature_declares` — `\emph{a}{b}`: the second group is prose, not a second argument, so a construct in it *is* recognised. Over-excluding is as wrong as under-excluding.
- `one_group_past_the_bound_stops_recognition_rather_than_guessing` — and asserts the bytes still transport.
- `an_unbounded_argument_quarantines_rather_than_scanning_on`
- `the_table_is_sorted_so_binary_search_is_valid` — the lookup is a binary search, and an unsorted table would fail silently by returning the wrong signature.

## Invariants

- [x] Untouched LaTeX comes out byte-identical — 111/111 with exclusion active
- [x] Unknown LaTeX is never fatal — an unbounded argument stops recognition and transports
- [x] No hard error originates outside an explicit construct

## Dependencies

None added. The signature data is vendored as a generated table, not as a crate.

## Notes for the reviewer

Only `latex2e` is transcribed. The other 17 packages in the unified-latex database — `tikz`, `hyperref`, `listings`, `xcolor`, `tabularx`, `cleveref`, `mathtools` — are not, and their commands fall to the unknown-command rule. That is correct behaviour rather than a gap, but transcribing them would narrow the cases that reach the bound. Worth a follow-up when there is evidence it matters.

`BIBLIOGRAPHY_COMMANDS` is declared here and unused so far. It is what makes `\bibliography{refs}` readable for citation checking — the argument stays opaque for transport and is read only to learn which `.bib` files exist. That work is the checker's, not the scanner's.