### PR TITLE
Build the symbol table, and connect the block parser nobody was calling

### DIFF
--- a/crates/nextex-cli/examples/pieces.rs
+++ b/crates/nextex-cli/examples/pieces.rs
@@ -1,0 +1,30 @@
+//! Prints what the scanner makes of a file.
+use nextex_core::scanner::{Piece, scan};
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: pieces <file>");
+    let bytes = std::fs::read(&path).expect("readable");
+    for piece in scan(&bytes) {
+        let (label, span) = match piece {
+            Piece::Text(s) => ("text", s),
+            Piece::Construct { kind, span } => (kind.name(), span),
+            Piece::Malformed { kind, span } => {
+                println!(
+                    "  MALFORMED {:<10} {:?}",
+                    kind.name(),
+                    String::from_utf8_lossy(
+                        &bytes[span.start()..span.end().min(span.start() + 40)]
+                    )
+                );
+                continue;
+            }
+        };
+        if label != "text" {
+            println!(
+                "  {:<10} {:?}",
+                label,
+                String::from_utf8_lossy(&bytes[span.start()..span.end().min(span.start() + 46)])
+            );
+        }
+    }
+}

--- a/crates/nextex-cli/examples/symbols.rs
+++ b/crates/nextex-cli/examples/symbols.rs
@@ -1,0 +1,30 @@
+//! Reads a .ntex file and prints what its symbol table holds.
+use nextex_core::{parse, source::Sources, symbols::SymbolTable};
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: symbols <file>");
+    let bytes = std::fs::read(&path).expect("readable");
+    let mut sources = Sources::new();
+    let id = sources.add(path.clone(), bytes);
+    let document = parse(&sources, id);
+    let mut table = SymbolTable::new();
+    table.merge(&sources, &document);
+
+    println!("  cobertura            {:.0}%", document.coverage() * 100.0);
+    println!(
+        "  declarados           {:?}",
+        table.declared().collect::<Vec<_>>()
+    );
+    println!(
+        "  citas                {:?}",
+        table.citations().map(|(n, _)| n).collect::<Vec<_>>()
+    );
+    println!(
+        "  referencias rotas    {:?}",
+        table
+            .unresolved_references()
+            .map(|(n, _)| n)
+            .collect::<Vec<_>>()
+    );
+    println!("  errores              {}", table.errors().count());
+}

--- a/crates/nextex-core/src/lib.rs
+++ b/crates/nextex-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod document;
 pub mod io;
 pub mod scanner;
 pub mod source;
+pub mod symbols;
 
 use std::error::Error;
 use std::fmt;

--- a/crates/nextex-core/src/scanner.rs
+++ b/crates/nextex-core/src/scanner.rs
@@ -97,6 +97,10 @@ pub enum EntryToken {
     Import,
     /// `latex {`
     Raw,
+    /// `\figure(`
+    Figure,
+    /// `\table(`
+    Table,
 }
 
 impl EntryToken {
@@ -108,6 +112,8 @@ impl EntryToken {
             Self::Cite => b"@cite",
             Self::Import => b"@import",
             Self::Raw => b"latex",
+            Self::Figure => b"\\figure",
+            Self::Table => b"\\table",
         }
     }
 
@@ -120,6 +126,8 @@ impl EntryToken {
             Self::Cite => "@cite",
             Self::Import => "@import",
             Self::Raw => "latex",
+            Self::Figure => "\\figure",
+            Self::Table => "\\table",
         }
     }
 }
@@ -158,6 +166,27 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
         match &region {
             Region::Prose => {
                 if let Some((token, end)) = entry_token_at(bytes, at) {
+                    if let Some(kind) = block_kind(token) {
+                        flush!(at);
+                        let piece = match crate::blocks::parse_block(bytes, kind, at, end) {
+                            Ok(block) => Piece::Construct {
+                                kind: token,
+                                span: block.span,
+                            },
+                            Err(_) => Piece::Malformed {
+                                kind: token,
+                                span: span(at, end),
+                            },
+                        };
+                        let resume = match piece {
+                            Piece::Construct { span, .. } => span.end(),
+                            _ => end,
+                        };
+                        pieces.push(piece);
+                        at = resume;
+                        text_start = at;
+                        continue;
+                    }
                     if token == EntryToken::Raw {
                         flush!(at);
                         region = Region::Raw { depth: 1 };
@@ -300,6 +329,15 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
     pieces
 }
 
+/// The block kind an entry token opens, if it opens one.
+const fn block_kind(token: EntryToken) -> Option<crate::blocks::BlockKind> {
+    match token {
+        EntryToken::Figure => Some(crate::blocks::BlockKind::Figure),
+        EntryToken::Table => Some(crate::blocks::BlockKind::Table),
+        _ => None,
+    }
+}
+
 /// Offset just past the `}` that closes the group opening at `open`.
 ///
 /// Counts with LaTeX's own escaping: `\{`, `\}` and `\%` do not count, decided
@@ -408,6 +446,16 @@ fn entry_token_at(bytes: &[u8], at: usize) -> Option<(EntryToken, usize)> {
             }
         }
         return None;
+    }
+
+    if bytes[at] == b'\\' {
+        for token in [EntryToken::Figure, EntryToken::Table] {
+            let keyword = token.keyword();
+            let end = at + keyword.len();
+            if bytes[at..].starts_with(keyword) && bytes.get(end) == Some(&b'(') {
+                return Some((token, end + 1));
+            }
+        }
     }
 
     if bytes[at] == b'l' && bytes[at..].starts_with(b"latex") {

--- a/crates/nextex-core/src/symbols.rs
+++ b/crates/nextex-core/src/symbols.rs
@@ -1,0 +1,361 @@
+//! What a construct names, and whether the name resolves.
+//!
+//! The scanner finds where a construct is. This reads what is inside it — the
+//! identifier, the bibliography key, the import path — and builds the table
+//! that `@ref` is checked against.
+//!
+//! # Scope
+//!
+//! An identifier is scoped to **one document root**, not one file and not the
+//! whole project. A root is its root file plus every file reached through
+//! `@import`, and its table is the merge of theirs, per `docs/grammar.md` §4.
+//!
+//! That matches LaTeX, where a label is document-wide. It also means two
+//! separately emitted papers in one project may reuse an identifier, which
+//! matters: the corpus contains a project with five document roots sharing a
+//! directory.
+
+use std::collections::BTreeMap;
+
+use crate::document::{Document, Node};
+use crate::scanner::EntryToken;
+use crate::source::{SourceId, Sources, Span};
+
+/// The text a construct carries between its parentheses.
+///
+/// Borrowed from the source rather than copied, because the source outlives the
+/// table and copying would put a second version of every identifier in memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Payload {
+    /// Source the construct came from.
+    pub source: SourceId,
+    /// The bytes between `(` and `)`, excluding both.
+    pub span: Span,
+}
+
+/// A declaration made by `@id`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Declaration {
+    /// Where the identifier text is.
+    pub payload: Payload,
+    /// The whole `@id(...)` construct, which is what a diagnostic points at.
+    pub construct: Span,
+}
+
+/// A use of a name, by `@ref` or `@cite`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Reference {
+    /// Which construct made the reference.
+    pub kind: EntryToken,
+    /// Where the referenced text is.
+    pub payload: Payload,
+    /// The whole construct, which is what a diagnostic points at.
+    pub construct: Span,
+}
+
+/// Something the table cannot accept.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SymbolError {
+    /// Two `@id` constructs declare the same identifier in one root.
+    ///
+    /// Blamed on the later one: the first declaration is not at fault for
+    /// existing.
+    Duplicate {
+        /// The identifier, as written.
+        name: String,
+        /// The `@id` that declared it first.
+        first: Span,
+        /// The `@id` being rejected.
+        second: Span,
+    },
+    /// An identifier is empty, or contains bytes an identifier may not.
+    Malformed {
+        /// The construct at fault.
+        construct: Span,
+    },
+}
+
+/// Names declared and used within one document root.
+#[derive(Debug, Default, Clone)]
+pub struct SymbolTable {
+    declarations: BTreeMap<String, Declaration>,
+    references: Vec<(String, Reference)>,
+    errors: Vec<SymbolError>,
+}
+
+impl SymbolTable {
+    /// Creates an empty table.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds every construct in `document` to the table.
+    ///
+    /// Merging a second document into the same table is how a root absorbs an
+    /// imported file: the scope is the root, so the two share one namespace and
+    /// a clash between them is a real clash.
+    pub fn merge(&mut self, sources: &Sources, document: &Document) {
+        for node in document.iter() {
+            let (kind, construct) = match node {
+                Node::Construct { kind, span, .. } => (*kind, *span),
+                _ => continue,
+            };
+            let Some(payload) = payload_of(sources, node.source(), construct, kind) else {
+                continue;
+            };
+            let Some(text) = text_of(sources, payload) else {
+                continue;
+            };
+
+            match kind {
+                EntryToken::Id | EntryToken::Figure | EntryToken::Table => {
+                    if !is_identifier(text.as_bytes()) {
+                        self.errors.push(SymbolError::Malformed { construct });
+                        continue;
+                    }
+                    if let Some(first) = self.declarations.get(&text) {
+                        self.errors.push(SymbolError::Duplicate {
+                            name: text,
+                            first: first.construct,
+                            second: construct,
+                        });
+                        continue;
+                    }
+                    self.declarations
+                        .insert(text, Declaration { payload, construct });
+                }
+                EntryToken::Ref | EntryToken::Cite => {
+                    if text.is_empty() {
+                        self.errors.push(SymbolError::Malformed { construct });
+                        continue;
+                    }
+                    self.references.push((
+                        text,
+                        Reference {
+                            kind,
+                            payload,
+                            construct,
+                        },
+                    ));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Declaration of `name`, if one exists.
+    #[must_use]
+    pub fn declaration(&self, name: &str) -> Option<&Declaration> {
+        self.declarations.get(name)
+    }
+
+    /// Every declared identifier, sorted.
+    pub fn declared(&self) -> impl Iterator<Item = &str> {
+        self.declarations.keys().map(String::as_str)
+    }
+
+    /// Every `@ref` whose identifier no `@id` declares.
+    ///
+    /// `@cite` is excluded: its keys come from a bibliography, and reporting a
+    /// missing key needs that bibliography to have been read successfully.
+    /// Reporting one here would call an unread bibliography an absent key.
+    pub fn unresolved_references(&self) -> impl Iterator<Item = (&str, &Reference)> {
+        self.references.iter().filter_map(|(name, reference)| {
+            (reference.kind == EntryToken::Ref && !self.declarations.contains_key(name))
+                .then_some((name.as_str(), reference))
+        })
+    }
+
+    /// Every `@cite`, for a checker that has a key set to compare against.
+    pub fn citations(&self) -> impl Iterator<Item = (&str, &Reference)> {
+        self.references.iter().filter_map(|(name, reference)| {
+            (reference.kind == EntryToken::Cite).then_some((name.as_str(), reference))
+        })
+    }
+
+    /// Problems found while building the table.
+    pub fn errors(&self) -> impl Iterator<Item = &SymbolError> {
+        self.errors.iter()
+    }
+}
+
+/// The span between `(` and `)` of a construct covering `construct`.
+///
+/// Returns `None` for a construct that carries no payload, such as the raw
+/// escape.
+fn payload_of(
+    sources: &Sources,
+    source: SourceId,
+    construct: Span,
+    kind: EntryToken,
+) -> Option<Payload> {
+    let keyword = match kind {
+        EntryToken::Id => "@id(",
+        EntryToken::Ref => "@ref(",
+        EntryToken::Cite => "@cite(",
+        EntryToken::Import => "@import(",
+        // A block declares its identifier just as `@id` does: the name between
+        // its parentheses is what a reference resolves to.
+        EntryToken::Figure => "\\figure(",
+        EntryToken::Table => "\\table(",
+        _ => return None,
+    };
+    let bytes = sources.get(source)?.slice(construct)?;
+    if !bytes.starts_with(keyword.as_bytes()) {
+        return None;
+    }
+    let start = construct.start() + keyword.len();
+    // An inline construct ends at its `)`. A block ends at its closing brace,
+    // so its identifier ends at the first `)` instead.
+    let end = match kind {
+        EntryToken::Figure | EntryToken::Table => {
+            construct.start() + bytes.iter().position(|b| *b == b')')?
+        }
+        _ if bytes.ends_with(b")") => construct.end() - 1,
+        _ => return None,
+    };
+    if start > end {
+        return None;
+    }
+    Some(Payload {
+        source,
+        span: Span::new(u32::try_from(start).ok()?, u32::try_from(end).ok()?),
+    })
+}
+
+/// The payload's bytes as text, if they are valid UTF-8.
+///
+/// An identifier is ASCII by the grammar, so anything that is not valid UTF-8
+/// is not an identifier and is reported rather than lossily converted.
+fn text_of(sources: &Sources, payload: Payload) -> Option<String> {
+    let bytes = sources.get(payload.source)?.slice(payload.span)?;
+    // A citation key may carry a comma and fields after it; the key is what
+    // precedes the first comma.
+    let key = bytes.split(|b| *b == b',').next().unwrap_or(bytes);
+    let trimmed = key
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .map_or(&[][..], |start| {
+            let end = key
+                .iter()
+                .rposition(|b| !b.is_ascii_whitespace())
+                .unwrap_or(start);
+            &key[start..=end]
+        });
+    std::str::from_utf8(trimmed).ok().map(str::to_owned)
+}
+
+fn is_identifier(bytes: &[u8]) -> bool {
+    matches!(bytes.first(), Some(b) if b.is_ascii_alphabetic())
+        && bytes
+            .iter()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b':' | b'.' | b'-'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+
+    fn table(files: &[(&str, &str)]) -> (Sources, SymbolTable) {
+        let mut sources = Sources::new();
+        let mut table = SymbolTable::new();
+        for (name, text) in files {
+            let id = sources.add(*name, text.as_bytes().to_vec());
+            let document = parse(&sources, id);
+            table.merge(&sources, &document);
+        }
+        (sources, table)
+    }
+
+    #[test]
+    fn a_declaration_is_found_by_its_name() {
+        let (_, t) = table(&[("a.ntex", "\\section{X} @id(sec:intro)")]);
+        assert_eq!(t.declared().collect::<Vec<_>>(), ["sec:intro"]);
+        assert!(t.declaration("sec:intro").is_some());
+        assert!(t.errors().next().is_none());
+    }
+
+    #[test]
+    fn a_reference_to_nothing_is_unresolved() {
+        let (_, t) = table(&[(
+            "a.ntex",
+            "See @ref(missing) and @ref(present). @id(present)",
+        )]);
+        let unresolved: Vec<_> = t.unresolved_references().map(|(n, _)| n).collect();
+        assert_eq!(unresolved, ["missing"]);
+    }
+
+    #[test]
+    fn the_scope_is_the_root_so_two_files_share_one_namespace() {
+        // Both files belong to one root, so the second declaration clashes.
+        let (_, t) = table(&[("a.ntex", "@id(fig:main)"), ("b.ntex", "@id(fig:main)")]);
+        let errors: Vec<_> = t.errors().collect();
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(errors[0], SymbolError::Duplicate { name, .. } if name == "fig:main"));
+    }
+
+    #[test]
+    fn separate_roots_may_reuse_an_identifier() {
+        // A project with several roots — the corpus has one with five. Separate
+        // tables, so the same name in each is not a clash.
+        let (_, first) = table(&[("paper_jss/main.ntex", "@id(fig:main)")]);
+        let (_, second) = table(&[("paper_tse/main.ntex", "@id(fig:main)")]);
+        assert!(first.errors().next().is_none());
+        assert!(second.errors().next().is_none());
+    }
+
+    #[test]
+    fn a_duplicate_is_blamed_on_the_later_declaration() {
+        let (_, t) = table(&[("a.ntex", "@id(x) then later @id(x)")]);
+        let Some(SymbolError::Duplicate { first, second, .. }) = t.errors().next() else {
+            panic!("expected a duplicate")
+        };
+        assert!(
+            first.start() < second.start(),
+            "the first declaration is not at fault for existing"
+        );
+    }
+
+    #[test]
+    fn a_citation_is_not_reported_as_an_unresolved_reference() {
+        // Its key comes from a bibliography. Reporting it here would call an
+        // unread bibliography an absent key.
+        let (_, t) = table(&[("a.ntex", "@cite(knuth1984)")]);
+        assert_eq!(t.unresolved_references().count(), 0);
+        assert_eq!(
+            t.citations().map(|(n, _)| n).collect::<Vec<_>>(),
+            ["knuth1984"]
+        );
+    }
+
+    #[test]
+    fn a_citation_key_stops_at_its_first_field() {
+        let (_, t) = table(&[("a.ntex", "@cite(knuth1984, style=textual)")]);
+        assert_eq!(
+            t.citations().map(|(n, _)| n).collect::<Vec<_>>(),
+            ["knuth1984"]
+        );
+    }
+
+    #[test]
+    fn a_malformed_identifier_is_reported_rather_than_declared() {
+        let (_, t) = table(&[("a.ntex", "@id(9starts-with-a-digit)")]);
+        assert_eq!(t.declared().count(), 0);
+        assert!(matches!(
+            t.errors().next(),
+            Some(SymbolError::Malformed { .. })
+        ));
+    }
+
+    #[test]
+    fn a_construct_inside_an_excluded_region_never_reaches_the_table() {
+        let (_, t) = table(&[(
+            "a.ntex",
+            "% @id(commented)\n$@id(math)$\n\\begin{verbatim}\n@id(verb)\n\\end{verbatim}\n@id(real)",
+        )]);
+        assert_eq!(t.declared().collect::<Vec<_>>(), ["real"]);
+    }
+}

--- a/tests/experiments/coverage/annotated.ntex
+++ b/tests/experiments/coverage/annotated.ntex
@@ -11,9 +11,7 @@ Definition~@ref(def:geakg) captures the \emph{static structure} of a GEAKG---ana
 Table~@ref(tab:roleschema_instances) reports the size and numerical characteristics of $\mathcal{S}$ in both case studies.
 
 \table(tab:roleschema_instances) {
-  needs   = booktabs
-  columns = 3
-  caption = RoleSchema instantiation for both case studies
+  caption = {RoleSchema instantiation for both case studies}
   body    = {
     \toprule
     \textbf{Component} & \textbf{CS1: NAS} & \textbf{CS2: Optimization} \\
@@ -23,24 +21,21 @@ Table~@ref(tab:roleschema_instances) reports the size and numerical characterist
     $|E_{L0}|$ (realized L0 edges)$^*$ & 42 & 38 \\
     \bottomrule
   }
+  trailing = {
+    \vspace{2pt}
+    {\scriptsize $^*$Edge counts depend on the LLM-generated L0 topology and may
+     vary across generations. Values shown are from representative runs.}
+  }
 }
 
-% GAP 1: the table note below has nowhere to live. It is positional LaTeX
-% inside the environment, not a field of the table.
-latex {
-  \vspace{2pt}
-  {\scriptsize $^*$Edge counts depend on the LLM-generated L0 topology and may
-   vary across generations. Values shown are from representative runs.}
-}
+% GAP 1 is closed: the table note now lives in the trailing field, above.
 
 This definition connects to standard KG formalism~@cite(hogan2021knowledge): $\mathcal{S}$ serves as the ontology imposing type constraints.
 
 Table~@ref(tab:kg_comparison) positions GEAKG relative to existing paradigms. Section~@ref(sec:results) presents empirical validation.
 
 \table(tab:kg_comparison) {
-  needs   = booktabs
-  columns = 7
-  caption = GEAKG vs. Existing Knowledge Representation Paradigms
+  caption = {GEAKG vs. Existing Knowledge Representation Paradigms}
   body    = {
     \toprule
     \textbf{Paradigm} & \textbf{Generative} & \textbf{Executable} & \textbf{Transferable} & \textbf{Learned} & \textbf{Domain-Agnostic} & \textbf{Zero-Shot} \\


### PR DESCRIPTION
Fixes #10 in part — imports and `nextex.toml` discovery are not here; see the end.

## What

Constructs were recognised but nothing read what is *inside* them. This extracts the identifier, the citation key and the import path, and builds the table a reference is checked against.

## Scope is one document root

Not one file, not the project. Two files in one root share a namespace, so a clash between them is real. Two separate roots may reuse a name — which matters, because the corpus contains a project with **five** document roots in one directory.

```
paper_jss/main.ntex  @id(fig:main)   ─┐
                                       ├─ separate roots, no clash
paper_tse/main.ntex  @id(fig:main)   ─┘
```

Two decisions worth naming:

- **A duplicate is blamed on the later declaration.** The first is not at fault for existing.
- **A citation is never reported as an unresolved reference.** Its key comes from a bibliography, and reporting it here would call an unread bibliography an absent key. `citations()` hands them to a checker that has a key set to compare against.

## The block parser had no caller

`\figure(` and `\table(` were not entry tokens. The block parser landed in #34 with tests that call `parse_block` directly, and nothing else did — so **no document ever contained a block**. Reviewing the diff rather than the artefact, in code this time; the same anti-pattern `AGENTS.md` §5 records for documents.

Both are entry tokens now, and a block declares its identifier just as `@id` does.

## What integration found

Running the Phase 0 hand annotation through it surfaced **three specification changes that file predates**, all three correctly rejected:

| Rejected | Because |
|---|---|
| `needs = booktabs` | removed — a block cannot add a `\usepackage` the source lacks |
| `columns = 3` | removed — the count is read from the tabular specification |
| `caption = unbraced text` | captions must be braced; 23% of real ones contain a newline |

Updating that file:

```
antes:  cobertura 11%  declarados ["def:geakg"]
ahora:  cobertura 56%  declarados ["def:geakg", "tab:kg_comparison", "tab:roleschema_instances"]
        referencias rotas ["alg:geakg_construction", "app:symbolic_executor", "sec:results"]
```

The three unresolved ones are correct: they point at things declared elsewhere in the full paper, outside this extract.

## And a real gap, filed rather than fixed here

Citations in that section went from four to **two**. A block is one span and the scanner does not descend into it, so a construct inside a field is not recognised — which contradicts the grammar's own example of a reference inside a caption. Filed as #36 rather than grown into this PR.

## Test plan

```
$ cargo test --workspace
test result: ok. 54 passed; 0 failed      (9 new, in symbols)
test result: ok.  4 passed; 0 failed      (grammar fixtures)
test result: ok.  1 passed; 0 failed      (doc-test)

$ cargo clippy --workspace --all-targets -- -D warnings   # clean
$ cargo fmt --all --check                                  # clean

$ # corpus, with the symbol table and blocks active
corpus — idénticos: 111  fallos: 0
```

Tests worth naming:

- `the_scope_is_the_root_so_two_files_share_one_namespace` and `separate_roots_may_reuse_an_identifier` — the two halves of the scope rule, asserted against each other.
- `a_citation_is_not_reported_as_an_unresolved_reference`
- `a_construct_inside_an_excluded_region_never_reaches_the_table` — comment, math and verbatim in one fixture; only the real declaration lands.
- `a_citation_key_stops_at_its_first_field` — `@cite(k, style=textual)` keys on `k`.

## Invariants

- [x] Untouched LaTeX comes out byte-identical — 111/111
- [x] Unknown LaTeX is never fatal
- [x] No hard error originates outside an explicit construct

## What is left of #10

`@import` resolution and `nextex.toml` discovery. The payload is extracted, but nothing loads the file it names or merges its table yet. Worth its own PR because it needs the loader, and this one is already larger than intended.

## Notes for the reviewer

Two `cargo` examples are included — `symbols` and `pieces`. They are how the three specification mismatches above were found, and they print what the compiler makes of a file without a debugger. Say if you would rather they were not in the tree.