### PR TITLE
Specify checking, and make the fixtures able to disagree with the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Prior art it does **not** claim to have invented: typed document languages that 
   hazards, and the phases with their exit criteria.
 - [`docs/grammar.md`](docs/grammar.md) — the language specification: entry tokens, constructs,
   boundaries, and where constructs are not recognized.
+- [`docs/checking.md`](docs/checking.md) — what the compiler is willing to call an error, and what it
+  refuses to: entity classes, the closed list of hard errors, coverage, blame, and the diagnostic fields.
 - [`docs/references.md`](docs/references.md) — what to read before each phase, and what each source
   already settled or blocked.
 - [`docs/testing.md`](docs/testing.md) — the six test layers, and why the property tests cannot wait

--- a/crates/nextex-core/src/scanner.rs
+++ b/crates/nextex-core/src/scanner.rs
@@ -584,6 +584,14 @@ enum Extent {
 /// signature selects. For one with no signature, §8 allows a run of adjacent
 /// balanced groups to be treated as its arguments, bounded at sixteen — beyond
 /// that the parser stops rather than assume the seventeenth group is prose.
+/// Bytes that never begin a single-token mandatory argument.
+///
+/// A mandatory argument may be one token — `\\newcommand\\foo{}` is real LaTeX.
+/// But these bytes open some *other* xparse argument form, so meeting one where
+/// a mandatory argument was expected means the signature does not describe this
+/// call. See `docs/grammar.md` §8.
+const ARGUMENT_OPENERS: &[u8] = b"[<(*";
+
 fn command_extent(bytes: &[u8], at: usize) -> Extent {
     let name_start = at + 1;
     let mut name_end = name_start;
@@ -597,6 +605,14 @@ fn command_extent(bytes: &[u8], at: usize) -> Extent {
     let mut cursor = name_end;
 
     if let Some(signature) = signature_of(name) {
+        // A signature is a claim about this call, and the call can refute it.
+        // 15 of the built-in commands carry a different signature under another
+        // package — `\\definecolor` is `m m m` under `color` and `o m m m` under
+        // `xcolor`, and beamer adds a `<overlay>` argument to twelve more. When
+        // the bytes do not fit, trusting the signature anyway resumes parsing
+        // *inside* an argument and exposes its contents to recognition. Falling
+        // through to the unknown-command rule excludes them instead.
+        let mut fits = true;
         for argument in signature {
             cursor = skip_ascii_whitespace(bytes, cursor);
             match argument {
@@ -619,6 +635,12 @@ fn command_extent(bytes: &[u8], at: usize) -> Extent {
                             Some(end) => cursor = end,
                             None => return Extent::Unbounded,
                         }
+                    } else if bytes
+                        .get(cursor)
+                        .is_some_and(|b| ARGUMENT_OPENERS.contains(b))
+                    {
+                        fits = false;
+                        break;
                     } else {
                         // A mandatory argument may be a single token.
                         cursor = (cursor + 1).min(bytes.len());
@@ -634,14 +656,15 @@ fn command_extent(bytes: &[u8], at: usize) -> Extent {
                 }
             }
         }
+        if fits {
+            return Extent::Through(cursor);
+        }
+        cursor = name_end;
+    } else if is_known(name) {
         return Extent::Through(cursor);
     }
 
-    if is_known(name) {
-        return Extent::Through(cursor);
-    }
-
-    // No signature. Claim adjacent groups, bounded.
+    // No signature, or one this call refuted. Claim adjacent groups, bounded.
     let mut groups = 0usize;
     loop {
         let next = skip_ascii_whitespace(bytes, cursor);

--- a/crates/nextex-core/tests/fixtures.rs
+++ b/crates/nextex-core/tests/fixtures.rs
@@ -22,6 +22,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use nextex_core::io::Memory;
+use nextex_core::scanner::{Piece, scan};
 use nextex_core::transport;
 
 fn fixtures_root() -> PathBuf {
@@ -154,5 +155,134 @@ fn every_fixture_transports_at_every_truncation() {
                 "{name}: transport changed bytes at cut {cut}"
             );
         }
+    }
+}
+
+/// The pieces an `expect.txt` declares, in order.
+///
+/// The `scanner:` line is the machine-checked one: `none`, or a space-separated
+/// list where `ref` is a construct and `!ref` is a malformed one. It was
+/// transcribed from each fixture's own prose, never from what the scanner
+/// happened to do — a `scanner:` line written to match the code would document
+/// the bug rather than the grammar.
+///
+/// The `constructs:` line stays as the note for a reader. It says things a
+/// checker will verify and a scanner cannot, such as which identifier attached
+/// to which caption.
+fn declared_pieces(expect: &str, name: &str) -> Vec<String> {
+    let line = expect
+        .lines()
+        .find(|l| l.starts_with("scanner:"))
+        .unwrap_or_else(|| panic!("{name}: expect.txt has no scanner line"));
+    let body = line.trim_start_matches("scanner:").trim();
+    if body == "none" {
+        return Vec::new();
+    }
+    body.split_whitespace().map(str::to_owned).collect()
+}
+
+/// The pieces the scanner produced, named as `expect.txt` names them.
+fn found_pieces(bytes: &[u8]) -> Vec<String> {
+    scan(bytes)
+        .into_iter()
+        .filter_map(|piece| match piece {
+            Piece::Construct { kind, .. } => Some(short(kind)),
+            Piece::Malformed { kind, .. } => Some(format!("!{}", short(kind))),
+            Piece::Text(_) | Piece::Excluded(_) => None,
+        })
+        .collect()
+}
+
+fn short(kind: nextex_core::scanner::EntryToken) -> String {
+    kind.name().trim_start_matches(['@', '\\']).to_owned()
+}
+
+/// Fixtures the scanner does not satisfy yet, each with the issue that closes it.
+///
+/// This is a statement about what is not built. An entry without an issue behind
+/// it is an expectation being quietly dropped, which is the anti-pattern in
+/// `AGENTS.md` §5.
+const NOT_YET: &[(&str, &str)] = &[
+    (
+        "revisions/01-inline-between-words-and-before-punctuation",
+        "#6, #15",
+    ),
+    ("revisions/02-a-long-multiline-revision", "#6, #15"),
+    (
+        "revisions/03-nested-constructs-inside-a-revision",
+        "#6, #15",
+    ),
+    (
+        "revisions/04-construct-inside-a-command-argument-in-a-revision",
+        "#6, #15",
+    ),
+    ("revisions/05-substitution-with-arrows-at-depth", "#6, #15"),
+    (
+        "revisions/06-substitution-with-zero-and-two-arrows",
+        "#6, #15",
+    ),
+    ("revisions/07-unmatched-revision-brace", "#6, #15"),
+    ("revisions/08-properly-nested-revisions", "#6, #15"),
+];
+
+#[test]
+fn every_fixture_produces_the_pieces_it_declares() {
+    // Until this ran, all 42 fixtures declared their constructs in prose and
+    // nothing read it. The grammar was documented and unfalsified at once.
+    let mut checked = 0usize;
+    let mut skipped = 0usize;
+    let mut failures = Vec::new();
+
+    for input in all_fixtures() {
+        let name = label(&input);
+        if let Some((_, issue)) = NOT_YET.iter().find(|(n, _)| *n == name) {
+            println!("{name}: not built yet, {issue}");
+            skipped += 1;
+            continue;
+        }
+        let raw = fs::read(&input).unwrap_or_else(|e| panic!("{name}: cannot read ({e})"));
+        let expect = fs::read_to_string(input.with_file_name("expect.txt"))
+            .unwrap_or_else(|e| panic!("{name}: cannot read expect.txt ({e})"));
+
+        let want = declared_pieces(&expect, &name);
+        let got = found_pieces(&raw);
+        if want != got {
+            failures.push(format!("{name}: declared {want:?}, produced {got:?}"));
+        }
+        checked += 1;
+    }
+
+    assert!(failures.is_empty(), "\n{}", failures.join("\n"));
+    assert!(
+        checked >= 30,
+        "only {checked} fixtures ran, {skipped} skipped"
+    );
+}
+
+#[test]
+fn ordinary_latex_yields_no_constructs() {
+    // The promise the whole project rests on: rename a `.tex` to `.ntex`,
+    // change nothing, and the compiler has nothing to say. It cannot hold if
+    // the scanner recognises a construct in bytes the author wrote as LaTeX.
+    let ordinary: &[&[u8]] = &[
+        br"Write to \texttt{author@example.org} for the data.",
+        br"\begin{tabular}{@{}lcc@{}} a & b & c \\ \end{tabular}",
+        br"The \verb+@ref+ syntax is not used in this paper.",
+        br"Coverage reached 94\% this run, up from 90\%.",
+        br"See \ref{fig:main} and \cite{knuth1984}; neither resolves.",
+        br"\newcommand{\ref}[1]{see #1} % a package redefining \ref",
+        br"\makeatletter \@ifpackageloaded{amsmath}{}{} \makeatother",
+        br"An email @ the start of a line, and a lone @ mid-sentence.",
+        br"\definecolor[named]{@id(a)}{rgb}{1,0,0} % xcolor form",
+        br"latex, plain prose about the word, with no brace after it.",
+    ];
+
+    for bytes in ordinary {
+        let found = found_pieces(bytes);
+        assert!(
+            found.is_empty(),
+            "recognised {found:?} in ordinary LaTeX: {}",
+            String::from_utf8_lossy(bytes)
+        );
     }
 }

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -6,6 +6,10 @@ The rule underneath everything here is one line: **a diagnostic is a claim, and 
 check that cannot substantiate itself stays quiet. That is not politeness — a checker that guesses trains its
 author to ignore it, and an ignored checker has no value at all.
 
+This document is the contract the checker, the CLI, the LSP and the test suites all read. The binding rules
+it obeys are in [`PHILOSOPHY.md`](../PHILOSOPHY.md) §5 and §6 and in [`AGENTS.md`](../AGENTS.md) §4; they are
+referenced here rather than restated.
+
 ---
 
 ## 1 · Only explicit constructs are checked
@@ -14,15 +18,142 @@ author to ignore it, and an ignored checker has no value at all.
 knows what they mean and may fail on them.
 
 Plain LaTeX does not. A `\cite{x}` in transported bytes may come from a macro body, an inactive branch of a
-conditional, or a package that redefines it. The compiler has no way to tell, so it says nothing. This is
-the same boundary the type system draws: an unknown control sequence is `?O`, the unknown *open* type, and
-`?O` is consistent with everything.
+conditional, or a package that redefines it. The compiler has no way to tell, so it says nothing.
 
 Concretely: `@cite(invented2026)` is checked. `\cite{invented2026}` on the line below it is not.
 
+This is what makes renaming a `.tex` to `.ntex` and changing nothing check clean. It follows by
+construction, not from care taken case by case.
+
 ---
 
-## 2 · Citations
+## 2 · Entity classes and the unknown open type
+
+Every checked thing has a class:
+
+```
+Text  Block  Figure  Table  Equation  Section  Citation  Length
+```
+
+Everything else — every unknown control sequence, every environment the compiler does not model, every
+region it quarantined — is `?O`: the unknown **open** datatype.
+
+The word *open* is doing work. `?` in a gradual type system means "unknown among a fixed set of types". LaTeX
+has no fixed set: any package may define new constructors at any time, so the unknown here is unbounded.
+The term is from Malewski, Greenberg and Tanter, *Gradually Structured Data* (OOPSLA 2021).
+
+Comparison is **consistency**, not equality:
+
+```
+Known(A) ~ Known(B)   if and only if A == B
+?O       ~ T          for every T
+T        ~ ?O         for every T
+```
+
+The second and third lines are the whole checking policy in two symbols. `?O` is consistent with
+everything, so nothing involving unmodelled LaTeX can ever be inconsistent, so nothing involving unmodelled
+LaTeX can ever fail. `?O` does not mean *invalid*. It means *the compiler has no grounds*.
+
+---
+
+## 3 · When the compiler may fail
+
+A **hard error** sets a non-zero exit code. The list is closed: if a condition is not on it, it is not a hard
+error.
+
+| Code | Condition | Class involved |
+|---|---|---|
+| `NT1001` | Two `@id` constructs declare the same identifier in one document root | any |
+| `NT1002` | An identifier is empty or contains bytes an identifier may not | any |
+| `NT1003` | `@ref(x)` where no `@id` in the root declares `x` | any |
+| `NT1004` | `@ref(x)` demanding class A on a target of known class B, A ≠ B | both known |
+| `NT1005` | `@cite(k)` where `k` is absent from a bibliography read completely | `Citation` |
+| `NT1006` | A `\figure` block whose image file does not resolve | `Figure` |
+| `NT1007` | A length with an unsupported unit, or a percentage outside 0–100 | `Length` |
+| `NT1008` | A block field that is required and absent, or present and malformed | `Figure`, `Table` |
+| `NT1009` | An `@import` path that does not resolve | any |
+
+Two properties hold across the whole table and are tested as properties, not as examples:
+
+1. **Every row requires an explicit construct.** There is no row that ordinary LaTeX can reach.
+2. **Every row requires both sides known.** `NT1004` cannot fire when either side is `?O`, and `NT1005`
+   cannot fire when the bibliography is `Unavailable`. Uncertainty on either side means silence.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | No hard errors. Advisories may have been printed. |
+| `1` | At least one hard error from the table above. |
+| `2` | Fatal: I/O failure, invalid annotation encoding, resource limit, broken internal invariant. |
+
+Exit `2` is never reachable from unknown LaTeX. Unknown LaTeX downgrades confidence and is preserved; see
+[`grammar.md`](grammar.md) §8.
+
+---
+
+## 4 · Advisory
+
+An advisory names something the compiler noticed but cannot substantiate. It is:
+
+- **off by default** — printed only behind `--strict-tex`;
+- **never** able to change the exit code;
+- marked `severity: advisory` in both output forms.
+
+The class of things that are advisory and not errors:
+
+- an unresolved `\ref` or `\cite` written in plain LaTeX;
+- a `\label` in an opaque region that appears to collide with an `@id`;
+- a bibliography that could not be read (see §7) — the advisory is about the file, never about a key;
+- a region that entered quarantine early, which is a coverage signal rather than a defect.
+
+**Never scan inside an opaque region and treat what you find as checkable.** Such a scan matches inside a
+`\newcommand` body, inside verbatim text, and inside an inactive `\if` branch. This was a design error caught
+in review, and it is the reason the rule is written as a prohibition rather than a preference.
+
+---
+
+## 5 · Coverage
+
+`nextex check` reports what fraction of the document it checked.
+
+```
+coverage = 1 − (bytes in opaque nodes ÷ bytes in all nodes)
+```
+
+Byte-weighted, over the parsed document, computed by `Document::coverage`. An empty document is `1.0` by
+convention: there is nothing unchecked in it.
+
+**Coverage is a drop signal, not a threshold.** No number is a passing grade, and the compiler never fails on
+one. What is worth acting on is a *fall*: a file that was 60% checked yesterday and is 30% today gained a
+construct the parser cannot model, or entered quarantine early. Comparing a project against a fixed target
+would only measure how much LaTeX that project happens to contain.
+
+The one place an absolute figure means something: a fully annotated file that still reports low coverage is
+reporting a parser gap, and that is what [issue #36](https://github.com/camilochs/nexttex/issues/36) is.
+
+This is the analogue of TypeScript's `any` and `noImplicitAny`, and it is the signal for supervising a draft
+an agent wrote.
+
+---
+
+## 6 · Erasure
+
+`erase(d)` is `d` with every NextTeX construct replaced by the LaTeX it stands for and every opaque node
+copied byte for byte.
+
+Erasure emits **no** assertion, wrapper environment, or support package. This is binding
+([`AGENTS.md`](../AGENTS.md) §4) and it is what makes property B testable at all: annotated and erased builds
+are compared by rendering both and diffing the rasters. If emission injected anything, the two builds would
+differ by construction and the property would be untestable rather than merely violated.
+
+Practical consequence for anyone extending the emitter: a typed block lowers to the LaTeX its fields
+describe and nothing else. A block that "helpfully" adds `\centering`, or loads a package its body needs, has
+broken the contract even when the PDF happens to look right.
+
+---
+
+## 7 · Citations
 
 A `@cite` key is reported absent only when the bibliography behind it was read **completely**.
 
@@ -88,7 +219,7 @@ files from the author's own projects:
 
 The one failure is `irace-package.bib`, shipped inside a widely used R package. It opens with an
 `@preamble` that concatenates brace-delimited groups with `#`; the crate expects a quotation mark there and
-stops. BibTeX accepts the file. Under the rule in §2, a parse failure is `Unavailable`, so adopting the
+stops. BibTeX accepts the file. Under the rule in §7, a parse failure is `Unavailable`, so adopting the
 crate would silence citation checking for that document entirely — trading a dependency for lost coverage on
 a file that works.
 
@@ -102,27 +233,112 @@ everything and the hand reader disagrees anywhere would reverse it.
 
 ---
 
-## 3 · References
+## 8 · References
 
-An `@ref` whose identifier no `@id` declares is an error. The scope is the document root — its root file
+An `@ref` whose identifier no `@id` declares is `NT1003`. The scope is the document root — its root file
 plus everything reached through `@import` — which matches LaTeX, where a label is document-wide.
 
-Two `@id` constructs declaring the same identifier in one root is an error, blamed on the later one. The
+Two `@id` constructs declaring the same identifier in one root is `NT1001`, blamed on the later one. The
 first declaration is not at fault for existing.
 
 `@cite` is excluded from this check even though it is also a reference: its keys come from a bibliography,
-so it is answered by §2 instead. Answering it here would call an unread bibliography an absent key.
+so it is answered by §7 instead. Answering it here would call an unread bibliography an absent key.
 
 ---
 
-## 4 · What is never an error
+## 9 · Blame
+
+Every diagnostic names which side of the compiler the offending bytes came from.
+
+| Value | Meaning |
+|---|---|
+| `author-latex` | Bytes the author wrote as LaTeX and the compiler transported. |
+| `nextex-construct` | Bytes the author wrote as NextTeX syntax. |
+| `nextex-generated` | Bytes the emitter produced from a construct. |
+| `unresolved` | No map segment supports an answer. |
+
+`unresolved` is a real value and it is used. Guessing is worse than admitting the map does not reach: a
+compiler that blames the author for its own generated bytes gets abandoned after the second time.
+
+Blame matters most for errors NextTeX did not produce. When TeX fails, the source map converts its
+`file:line` to an offset, finds the segment, and reports the origin — that is [issue
+#14](https://github.com/camilochs/nexttex/issues/14) and it is why the map stores segments rather than
+points.
+
+---
+
+## 10 · Diagnostics: two forms, one content
+
+`nextex check` prints for a person. `nextex check --json` prints for a program. **Both carry the same
+fields.** Neither form may hold something the other cannot express; a field added to one is added to both in
+the same change.
+
+The fields:
+
+| Field | Meaning |
+|---|---|
+| `code` | `NT1001`…, stable across versions. |
+| `severity` | `error` or `advisory`. |
+| `blame` | One of the four values in §9. |
+| `entity` | The class from §2, or `unknown-open`. |
+| `name` | The identifier or key the diagnostic is about, when there is one. |
+| `span` | File, byte offset, length, and the line/column derived from them. |
+| `message` | One sentence, no trailing period, naming the thing rather than the rule. |
+| `related` | Zero or more spans that explain the first, each with its own message. |
+
+Human form:
+
+```
+error[NT1001]: identifier `fig:main` is already declared
+  --> paper.ntex:88:14
+   |
+88 | \figure(fig:main) {
+   |         ^^^^^^^^ declared again here
+   |
+  --> paper.ntex:41:9
+   |
+41 | @id(fig:main)
+   |     -------- first declared here
+   |
+  blame: nextex-construct
+```
+
+JSON form, same diagnostic:
+
+```json
+{
+  "code": "NT1001",
+  "severity": "error",
+  "blame": "nextex-construct",
+  "entity": "figure",
+  "name": "fig:main",
+  "span": { "file": "paper.ntex", "offset": 2317, "length": 8, "line": 88, "column": 14 },
+  "message": "identifier `fig:main` is already declared",
+  "related": [
+    {
+      "span": { "file": "paper.ntex", "offset": 990, "length": 8, "line": 41, "column": 5 },
+      "message": "first declared here"
+    }
+  ]
+}
+```
+
+The LSP is a third rendering of the same record and adds nothing to it. If the LSP needs a field, it goes in
+the table above first.
+
+---
+
+## 11 · What is never an error
 
 - An unresolved `\ref` or `\cite` written in plain LaTeX.
 - An unknown control sequence, environment, or package.
 - Anything inside an excluded or quarantined region.
 - Anything where one side of a comparison is `?O`.
-
-These may become `advisory` diagnostics, which are off by default and never change the exit code.
+- A low coverage figure.
+- A bibliography that could not be read — the advisory is about the file.
 
 The invariant this protects is in [`AGENTS.md`](../AGENTS.md) §4: renaming a `.tex` to `.ntex` and changing
-nothing must check clean. It follows by construction from the list above, not from care taken case by case.
+nothing must check clean. It follows by construction from §1 and §3, not from care taken case by case.
+
+The test that holds it is a property over the transport corpus, not a list of examples: for every file in
+it, `check` on the renamed file must exit `0` and emit zero diagnostics of severity `error`.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -668,10 +668,45 @@ entry token are ordinary bytes.
 The default verbatim environment set is `verbatim`, `verbatimtab`, `Verbatim`, `listing` and `lstlisting`,
 extended by `nextex.toml`.
 
+The verbatim **command** set is `\verb` and `\verb*` from the LaTeX kernel, `\lstinline` from `listings`, and
+`\mint` and `\mintinline` from `minted`. The last three are transcribed from unified-latex, which marks them
+`argumentParser` rather than giving them a signature — the database itself records that their arguments
+cannot be described by one, which is the same reason they are listed here. `fancyvrb`'s `\Verb` is not in the
+set because no source for it was read; adding it requires reading one.
+
+Each takes its delimiter as the first byte after any arguments that precede it, and ends at that byte's next
+occurrence. `\lstinline` and `\mintinline` may also take a braced form, which is an ordinary balanced group.
+
 An unterminated excluded region whose boundary cannot safely be recovered enters quarantine rather than
 resuming recognition at a guessed byte.
 
 ### Command argument regions
+
+#### A signature is a claim the call can refute
+
+A command name does not determine a signature. Of the 130 built-in signatures, **15 carry a different one
+under another package**: `\definecolor` is `m m m` under `color` and `o m m m` under `xcolor`; `beamer` adds a
+`<overlay>` argument to twelve commands including `\section`, `\item` and `\label`; `cleveref` redefines
+`\ref` from `s m` to `m`. Measured against unified-latex, package by package.
+
+So the rule is not "look up the signature and follow it". It is:
+
+1. Look up the signature and try to follow it.
+2. If a mandatory argument is required where the bytes hold `[`, `<`, `(` or `*`, the signature does not
+   describe this call. **Discard it** and fall through to the unknown-command rule below.
+
+The fall-through is what makes package ambiguity safe without reading the preamble. Every one of the 15
+variants differs by adding an argument at the front, so the mismatch is detected at the first argument and
+the conservative path — exclude the adjacent groups — is taken instead.
+
+Trusting the signature anyway is the failure this prevents, and it is not hypothetical: with `m m m` applied
+to `\definecolor[named]{...}{...}{...}`, the `m` consumed the single byte `[`, recognition resumed **inside**
+`named`, and all three arguments were opened to construct recognition.
+
+Reading `\usepackage` from the preamble to pick the right variant would be an improvement in precision. It is
+not required for safety, and it is not in v0.1.
+
+#### Where signatures come from
 
 Command shapes are not inferred from the corpus. They come from declarative specifications:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -107,6 +107,20 @@ corpus entry pins three things, and a change to any of them is a reviewable diff
 diagnostics — ordinary papers with unresolved `\ref`, undefined citations, exotic packages — are what keep
 the "renamed `.tex` checks clean" promise honest. A checker that gets stricter over time fails here first.
 
+Its first form is `ordinary_latex_yields_no_constructs` in `crates/nextex-core/tests/fixtures.rs`. It found
+[#39](https://github.com/camilochs/nexttex/issues/39) on the day it was written: `\lstinline|@id(x)|` was
+being read as syntax, in a sentence whose whole point was to write the token without using it.
+
+**Every fixture's `scanner:` line is checked.** Each `expect.txt` carries a strict line — `none`, or a list
+where `ref` is a construct and `!ref` a malformed one — and `every_fixture_produces_the_pieces_it_declares`
+compares it against what the scanner produced. Before that test existed, all 42 fixtures declared their
+constructs in prose and nothing read it: the grammar was documented and unfalsified at the same time.
+
+The `scanner:` lines were transcribed from each fixture's own prose, never from what the scanner did. Where
+the two disagreed, the grammar decided: it found one real scanner defect (a signature trusted through a
+mismatch) and one wrong fixture input (`latex{}`, which §7 does make a raw escape). A `scanner:` line
+written to match the code would have documented both as correct.
+
 ---
 
 ## 5 · Hazard fixtures — the falsifying observation is the test

--- a/tests/fixtures/blocks/01-multiline-caption-with-nested-braces/expect.txt
+++ b/tests/fixtures/blocks/01-multiline-caption-with-nested-braces/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: table
 constructs: table(t)

--- a/tests/fixtures/blocks/02-caption-with-percent-and-escaped-braces/expect.txt
+++ b/tests/fixtures/blocks/02-caption-with-percent-and-escaped-braces/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: figure
 constructs: figure(f)

--- a/tests/fixtures/blocks/03-backslash-runs-before-delimiters/expect.txt
+++ b/tests/fixtures/blocks/03-backslash-runs-before-delimiters/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: figure
 constructs: figure(f)

--- a/tests/fixtures/blocks/04-trailing-field-with-spacing-and-font-group/expect.txt
+++ b/tests/fixtures/blocks/04-trailing-field-with-spacing-and-font-group/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: table
 constructs: table(t)

--- a/tests/fixtures/blocks/05-at-brace-inside-a-block-body/expect.txt
+++ b/tests/fixtures/blocks/05-at-brace-inside-a-block-body/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: table
 constructs: table(t); columns derived = 3

--- a/tests/fixtures/blocks/06-derived-column-count-with-repeats-and-multicolumn/expect.txt
+++ b/tests/fixtures/blocks/06-derived-column-count-with-repeats-and-multicolumn/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: table
 constructs: table(t); columns derived = 7, accounting for multicolumn

--- a/tests/fixtures/blocks/07-unknown-tabular-environment/expect.txt
+++ b/tests/fixtures/blocks/07-unknown-tabular-environment/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: table
 constructs: table(t); column check advisory — environment not modelled

--- a/tests/fixtures/blocks/08-fields-that-no-longer-exist/expect.txt
+++ b/tests/fixtures/blocks/08-fields-that-no-longer-exist/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: !table
 constructs: all three malformed — hard errors

--- a/tests/fixtures/blocks/09-unmatched-block-opening/expect.txt
+++ b/tests/fixtures/blocks/09-unmatched-block-opening/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: !figure
 constructs: figure malformed — boundary is end of file, hard error

--- a/tests/fixtures/entry-tokens/01-at-brace-in-column-spec/expect.txt
+++ b/tests/fixtures/entry-tokens/01-at-brace-in-column-spec/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: none
 constructs: none

--- a/tests/fixtures/entry-tokens/02-at-shapes-that-are-not-constructs/expect.txt
+++ b/tests/fixtures/entry-tokens/02-at-shapes-that-are-not-constructs/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: none
 constructs: none

--- a/tests/fixtures/entry-tokens/03-a-reference-in-prose/expect.txt
+++ b/tests/fixtures/entry-tokens/03-a-reference-in-prose/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: ref
 constructs: ref(a) at 21..29

--- a/tests/fixtures/entry-tokens/04-figure-with-and-without-paren/expect.txt
+++ b/tests/fixtures/entry-tokens/04-figure-with-and-without-paren/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: figure
 constructs: figure(a)

--- a/tests/fixtures/entry-tokens/05-latex-word-not-followed-by-brace/expect.txt
+++ b/tests/fixtures/entry-tokens/05-latex-word-not-followed-by-brace/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: none
 constructs: none

--- a/tests/fixtures/exclusions/01-escaped-and-real-percent/expect.txt
+++ b/tests/fixtures/exclusions/01-escaped-and-real-percent/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: ref
 constructs: ref(real)

--- a/tests/fixtures/exclusions/02-entry-token-after-closing-math/expect.txt
+++ b/tests/fixtures/exclusions/02-entry-token-after-closing-math/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: ref
 constructs: ref(after)

--- a/tests/fixtures/exclusions/03-entry-token-as-a-verb-delimiter/expect.txt
+++ b/tests/fixtures/exclusions/03-entry-token-as-a-verb-delimiter/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: none
 constructs: none

--- a/tests/fixtures/exclusions/04-mixed-case-verbatim-environments/expect.txt
+++ b/tests/fixtures/exclusions/04-mixed-case-verbatim-environments/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: none
 constructs: none

--- a/tests/fixtures/exclusions/05-known-signature-with-tokens-in-every-argument/expect.txt
+++ b/tests/fixtures/exclusions/05-known-signature-with-tokens-in-every-argument/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: ref
 constructs: ref(after) only — the four arguments are excluded

--- a/tests/fixtures/exclusions/06-unknown-command-with-one-sixteen-and-seventeen-groups/expect.txt
+++ b/tests/fixtures/exclusions/06-unknown-command-with-one-sixteen-and-seventeen-groups/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: ref ref
 constructs: see note — 1 and 16 groups excluded, the 17th quarantines

--- a/tests/fixtures/exclusions/07-environment-optional-title-and-body/expect.txt
+++ b/tests/fixtures/exclusions/07-environment-optional-title-and-body/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: id ref
 constructs: id(thm:x) on the header; ref(good) in the body; the title is opaque

--- a/tests/fixtures/exclusions/08-unmatched-openers-that-quarantine/expect.txt
+++ b/tests/fixtures/exclusions/08-unmatched-openers-that-quarantine/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: none
 constructs: none after the opener — recognition stops

--- a/tests/fixtures/inline/01-caption-then-id-same-line-and-next/expect.txt
+++ b/tests/fixtures/inline/01-caption-then-id-same-line-and-next/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: id id
 constructs: id(x) id(y)

--- a/tests/fixtures/inline/02-attachment-across-line-endings/expect.txt
+++ b/tests/fixtures/inline/02-attachment-across-line-endings/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: id id
 constructs: id(ok) attached; id(toofar) unattached — hard error

--- a/tests/fixtures/inline/03-attachment-at-the-byte-bound/expect.txt
+++ b/tests/fixtures/inline/03-attachment-at-the-byte-bound/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: id
 constructs: id(atbound) attached at exactly 256 skipped bytes

--- a/tests/fixtures/inline/04-attachment-blocked-by-a-comment/expect.txt
+++ b/tests/fixtures/inline/04-attachment-blocked-by-a-comment/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: id
 constructs: id(blocked) unattached — a comment is not skipped

--- a/tests/fixtures/inline/05-reference-followed-by-punctuation/expect.txt
+++ b/tests/fixtures/inline/05-reference-followed-by-punctuation/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: ref ref ref
 constructs: ref(x) ref(y) ref(z)

--- a/tests/fixtures/inline/06-paren-inside-an-import-string/expect.txt
+++ b/tests/fixtures/inline/06-paren-inside-an-import-string/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: import
 constructs: import(sections/a(1).ntex)

--- a/tests/fixtures/inline/07-unterminated-then-valid-on-next-line/expect.txt
+++ b/tests/fixtures/inline/07-unterminated-then-valid-on-next-line/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: !ref ref
 constructs: ref malformed — hard error; ref(good) recognised

--- a/tests/fixtures/inline/08-empty-and-non-ascii-identifiers/expect.txt
+++ b/tests/fixtures/inline/08-empty-and-non-ascii-identifiers/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: ref id
 constructs: both malformed — hard errors inside the explicit construct

--- a/tests/fixtures/raw/01-every-entry-token-inside-a-raw-escape/expect.txt
+++ b/tests/fixtures/raw/01-every-entry-token-inside-a-raw-escape/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: latex
 constructs: raw; nothing inside recognised

--- a/tests/fixtures/raw/02-braces-escapes-and-a-comment-inside-raw/expect.txt
+++ b/tests/fixtures/raw/02-braces-escapes-and-a-comment-inside-raw/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: latex
 constructs: raw

--- a/tests/fixtures/raw/03-unmatched-raw-opening/expect.txt
+++ b/tests/fixtures/raw/03-unmatched-raw-opening/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: !latex
 constructs: raw malformed — boundary is end of file, hard error

--- a/tests/fixtures/raw/04-latex-word-without-a-brace/expect.txt
+++ b/tests/fixtures/raw/04-latex-word-without-a-brace/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
-constructs: none
+scanner: none
+constructs: none — grammar §7 is "latex" ws* braced, and nothing braced follows

--- a/tests/fixtures/raw/04-latex-word-without-a-brace/input.ntex
+++ b/tests/fixtures/raw/04-latex-word-without-a-brace/input.ntex
@@ -1,1 +1,4 @@
-We compile with latex, not with latex{}\relax — the first is prose.
+We compile with latex, not with latexmk — the first is prose.
+The word latex\relax and latex(parenthesised) and latex[bracketed] stay prose.
+A line ending after latex
+is prose too, because nothing braced follows on it.

--- a/tests/fixtures/raw/05-latex-word-with-no-space-before-the-brace/expect.txt
+++ b/tests/fixtures/raw/05-latex-word-with-no-space-before-the-brace/expect.txt
@@ -1,0 +1,3 @@
+transport: identical
+scanner: latex latex
+constructs: raw raw — §7 says ws*, so zero spaces and two spaces both qualify

--- a/tests/fixtures/raw/05-latex-word-with-no-space-before-the-brace/input.ntex
+++ b/tests/fixtures/raw/05-latex-word-with-no-space-before-the-brace/input.ntex
@@ -1,0 +1,2 @@
+The token is latex{@ref(example)} with no space before the brace.
+And latex  {@id(spaced)} with two spaces is the same construct.

--- a/tests/fixtures/revisions/01-inline-between-words-and-before-punctuation/expect.txt
+++ b/tests/fixtures/revisions/01-inline-between-words-and-before-punctuation/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: add add
 constructs: add(c1) add(c2)

--- a/tests/fixtures/revisions/02-a-long-multiline-revision/expect.txt
+++ b/tests/fixtures/revisions/02-a-long-multiline-revision/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: add
 constructs: add(c1) — content longer than 2040 bytes

--- a/tests/fixtures/revisions/03-nested-constructs-inside-a-revision/expect.txt
+++ b/tests/fixtures/revisions/03-nested-constructs-inside-a-revision/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: add cite ref del
 constructs: add(c1) containing cite(knuth1984) ref(tab:x) del(c2)

--- a/tests/fixtures/revisions/04-construct-inside-a-command-argument-in-a-revision/expect.txt
+++ b/tests/fixtures/revisions/04-construct-inside-a-command-argument-in-a-revision/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: add
 constructs: add(c1); the @ref inside \texttt is ordinary text

--- a/tests/fixtures/revisions/05-substitution-with-arrows-at-depth/expect.txt
+++ b/tests/fixtures/revisions/05-substitution-with-arrows-at-depth/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: sub
 constructs: sub(c1) — one separator at depth one

--- a/tests/fixtures/revisions/06-substitution-with-zero-and-two-arrows/expect.txt
+++ b/tests/fixtures/revisions/06-substitution-with-zero-and-two-arrows/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: !sub !sub
 constructs: both malformed — hard errors

--- a/tests/fixtures/revisions/07-unmatched-revision-brace/expect.txt
+++ b/tests/fixtures/revisions/07-unmatched-revision-brace/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: !add
 constructs: add malformed — boundary is end of file, hard error

--- a/tests/fixtures/revisions/08-properly-nested-revisions/expect.txt
+++ b/tests/fixtures/revisions/08-properly-nested-revisions/expect.txt
@@ -1,2 +1,3 @@
 transport: identical
+scanner: add add
 constructs: add(outer) containing add(inner)


### PR DESCRIPTION
Closes #4. Phase 1, first of three.

## The contract

`docs/checking.md` is now the single document the checker, CLI, LSP and test suites read: entity classes and `?O`, the closed list of hard errors with codes, exit codes, advisories, coverage, erasure, the four blame values, and the diagnostic fields in both output forms.

Two rules carry it, and both are properties rather than example lists:

```
                        is it inside an explicit @construct?
                                    |
                        no ---------+--------- yes
                         |                      |
                      silence          are BOTH sides known?
                                                |
                                  no -----------+----------- yes
                                   |                          |
                                silence                   may be a
                              (?O ~ everything)          hard error
```

Everything else follows. There is no row in the hard-error table that ordinary LaTeX can reach, so renaming a `.tex` and changing nothing checks clean by construction rather than by care.

## Writing it down exposed that nothing checked the grammar

All 42 fixtures declared their constructs, in prose, and no test read the line. The grammar was documented and unfalsified at the same time.

Each `expect.txt` now carries a strict `scanner:` line — `none`, or a list where `ref` is a construct and `!ref` a malformed one — and the harness compares it against what the scanner produced.

| | Fixtures |
|---|---|
| Verified against the scanner | 34 |
| Listed as not built, naming #6 and #15 | 8 |

**The lines were transcribed from each fixture's own prose, never from what the scanner does.** A `scanner:` line written to match the code documents the bug. Where prose and code disagreed, the grammar decided — and it found one of each.

## Defect 1: a signature was trusted through a mismatch

15 of the 130 built-in signatures carry a different one under another package. Measured against unified-latex, package by package:

| Command | latex2e | other |
|---|---|---|
| `\definecolor` | `m m m` | `o m m m` (xcolor) |
| `\fcolorbox` | `o m m` | `o m o m m` (xcolor) |
| `\ref` | `s m` | `m` (cleveref) |
| `\section`, `\item`, `\label`, `\part`, … | as written | `d<>` prepended (beamer), 12 in all |

With `m m m` applied to the xcolor form, the mandatory argument hit `[`, took the "a mandatory argument may be a single token" branch, and consumed one byte:

```
\definecolor[named]{@ref(a)}{@ref(b)}{@ref(c)} then @ref(after).
             ^
             m consumed just this, and recognition resumed inside `named`

declared:  ref                       (the fixture's own prose)
produced:  ref ref ref ref           (all three arguments opened)
```

A signature is a claim the call can refute. A mandatory argument required where the bytes hold `[`, `<`, `(` or `*` now discards the signature and falls through to the conservative unknown-command rule.

That is also what makes the package ambiguity safe without reading the preamble: every one of the 15 variants differs by adding an argument at the front, so the mismatch is caught at the first argument and the groups get excluded anyway. Reading `\usepackage` would buy precision, not safety, and is not in v0.1.

## Defect 2: a fixture input contradicted its own name

`raw/04-latex-word-without-a-brace` contained `latex{}`. Grammar §7 is `raw = "latex" ws* braced`, and `ws*` admits zero — so that **is** a raw escape and the scanner was right. Input corrected; `raw/05` added for the zero-space and two-space forms.

## The negative corpus, and what it found immediately

`ordinary_latex_yields_no_constructs` asserts the promise the project rests on: ordinary LaTeX yields nothing. It found #39 on the day it was written.

```
\lstinline|@id(x)| shows the syntax without using it.
```

produced `id` — in a sentence whose entire point was to write the token without using it. §8 now specifies the verbatim command set (`\verb`, `\verb*`, `\lstinline`, `\mint`, `\mintinline`), transcribed from unified-latex, which marks the last three as needing a custom argument parser rather than a signature. `fancyvrb`'s `\Verb` is deliberately absent: no source for it was read.

## Checks

`cargo test --workspace`: 92 pass. Clippy clean at `-D warnings`. Transport byte-identical at every truncation of every fixture.