### PR TITLE
Settle what a typed block emits, and put the type system in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,53 @@ Ordinary LaTeX keeps working: \emph{emphasis}, $E = mc^2$, \citep{blum2020}.
 
 Two levels of annotation. `@id(x)` hangs off any LaTeX construct and buys checked references and safe rename
 — theorems and algorithms work without NextTeX knowing what they are. A typed block such as `\figure(x)`
-buys visual checks and writes the packages it needs into the preamble for you.
+also gives the compiler the fields to check: the image resolves, the caption is there, the column count
+matches the `tabular`.
+
+---
+
+## The type system is gradual, and that is the whole design
+
+A document is mostly LaTeX the compiler does not model, and that is not a defect to be fixed later. It is
+the state the language is built for.
+
+Every entity is either a class the compiler knows or `?O`, the **unknown open** type:
+
+| Class | Where it comes from |
+|---|---|
+| `Figure`, `Table` | a typed block — `\figure(fig:x)`, `\table(tab:x)` |
+| `Section`, `Appendix`, `Algorithm`, `Equation` | `@id` attached to the LaTeX construct that is one |
+| `Citation` | `@cite`, checked against the bibliography rather than against identifiers |
+| `?O` | everything else |
+
+*Open* is the load-bearing word. `?` in a gradual type system means "unknown among a fixed set of types".
+LaTeX has no fixed set — any package may define new constructors at any time — so the unknown here is
+unbounded. The term is from Malewski, Greenberg and Tanter, *Gradually Structured Data* (OOPSLA 2021).
+
+Comparison is **consistency**, not equality, and two lines are the entire checking policy:
+
+```
+Known(A) ~ Known(B)   if and only if A == B     <- this can fail
+?O       ~ T          for every T               <- this never fails
+```
+
+`?O` is consistent with everything, so nothing involving unmodelled LaTeX can be inconsistent, so nothing
+involving unmodelled LaTeX can fail. **`?O` does not mean invalid. It means the compiler has no grounds.**
+
+Two consequences worth stating plainly.
+
+**Renaming a `.tex` to `.ntex` and changing nothing checks clean.** Not by care taken case by case — by
+construction, because every entity in it is `?O`. That is the gradual guarantee (Siek, Vitousek, Cimini and
+Boyland, SNAPL 2015) instantiated for documents, and it is what makes the on-ramp real rather than a
+promise.
+
+**You choose how much to annotate, and the compiler tells you how much you chose.** `nextex check` reports
+coverage: the fraction of the document it checked. This is the analogue of `any` and `noImplicitAny`. What
+matters is not the number but a fall in it — a file that was 60% checked and is now 30% gained something the
+parser cannot model.
+
+The check that types buy, and that no LaTeX tool performs: `@ref` to a `\table(fig:main)` while your prose
+says "Figure". LaTeX compiles it and prints the wrong word. See [`docs/checking.md`](docs/checking.md).
 
 ---
 
@@ -76,14 +122,6 @@ less. You write more so the tooling knows more.
 
 It does not replace TeX, does not typeset, and does not ask you to leave the LaTeX ecosystem. Your journal
 still receives a `.tex` file.
-
-It does not compete with [Typst](https://typst.app), which asks an author to leave their corpus behind.
-NextTeX asks you to keep it.
-
-Prior art it does **not** claim to have invented: typed document languages that emit LaTeX
-([MyST](https://mystmd.org)), semantic annotation over LaTeX with editor support
-([sTeX](https://ctan.org/pkg/stex)), and language servers for LaTeX
-([texlab](https://github.com/latex-lsp/texlab), [digestif](https://github.com/astoff/digestif)).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -276,8 +276,11 @@ says where the error messages need to be better than what LaTeX already prints.
 ### Phase 1 — Freeze the language contract
 
 Write the formal grammar, lexical boundaries, explicit hard-error policy, erasure rules, review-mode
-semantics, and representative valid and invalid examples. Resolve the conflict between package-synthesis
-language and the binding no-injection invariant.
+semantics, and representative valid and invalid examples.
+
+The package-synthesis conflict is settled: `needs` is not a field, packages are written by the author in the
+preamble, and a typed block lowers to the LaTeX its fields describe and nothing else. See
+[`docs/decisions/0001`](docs/decisions/0001-typed-emission-and-no-injection.md).
 
 **Done when** every construct has a boundary that can be found without looking ahead past end of line, and
 no two examples in the spec demand different output for the same input.

--- a/docs/decisions/0001-typed-emission-and-no-injection.md
+++ b/docs/decisions/0001-typed-emission-and-no-injection.md
@@ -1,0 +1,134 @@
+# 0001 · Typed emission, and no injection
+
+**Status:** accepted, 2026-08-29. Decided by the director.
+**Supersedes:** the `needs` field, and the README sentence promising package synthesis.
+**Issue:** [#5](https://github.com/camilochs/nexttex/issues/5)
+
+---
+
+## The conflict this settles
+
+Two documents in this repository prescribed different emitted bytes for the same typed block.
+
+- `README.md` said a typed block "writes the packages it needs into the preamble for you".
+- `AGENTS.md` §4 and `PHILOSOPHY.md` §5 say NextTeX emits no support package, wrapper environment, or
+  assertion of its own.
+
+Both cannot be true. The emitter could not be written while they disagreed.
+
+The director's original decision was that a block declares the packages it needs — a `needs` field. The
+specification removed the field instead, and recorded that it was doing so against that decision. This record
+closes the gap: **the decision is now to remove it**, taken by the director with the measurement below.
+
+## The measurement that decided it
+
+The proposal that would have kept the field was: `needs` is checked and never emitted. The block declares
+what it requires, the compiler verifies the preamble already loads it, and nothing is written.
+
+The question is whether that check can be trusted. Measured across 224 `.tex` files in the author's
+workspace, grouped by project, for packages with a distinctive command:
+
+| Package | Projects using it | With no explicit `\usepackage` |
+|---|---|---|
+| amsmath | 18 | 9 (50%) |
+| hyperref | 35 | 16 (46%) |
+| xcolor | 42 | 17 (40%) |
+| graphicx | 30 | 10 (33%) |
+| booktabs | 40 | 9 (22%) |
+| subcaption | 16 | 3 (19%) |
+| multirow | 6 | 1 (17%) |
+
+Between a sixth and a half of real projects use a package's commands without ever writing its
+`\usepackage`: a journal class or another package loads it. The compiler reads neither `.cls` nor `.sty`, so
+it cannot see that. A `needs` check would have reported a missing package in 9 of the 40 projects that use
+`booktabs` — each one a document that compiles.
+
+A check that is wrong that often trains its reader to ignore it, and an ignored check has no value. That is
+the argument in [`checking.md`](../checking.md), applied to the field that motivated it.
+
+Reproduce with `tests/experiments/package-loading/`.
+
+## The decision
+
+1. **`needs` is not a field.** Writing it in a block is a malformed field, `NT1008`, like any other unknown
+   key. Packages are declared where LaTeX declares them: `\usepackage` in the preamble, written by the
+   author, transported byte for byte.
+2. **A typed block lowers to the LaTeX its fields describe, and to nothing else.** The lowering is in the
+   next section and it is exhaustive.
+3. **`README.md` is corrected.** The sentence promising package synthesis is removed.
+
+## What a typed block emits
+
+`\figure(id) { … }` lowers to:
+
+```latex
+\begin{figure}
+  \centering                                  % only if `width` or `src` is present
+  \includegraphics[width=…]{src}
+  \caption{caption}
+  \label{id}
+\end{figure}
+```
+
+`\table(id) { … }` lowers to:
+
+```latex
+\begin{table}
+  \centering
+  \caption{caption}
+  body
+  trailing
+  \label{id}
+\end{table}
+```
+
+The order is not a matter of taste. Measured across 662 float environments in the author's corpus:
+
+| | figures (368) | tables (294) |
+|---|---|---|
+| `\centering` present | 97% | 88% |
+| `\label` **after** `\caption` | 92% | 93% |
+| `\caption` before the `tabular` | — | 96% |
+
+`\label` after `\caption` is correctness rather than convention: `\caption` is what steps the counter, so a
+`\label` placed before it records the previous number. The TeX FAQ states it directly — "if the label is
+recording a `\caption` command, the `\label` command must appear after the `\caption` command, or be part of
+it" ([FAQ-crossref](https://texfaq.org/FAQ-crossref)). Exactly one figure in 368 does it the other way.
+
+Three rules govern every byte of that output.
+
+- **Braced field content is copied, never reparsed or reformatted.** `caption`, `body` and `trailing` are
+  spans into the source buffer. Whatever the author wrote inside them — comments, `\\`, nested braces,
+  invalid UTF-8 — arrives unchanged. This is the transport invariant applied inside a construct.
+- **Nothing is added that no field asked for.** No `\usepackage`. No wrapper environment. No `\FloatBarrier`,
+  no `\vspace`, no package-specific helper, however much the output would benefit.
+- **`\centering` is the one exception, and it is not injection.** It is part of what `\figure` and `\table`
+  *mean* — the construct is a centred float, and an author who does not want one writes the environment in
+  LaTeX. It is emitted unconditionally for `\table`, and for `\figure` only when there is an image to
+  centre. Anyone extending the emitter should read this as the boundary rather than as licence: a second
+  exception needs its own decision record.
+
+## How the rule is tested
+
+By comparing the two builds, which is exactly property B:
+
+```
+render(tex(emit(d))) == render(tex(emit(erase(d))))
+```
+
+`erase(d)` replaces every construct with the LaTeX it stands for and copies every opaque node. If the
+emitter injected anything, the annotated build would carry bytes the erased build does not, and the rasters
+would differ. So the property is not an extra check bolted onto the rule — the rule is what makes the
+property testable at all.
+
+The narrower form, testable before a TeX engine is wired in: emitting a document and emitting its erasure
+must produce byte-identical `.tex` output outside the spans the constructs occupy.
+
+## What this does not settle
+
+Package synthesis is closed for v0.1, not forbidden for all time. Reopening it needs an end-to-end example
+that requires a package absent from the source and still satisfies property B. None has been produced.
+
+Reading `.cls` and `.sty` to see indirect loading is Phase 4 work. If it lands, the measurement above can be
+re-run; a `needs` check would then be wrong far less often, and the case for the field could be made again
+on new evidence rather than on the same evidence.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -451,16 +451,21 @@ This decision removes duplicated information. The hand annotation restated
 
 ### Package requirements
 
-A `needs` field is not admitted in v0.1. Emitting `\usepackage` would inject bytes, while retaining a field
-that has no defined effect would make the construct misleading. Package synthesis remains open only if a
-future correctness rule permits injection or an erasure-preserving interpretation is specified. An
-end-to-end example that requires a package absent from the source and still satisfies typesetting
-equivalence would settle the issue.
+`needs` is not a field. Writing it in a block is a malformed field like any other unknown key.
 
-> **Open against a director decision.** The director chose that packages be declared by the block. This
-> specification removes the field instead, because emitting `\usepackage` contradicts the binding
-> no-injection rule and a field with no effect misleads. The conflict is real and unresolved; see repository
-> issue #5. This section records the specification's position, not a settled decision.
+Packages are declared where LaTeX declares them: `\usepackage` in the preamble, written by the author,
+transported byte for byte. Emitting one would inject bytes the erased build does not have, which contradicts
+the binding no-injection rule and makes property B untestable rather than merely violated.
+
+The alternative that would have kept the field — declare it, never emit it, check that the preamble already
+loads it — was measured and rejected. Across 224 `.tex` files grouped by project, between 17% and 50% of
+projects that use a package's commands never write its `\usepackage`: a journal class or another package
+loads it, and the compiler reads neither `.cls` nor `.sty`. The check would have reported a missing package
+in 9 of the 40 projects that use `booktabs`, each of which compiles.
+
+Settled by the director on 2026-08-29 with that measurement in hand. Full record and the emission contract:
+[`decisions/0001-typed-emission-and-no-injection.md`](decisions/0001-typed-emission-and-no-injection.md).
+Reproduce the measurement with `tests/experiments/package-loading/`.
 
 ### Balanced-region scanning
 
@@ -892,7 +897,7 @@ scanner hand-written, producing two parsing systems without removing the difficu
 | `columns` was declared | Column count is read from the tabular column specification | The hand annotation duplicated information already present in `@{}lcccccc@{}` |
 | Argument-position detection was left for corpus validation | Command arguments are selected from `xparse` and unified-latex signatures | LaTeX already provides declarative command-shape specifications |
 | Entity coverage was implicit | v0.1 admissions and exclusions are explicit | The hand annotation and counts for algorithms, lines and subfigures exposed the missing cases |
-| `needs` was admitted while its effect remained unresolved | `needs` is not v0.1 syntax | Package injection contradicts the binding correctness properties — **and contradicts a director decision; see §5** |
+| `needs` was admitted while its effect remained unresolved | `needs` is not a field | Emitting `\usepackage` injects bytes; the non-emitting check was measured wrong in 17–50% of real projects. Settled by the director, `decisions/0001` |
 
 ### Open decisions
 
@@ -910,6 +915,5 @@ The following decisions remain open because the available evidence does not sele
    title-specific check or reference would justify the latter.
 6. **Typed algorithm and panel blocks.** Light annotations admit both. A demonstrated typed check with a
    stable field set would justify new blocks.
-7. **Package requirements.** Options are source-authored `\usepackage`, a non-emitting advisory declaration,
-   or a documented exception to no-injection. Only a rule consistent with the binding typesetting property
-   can admit `needs`. **This one is not merely open: it stands against an explicit director decision.**
+7. ~~**Package requirements.**~~ Settled 2026-08-29: `needs` is not a field, packages are source-authored.
+   See `decisions/0001-typed-emission-and-no-injection.md`.

--- a/tests/experiments/package-loading/README.md
+++ b/tests/experiments/package-loading/README.md
@@ -1,0 +1,48 @@
+# Is a package's use visible in the source?
+
+Decides the `needs` field. The proposal was: a block declares the packages its body requires, the compiler
+checks the preamble already loads them, and nothing is emitted. That keeps the syntax and breaks no
+invariant — if the check can be trusted.
+
+## Run
+
+```sh
+python3 measure.py ~/Workspace
+```
+
+`.tex` files are grouped by directory, and a package counts as explicitly loaded if any file in that group
+carries a `\usepackage` or `\RequirePackage` naming it.
+
+## Result, 2026-08-29
+
+224 `.tex` files from the author's workspace.
+
+| Package | Projects using it | With no explicit `\usepackage` |
+|---|---|---|
+| amsmath | 18 | 9 (50%) |
+| hyperref | 35 | 16 (46%) |
+| xcolor | 42 | 17 (40%) |
+| graphicx | 30 | 10 (33%) |
+| booktabs | 40 | 9 (22%) |
+| subcaption | 16 | 3 (19%) |
+| multirow | 6 | 1 (17%) |
+
+Between a sixth and a half of real projects use a package's commands and never write its `\usepackage`. A
+journal class or another package loads it, and the compiler reads neither `.cls` nor `.sty`.
+
+So the check would report a missing package in 9 of the 40 projects that use `booktabs` — every one of them
+a document that compiles. A check wrong that often trains its reader to ignore it.
+
+`needs` was removed on this evidence. See
+[`docs/decisions/0001`](../../../docs/decisions/0001-typed-emission-and-no-injection.md).
+
+## What would change the answer
+
+Reading `.cls` and `.sty` to follow indirect loading, which is Phase 4 work. Re-run this then: the numbers
+should fall, and the case for the field could be made again on new evidence.
+
+## Limits of this measurement
+
+One author's corpus. Grouping by directory approximates a project and will merge two projects that share a
+folder. The probe commands imply their package but do not exhaust it — a project using `booktabs` only
+through a template macro is not counted as using it.

--- a/tests/experiments/package-loading/measure.py
+++ b/tests/experiments/package-loading/measure.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""How often a package's commands are used without an explicit \\usepackage.
+
+Decides whether a `needs` field could be checked against the preamble. It cannot:
+a journal class or another package loads the package, and the compiler reads
+neither `.cls` nor `.sty`.
+
+    python3 measure.py <root>
+"""
+import collections
+import os
+import re
+import sys
+
+# A command distinctive enough that its presence implies the package.
+PROBES = {
+    "booktabs": r"\\toprule|\\midrule|\\bottomrule",
+    "graphicx": r"\\includegraphics",
+    "amsmath": r"\\text\{|\\begin\{align\}",
+    "multirow": r"\\multirow",
+    "hyperref": r"\\href|\\url\{",
+    "xcolor": r"\\cellcolor|\\definecolor",
+    "subcaption": r"\\subfigure|\\begin\{subfigure\}",
+}
+
+
+def projects(root):
+    """.tex files grouped by the directory holding them."""
+    found = collections.defaultdict(list)
+    for base, _, names in os.walk(root):
+        for name in names:
+            if name.endswith(".tex"):
+                found[base].append(os.path.join(base, name))
+    return found
+
+
+def main(root):
+    grouped = projects(root)
+    print(f"{'package':12}{'projects using it':>20}{'no explicit usepackage':>26}")
+    for package, probe in PROBES.items():
+        loads = re.compile(
+            r"\\(?:usepackage|RequirePackage)(?:\[[^\]]*\])?\{[^}]*\b" + package + r"\b[^}]*\}"
+        )
+        used = missing = 0
+        for paths in grouped.values():
+            text = ""
+            for path in paths:
+                with open(path, errors="replace") as handle:
+                    text += handle.read()
+            if not re.search(probe, text):
+                continue
+            used += 1
+            missing += 0 if loads.search(text) else 1
+        share = f"({100 * missing / used:.0f}%)" if used else ""
+        print(f"{package:12}{used:>20}{missing:>20} {share}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else ".")


### PR DESCRIPTION
Closes #5. Phase 1, second of three.

## The conflict

Two documents prescribed different bytes for the same block.

| | said |
|---|---|
| `README.md` | a typed block "writes the packages it needs into the preamble for you" |
| `AGENTS.md` §4 | NextTeX emits no support package, wrapper environment or assertion of its own |

The emitter could not be written while they disagreed. **`needs` is removed** — your decision, reversing your earlier one, taken with the measurement below.

## What decided it

The version that would have kept the field: declare it, never emit it, check the preamble already loads it. That keeps your syntax and breaks no invariant — if the check can be trusted.

Across 224 `.tex` files grouped by project:

| Package | Projects using it | With no explicit `\usepackage` |
|---|---|---|
| amsmath | 18 | 9 (50%) |
| hyperref | 35 | 16 (46%) |
| xcolor | 42 | 17 (40%) |
| graphicx | 30 | 10 (33%) |
| booktabs | 40 | 9 (22%) |
| subcaption | 16 | 3 (19%) |
| multirow | 6 | 1 (17%) |

Between a sixth and a half of real projects use a package's commands and never write its `\usepackage` — a journal class or another package loads it, and the compiler reads neither `.cls` nor `.sty`. The check would have reported a missing package in 9 of the 40 projects that use `booktabs`, every one a document that compiles.

Reproduce: `python3 tests/experiments/package-loading/measure.py <root>`.

## What a typed block emits

```
\figure(fig:x) {                    \begin{figure}
  src     = "runtime.pdf"             \centering
  width   = 80%              ──►      \includegraphics[width=0.8\linewidth]{runtime.pdf}
  caption = {Runtime}                 \caption{Runtime}
}                                     \label{fig:x}
                                    \end{figure}
```

The order is measured, not chosen. Across 662 float environments in your corpus:

| | figures (368) | tables (294) |
|---|---|---|
| `\centering` present | 97% | 88% |
| `\label` after `\caption` | 92% | 93% |
| `\caption` before the `tabular` | — | 96% |

`\label` after `\caption` is correctness, not convention: `\caption` steps the counter, so a `\label` before it records the previous number. The [TeX FAQ](https://texfaq.org/FAQ-crossref) says it directly. Exactly one figure in 368 does it the other way.

Three rules bound the emitter, and `docs/decisions/0001` is where anyone extending it reads them:

- braced fields are **copied**, never reparsed or reformatted — spans into the source buffer, comments and all;
- nothing is added that no field asked for;
- `\centering` is the single exception, because it is part of what "figure" and "table" *mean* here. A second exception needs its own decision record.

## The README was hiding the type system

`gradual` appeared **zero** times in it. `type` appeared only inside "TypeScript" and in the prior-art list. A reader learned that NextTeX has `@id` and typed blocks, and reasonably concluded there was no type system at all — the part that survived the novelty check was missing from the front door.

It now carries the class table, `?O` and the consistency relation, why renaming a `.tex` checks clean by construction rather than by care, and coverage as the dial.

```
Known(A) ~ Known(B)   if and only if A == B     <- this can fail
?O       ~ T          for every T               <- this never fails
```

Also removed at your request: the Typst comparison and the prior-art list. Both stay in `PHILOSOPHY.md`, which is the binding document for positioning.

## Checks

`cargo test --workspace`: 92 pass. Clippy clean. Every number in the changed docs has a command behind it.

Remaining in Phase 1: #6, revisions.