### PR TITLE
Give a reference a way to say what it wants: the prefix

### DIFF
--- a/docs/checking.md
+++ b/docs/checking.md
@@ -54,6 +54,40 @@ The second and third lines are the whole checking policy in two symbols. `?O` is
 everything, so nothing involving unmodelled LaTeX can ever be inconsistent, so nothing involving unmodelled
 LaTeX can ever fail. `?O` does not mean *invalid*. It means *the compiler has no grounds*.
 
+### How a reference states what it wants
+
+A comparison needs two sides. The declaration supplies one: `\figure(fig:main)` is a `Figure` by its
+keyword, and an `@id` takes the class of the construct it attached to — `\section` gives `Section`,
+`\begin{algorithm}` gives `Algorithm`, anything unmodelled gives `?O`.
+
+The reference supplies the other, and **it does so through the prefix before the first `:`**.
+`@ref(fig:main)` demands a `Figure`; pointing it at a `\table(fig:main)` is `NT1004`.
+
+```toml
+# the default map, replaced entirely by nextex.toml, never merged into
+[prefixes]
+figure    = ["fig"]
+table     = ["tab"]
+section   = ["sec", "subsec", "subsubsec", "ssec", "chap", "cap"]
+appendix  = ["app", "appendix"]
+algorithm = ["alg", "algo"]
+equation  = ["eq"]
+```
+
+The convention was read from documents rather than imposed on them: 1,344 of 1,374 measured labels carry a
+prefix, and inside a typed environment it agrees with the environment 96–100% of the time. The several
+spellings per class are in the map for the same reason — one author writes `sec:`, `subsec:` and `ssec:` for
+one class, and a single-spelling map would fail 54 correct labels in that corpus.
+
+Two ways the demand is absent, and both are silence rather than error:
+
+- **An unmapped prefix demands nothing.** `def:geakg` is not in the map, so the reference is `?O`. Adding a
+  prefix is how a class opts into checking; never adding one is a valid permanent state.
+- **No prefix demands nothing.** The 30 unprefixed labels keep working.
+
+Full record, including the two rejected alternatives:
+[`decisions/0003`](decisions/0003-the-prefix-is-the-demand.md).
+
 ---
 
 ## 3 · When the compiler may fail

--- a/docs/decisions/0003-the-prefix-is-the-demand.md
+++ b/docs/decisions/0003-the-prefix-is-the-demand.md
@@ -1,0 +1,114 @@
+# 0003 · The identifier prefix is the reference's demand
+
+**Status:** accepted, 2026-08-29. Decided by the director.
+**Issue:** [#11](https://github.com/camilochs/nexttex/issues/11)
+
+---
+
+## The gap this closes
+
+A type system needs two sides. NextTeX had one.
+
+`\figure(fig:main)` declares a `Figure` — the class is known the moment the scanner reads the entry token.
+But `@ref(fig:main)` demands nothing, so there is nothing a declaration can contradict, so nothing can be
+checked. The class was computed and discarded.
+
+In TypeScript the demand is written at the use site:
+
+```ts
+function f(x: number) { … }
+f("a")                       // error: the signature says what it wants
+```
+
+The equivalent question here is how `@ref` says what it wants.
+
+## The decision
+
+**The prefix before the first `:` is the demand.** `@ref(fig:main)` demands a `Figure`. Pointing it at a
+`\table(fig:main)` is `NT1004`.
+
+Three options were on the table. This one was chosen because it costs nothing in the corpus it has to work
+on, and because the syntax was already frozen — it adds no new form.
+
+| Option | |
+|---|---|
+| **The prefix is the demand** | chosen |
+| `@ref:figure(x)` states it explicitly | rejected: more to write, and it changes frozen syntax |
+| No demand; the class only powers hover and rename | rejected: leaves the check that motivated the type system unbuilt |
+
+## What made it free
+
+Every `\label` in the author's corpus, 1,374 of them:
+
+| Prefix | Count | Class |
+|---|---|---|
+| `sec` | 463 | Section |
+| `fig` | 413 | Figure |
+| `tab` | 277 | Table |
+| `app` | 101 | Appendix |
+| *(no prefix)* | 30 | — |
+| `alg` | 25 | Algorithm |
+| `subsec` | 24 | Section |
+| `appendix` | 12 | Appendix |
+| `ssec` | 11 | Section |
+| `cap`, `eq` | 4 each | Section, Equation |
+| `def` | 3 | `?O` — no admitted class |
+| `chap`, `lst` | 2 each | Section, `?O` |
+| `subsubsec`, `algo` | 1 each | Section, Algorithm |
+
+**Only 30 of 1,374 carry no prefix at all**, and within a typed environment the prefix matches the
+environment essentially always: `fig:` on 413 of 417 labelled figures, `tab:` on 272 of 276 tables, `alg:` on
+25 of 26 algorithms.
+
+The convention is already there. This decision reads it rather than imposing it.
+
+## The default map, and why it is configurable
+
+```toml
+[prefixes]
+figure    = ["fig"]
+table     = ["tab"]
+section   = ["sec", "subsec", "subsubsec", "ssec", "chap", "cap"]
+appendix  = ["app", "appendix"]
+algorithm = ["alg", "algo"]
+equation  = ["eq"]
+```
+
+The corpus is why `section` has six spellings and `appendix` two. One author writes `subsec:`, `ssec:` and
+`sec:` for the same class in one project. A map with a single spelling per class would report a type error on
+54 correct labels in this corpus alone, which is the failure mode this whole document exists to avoid.
+
+`nextex.toml` replaces the map entirely, never merges into it. An author whose convention is `figura:` writes
+their own and nothing above applies.
+
+## Where it does not fire
+
+**An unmapped prefix demands nothing.** `def:geakg` and `lst:algorithm` are not in the map, so the reference
+is `?O` and cannot fail. Adding a prefix to the map is how you opt a class into checking, and not adding one
+is a valid permanent state.
+
+**No prefix demands nothing.** The 28 unprefixed labels keep working exactly as they do today.
+
+**A target of unknown class cannot fail.** `@ref(fig:x)` pointing at an `@id` attached to a `\newtheorem`
+NextTeX does not model is `Known(Figure) ~ ?O`, which is consistent. Both sides must be known, per
+[`checking.md`](../checking.md) §3.
+
+This is the same renunciation TypeScript makes with `any`, and in a document most entities are `any`.
+
+## What it catches
+
+The failure that motivated it, and that no LaTeX tool reports:
+
+```latex
+\table(fig:results) { … }          % renamed from a figure, label kept
+As shown in Figure~\Cref{fig:results}
+```
+
+LaTeX compiles it. `\Cref` reads the counter and prints "Table 4". The prose says "Figure". The PDF is wrong
+and silent. The author uses `\Cref` 110 times across 4 projects, so this is a defect they can actually hit.
+
+## What would reverse it
+
+A corpus where the prefix convention is weak — say under 90% agreement between prefix and environment. Then
+the map produces false errors and the explicit form becomes the better trade. Re-run
+`tests/experiments/label-prefixes/` on that corpus before arguing it.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -135,6 +135,10 @@ ident        = [A-Za-z] [A-Za-z0-9_:.-]*
 bibkey       = [A-Za-z0-9] [A-Za-z0-9_:.+/-]*
 ```
 
+The prefix before the first `:` in an identifier is not decoration: it is the class the reference demands,
+per [`decisions/0003`](decisions/0003-the-prefix-is-the-demand.md). `@ref(fig:x)` requires a `Figure`. An
+unmapped prefix, or none, demands nothing.
+
 `@ref` emits the referenced label value only. The entity-kind word remains author text:
 
 ```latex

--- a/tests/experiments/label-prefixes/README.md
+++ b/tests/experiments/label-prefixes/README.md
@@ -1,0 +1,60 @@
+# Can the identifier prefix carry the type demand?
+
+Decides how `@ref` says what class it expects. If `fig:` reliably means "figure", the demand is already
+written in every document and costs nothing. If it does not, the reference has to say so explicitly and the
+frozen syntax has to change.
+
+## Run
+
+```sh
+python3 measure.py ~/Workspace
+```
+
+## Result, 2026-08-29
+
+1,374 labels across 224 `.tex` files.
+
+| Prefix | Count |
+|---|---|
+| `sec` | 463 |
+| `fig` | 413 |
+| `tab` | 277 |
+| `app` | 101 |
+| *(none)* | 30 |
+| `alg` | 25 |
+| `subsec` | 24 |
+| `appendix` | 12 |
+| `ssec` | 11 |
+| `cap`, `eq` | 4 each |
+| `def` | 3 |
+| `chap`, `lst` | 2 each |
+| `subsubsec`, `algo` | 1 each |
+
+Agreement between prefix and the environment the label sits in:
+
+| Environment | Labelled | Dominant prefix |
+|---|---|---|
+| figure | 417 | `fig` — 413 (99%) |
+| table | 276 | `tab` — 272 (99%) |
+| algorithm | 26 | `alg` — 25 (96%) |
+| equation | 3 | `eq` — 3 (100%) |
+
+Only 30 of 1,374 labels carry no prefix, and inside a typed environment the prefix agrees essentially
+always. The convention is already there to be read.
+
+**The reason the map is configurable is also in this table.** One author writes `sec:`, `subsec:`, `ssec:`,
+`subsubsec:`, `chap:` and `cap:` for the same class, and `app:` and `appendix:` for another. A map with one
+spelling per class would report a type error on 54 correct labels in this corpus alone.
+
+See [`docs/decisions/0003`](../../../docs/decisions/0003-the-prefix-is-the-demand.md).
+
+## What would reverse it
+
+Agreement under about 90% between prefix and environment. Then the map produces false errors and the
+explicit form (`@ref:figure(x)`) becomes the better trade.
+
+## Limits
+
+One author's corpus, and the strongest evidence in it comes from figures and tables. Equations are 3 labels;
+that row proves nothing on its own. A second author's corpus with a different convention is the obvious next
+measurement, and none was taken.

--- a/tests/experiments/label-prefixes/measure.py
+++ b/tests/experiments/label-prefixes/measure.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Does the `prefix:` convention hold well enough to be a type demand?
+
+Decides whether `@ref(fig:x)` can mean "this must be a figure". Two questions:
+how many labels carry a prefix at all, and how often the prefix agrees with the
+environment the label sits in.
+
+    python3 measure.py <root>
+"""
+import collections
+import os
+import re
+import sys
+
+ENV = re.compile(
+    r"\\begin\{(figure|table|algorithm|equation|align)\*?\}(.*?)\\end\{\1\*?\}", re.S
+)
+LABEL = re.compile(r"\\label\{([^}]*)\}")
+
+
+def strip_comments(text):
+    return "\n".join(re.sub(r"(?<!\\)%.*$", "", line) for line in text.split("\n"))
+
+
+def tex_files(root):
+    for base, _, names in os.walk(root):
+        for name in names:
+            if name.endswith(".tex"):
+                yield os.path.join(base, name)
+
+
+def main(root):
+    prefixes = collections.Counter()
+    inside = collections.defaultdict(collections.Counter)
+    total = 0
+
+    for path in tex_files(root):
+        with open(path, errors="replace") as handle:
+            text = strip_comments(handle.read())
+        for match in LABEL.finditer(text):
+            total += 1
+            name = match.group(1)
+            prefixes[name.split(":")[0].lower() if ":" in name else "(none)"] += 1
+        for match in ENV.finditer(text):
+            kind, body = match.group(1), match.group(2)
+            for label in LABEL.finditer(body):
+                name = label.group(1)
+                inside[kind][name.split(":")[0].lower() if ":" in name else "(none)"] += 1
+
+    print(f"{total} labels\n")
+    for prefix, count in prefixes.most_common():
+        print(f"  {prefix:16}{count:5}")
+
+    print("\nagreement between prefix and environment:")
+    for kind in sorted(inside):
+        counts = inside[kind]
+        subtotal = sum(counts.values())
+        top, best = counts.most_common(1)[0]
+        print(f"  {kind:12}{subtotal:5} labelled   {top}: {best} ({100 * best / subtotal:.0f}%)")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else ".")


### PR DESCRIPTION
Specification only. Part of #11 — the implementation follows, and Codex takes it from here.

## The gap

A type system needs two sides. NextTeX had one.

```
\figure(fig:main) { … }     declares Figure   <- the class is known
@ref(fig:main)              demands nothing   <- so nothing can contradict it
```

The class was computed by the scanner and thrown away by the symbol table, because there was no demand for it to answer.

## The decision: the prefix is the demand

`@ref(fig:main)` requires a `Figure`. Pointing it at a `\table(fig:main)` is `NT1004`.

## What made it free

1,374 labels in your corpus. **1,344 carry a prefix.**

| Environment | Labelled | Dominant prefix |
|---|---|---|
| figure | 417 | `fig` — 413 (99%) |
| table | 276 | `tab` — 272 (99%) |
| algorithm | 26 | `alg` — 25 (96%) |
| equation | 3 | `eq` — 3 (100%) |

The convention was already written in every document. This reads it rather than imposing it, and it adds no syntax to the frozen grammar.

## The same measurement is why the map is configurable

```toml
[prefixes]
figure    = ["fig"]
table     = ["tab"]
section   = ["sec", "subsec", "subsubsec", "ssec", "chap", "cap"]
appendix  = ["app", "appendix"]
algorithm = ["alg", "algo"]
equation  = ["eq"]
```

You write `sec:`, `subsec:`, `ssec:`, `subsubsec:`, `chap:` and `cap:` for one class, and `app:` and `appendix:` for another. **A map with one spelling per class would report a type error on 54 correct labels in this corpus alone** — exactly the failure the project exists to avoid. `nextex.toml` replaces the map entirely rather than merging into it.

## Where it stays silent

- **An unmapped prefix demands nothing.** `def:geakg` and `lst:x` are not in the map, so the reference is `?O`. Adding a prefix is how a class opts into checking; never adding one is a valid permanent state.
- **No prefix demands nothing.** The 30 unprefixed labels are unaffected.
- **Both sides must be known.** `@ref(fig:x)` against an `@id` on an unmodelled `\newtheorem` is `Known ~ ?O`, consistent, silent.

## What it catches

```latex
\table(fig:results) { … }              % renamed from a figure, label kept
As shown in Figure~\Cref{fig:results}
```

LaTeX compiles it. `\Cref` reads the counter and prints "Table 4". The prose says "Figure". Wrong PDF, no warning, no tool reports it. You use `\Cref` 110 times across 4 projects.

## Reproduce and reverse

`python3 tests/experiments/label-prefixes/measure.py <root>`. It would be reversed by agreement under about 90%, at which point the map produces false errors and `@ref:figure(x)` becomes the better trade.

Limits stated in the experiment: one author's corpus, and the equation row is 3 labels and proves nothing on its own.