### PR TITLE
Build the prefix map from the documented convention, not from one corpus

### DIFF
--- a/docs/checking.md
+++ b/docs/checking.md
@@ -68,16 +68,19 @@ The reference supplies the other, and **it does so through the prefix before the
 [prefixes]
 figure    = ["fig"]
 table     = ["tab"]
-section   = ["sec", "subsec", "subsubsec", "ssec", "chap", "cap"]
-appendix  = ["app", "appendix"]
-algorithm = ["alg", "algo"]
+section   = ["sec", "subsec", "ch"]
+appendix  = ["app"]
+algorithm = ["alg"]
 equation  = ["eq"]
 ```
 
-The convention was read from documents rather than imposed on them: 1,344 of 1,374 measured labels carry a
-prefix, and inside a typed environment it agrees with the environment 96–100% of the time. The several
-spellings per class are in the map for the same reason — one author writes `sec:`, `subsec:` and `ssec:` for
-one class, and a single-spelling map would fail 54 correct labels in that corpus.
+Those are the prefixes the published convention names — the LaTeX2e reference manual and the Wikibooks
+LaTeX book, which agree. LaTeX has no specification for label names; this is the documented common practice,
+transcribed rather than invented or inferred from a sample.
+
+The map is replaceable because real documents add spellings the documentation does not name. One measured
+corpus uses six of them (`appendix`, `ssec`, `subsubsec`, `cap`, `algo`, `def`) across 55 labels, and a
+fixed map would have called every one a type error.
 
 Two ways the demand is absent, and both are silence rather than error:
 

--- a/docs/decisions/0003-the-prefix-is-the-demand.md
+++ b/docs/decisions/0003-the-prefix-is-the-demand.md
@@ -36,50 +36,56 @@ on, and because the syntax was already frozen — it adds no new form.
 | `@ref:figure(x)` states it explicitly | rejected: more to write, and it changes frozen syntax |
 | No demand; the class only powers hover and rename | rejected: leaves the check that motivated the type system unbuilt |
 
-## What made it free
+## Where the default map comes from
 
-Every `\label` in the author's corpus, 1,374 of them:
+**From the published convention, not from a corpus.** LaTeX has no specification for label names, but the
+convention is documented, and two sources agree. Both transcribed on 2026-08-29:
 
-| Prefix | Count | Class |
-|---|---|---|
-| `sec` | 463 | Section |
-| `fig` | 413 | Figure |
-| `tab` | 277 | Table |
-| `app` | 101 | Appendix |
-| *(no prefix)* | 30 | — |
-| `alg` | 25 | Algorithm |
-| `subsec` | 24 | Section |
-| `appendix` | 12 | Appendix |
-| `ssec` | 11 | Section |
-| `cap`, `eq` | 4 each | Section, Equation |
-| `def` | 3 | `?O` — no admitted class |
-| `chap`, `lst` | 2 each | Section, `?O` |
-| `subsubsec`, `algo` | 1 each | Section, Algorithm |
+| Source | Prefixes it names |
+|---|---|
+| [LaTeX2e unofficial reference manual](https://latexref.xyz/_005clabel.html) | `ch`, `sec`, `fig`, `tab`, `eq` |
+| [Wikibooks, *LaTeX/Labels and Cross-referencing*](https://en.wikibooks.org/wiki/LaTeX/Labels_and_Cross-referencing) | those five, plus `subsec`, `lst`, `itm`, `alg`, `app` |
 
-**Only 30 of 1,374 carry no prefix at all**, and within a typed environment the prefix matches the
-environment essentially always: `fig:` on 413 of 417 labelled figures, `tab:` on 272 of 276 tables, `alg:` on
-25 of 26 algorithms.
+The reference manual: *"A common convention is to use key names consisting of a prefix and a suffix
+separated by a colon or period."* Wikibooks: *"It is common practice among LaTeX users to add a few letters
+to the label to describe what you are referencing"*, and *"You are not obligated to use these prefixes."*
 
-The convention is already there. This decision reads it rather than imposing it.
-
-## The default map, and why it is configurable
+So the default map is:
 
 ```toml
 [prefixes]
 figure    = ["fig"]
 table     = ["tab"]
-section   = ["sec", "subsec", "subsubsec", "ssec", "chap", "cap"]
-appendix  = ["app", "appendix"]
-algorithm = ["alg", "algo"]
+section   = ["sec", "subsec", "ch"]
+appendix  = ["app"]
+algorithm = ["alg"]
 equation  = ["eq"]
 ```
 
-The corpus is why `section` has six spellings and `appendix` two. One author writes `subsec:`, `ssec:` and
-`sec:` for the same class in one project. A map with a single spelling per class would report a type error on
-54 correct labels in this corpus alone, which is the failure mode this whole document exists to avoid.
+`lst` and `itm` are documented but have no admitted entity class, so they stay unmapped and demand nothing.
 
-`nextex.toml` replaces the map entirely, never merges into it. An author whose convention is `figura:` writes
-their own and nothing above applies.
+## What the corpus is used for, and what it is not
+
+One author's corpus cannot show that a convention is universal. It can show that something occurs, and that
+is the only claim made from it here.
+
+Measured across 1,374 labels in that corpus: the documented prefixes are used, and **so are six spellings
+the documentation does not name** — `appendix`, `ssec`, `subsubsec`, `cap`, `algo`, `def`. Together they
+account for 55 labels.
+
+That is an existence proof and it settles one thing only: **the map has to be replaceable.** A fixed map
+built from the published convention would report a type error on those 55 correct labels, in the first real
+project it met.
+
+It settles nothing about how common the convention is. `tests/experiments/label-prefixes/` says the same in
+its limits section.
+
+### An earlier version of this record over-claimed
+
+It said the decision "costs nothing in the corpus it has to work on" and that the convention is "already
+there", citing agreement rates from that one corpus as though they measured LaTeX practice. They measured
+one author's habit. The decision stands, but it stands on the documented convention above and on the
+fallback in the next section, not on that sample.
 
 ## Where it does not fire
 
@@ -109,6 +115,11 @@ and silent. The author uses `\Cref` 110 times across 4 projects, so this is a de
 
 ## What would reverse it
 
-A corpus where the prefix convention is weak — say under 90% agreement between prefix and environment. Then
-the map produces false errors and the explicit form becomes the better trade. Re-run
-`tests/experiments/label-prefixes/` on that corpus before arguing it.
+Evidence that the published convention is not followed widely enough for an unmapped prefix to be the rare
+case — say under 90% agreement between prefix and environment across many authors. Then most references
+would demand nothing, the check would rarely fire, and the explicit form would be worth its verbosity after
+all.
+
+That evidence does not exist yet in either direction. `tests/experiments/label-prefixes/` runs on any
+corpus; pointing it at a broad sample of published sources is the measurement that would settle it, and it
+has not been taken.

--- a/tests/experiments/label-prefixes/README.md
+++ b/tests/experiments/label-prefixes/README.md
@@ -1,8 +1,16 @@
-# Can the identifier prefix carry the type demand?
+# Which label prefixes does a real project actually use?
 
-Decides how `@ref` says what class it expects. If `fig:` reliably means "figure", the demand is already
-written in every document and costs nothing. If it does not, the reference has to say so explicitly and the
-frozen syntax has to change.
+**This experiment does not decide whether the prefix convention exists.** That question is answered by
+documentation, not by sampling: the [LaTeX2e reference manual](https://latexref.xyz/_005clabel.html) and the
+[Wikibooks LaTeX book](https://en.wikibooks.org/wiki/LaTeX/Labels_and_Cross-referencing) both document it,
+and between them they name `ch`, `sec`, `subsec`, `fig`, `tab`, `eq`, `lst`, `itm`, `alg` and `app`. That is
+where the default map in `docs/decisions/0003` comes from.
+
+What this measures is narrower and is the thing documentation cannot tell you: **which spellings a real
+project adds beyond the documented set.** One corpus is enough for that, because the claim is an existence
+proof — if a real project writes `ssec:`, then a fixed map would fail it, and the map has to be replaceable.
+
+It is not enough for any claim about how common the convention is, and none is made here.
 
 ## Run
 
@@ -48,13 +56,18 @@ spelling per class would report a type error on 54 correct labels in this corpus
 
 See [`docs/decisions/0003`](../../../docs/decisions/0003-the-prefix-is-the-demand.md).
 
-## What would reverse it
+## Limits, and they are the point
 
-Agreement under about 90% between prefix and environment. Then the map produces false errors and the
-explicit form (`@ref:figure(x)`) becomes the better trade.
+**One author's corpus.** These numbers are that author's habit. They are not a measurement of LaTeX
+practice and must never be quoted as one — an earlier version of `decisions/0003` did exactly that and was
+corrected.
 
-## Limits
+Within the corpus, the strongest evidence comes from figures and tables. Equations are 3 labels; that row
+proves nothing on its own.
 
-One author's corpus, and the strongest evidence in it comes from figures and tables. Equations are 3 labels;
-that row proves nothing on its own. A second author's corpus with a different convention is the obvious next
-measurement, and none was taken.
+## The measurement that has not been taken
+
+Point this script at a broad sample of published LaTeX sources — arXiv distributes them — across areas and
+authors. That would say how often an unmapped prefix is the rare case, which is the only thing that could
+reverse the decision. Nobody has run it, and until someone does, "the convention is widespread" is not a
+claim this repository makes.


### PR DESCRIPTION
Corrects `decisions/0003`, which I argued badly.

## What was wrong

The default prefix map was derived from measurements of **your** corpus, and the record argued from agreement rates in it — "1,344 of 1,374 labels carry a prefix", "the convention is already there", "it costs nothing" — as though those measured LaTeX practice.

They measured one author's habit. Sampling one corpus cannot establish that a convention is widespread, and the record claimed it did.

## What the sources actually say

LaTeX has no specification for label names. But the convention **is** documented, and two sources agree. Both transcribed today:

| Source | Prefixes named |
|---|---|
| [LaTeX2e unofficial reference manual](https://latexref.xyz/_005clabel.html) | `ch`, `sec`, `fig`, `tab`, `eq` |
| [Wikibooks, *LaTeX/Labels and Cross-referencing*](https://en.wikibooks.org/wiki/LaTeX/Labels_and_Cross-referencing) | those five, plus `subsec`, `lst`, `itm`, `alg`, `app` |

> "A common convention is to use key names consisting of a prefix and a suffix separated by a colon or period." — reference manual

> "It is common practice among LaTeX users to add a few letters to the label to describe *what* you are referencing." … "You are not obligated to use these prefixes." — Wikibooks

The default map is now those and nothing else:

```toml
[prefixes]
figure    = ["fig"]
table     = ["tab"]
section   = ["sec", "subsec", "ch"]
appendix  = ["app"]
algorithm = ["alg"]
equation  = ["eq"]
```

`lst` and `itm` are documented but have no admitted entity class, so they stay unmapped and demand nothing.

## What the corpus is still for

A corpus cannot show a convention is universal. It **can** show that something occurs, and that is now the only claim made from it.

Your corpus writes six spellings the documentation does not name — `appendix`, `ssec`, `subsubsec`, `cap`, `algo`, `def` — across 55 labels. That is an existence proof, and it settles exactly one thing: **the map has to be replaceable.** A fixed map built from the documentation would have called all 55 a type error in the first real project it met.

It settles nothing about how common the convention is, and the record and the experiment both now say so.

## The measurement nobody has taken

Point `tests/experiments/label-prefixes/measure.py` at a broad sample of published LaTeX sources — arXiv distributes them — across areas and authors. That is the only thing that could reverse the decision, and it has not been run. Until it is, "the convention is widespread" is not a claim this repository makes.

The decision itself stands. It stands on the documented convention and on the fallback — an unmapped prefix demands nothing, so an author with their own scheme gets silence rather than errors — not on the sample.