### PR TITLE
A citation construct is a LaTeX citation command written with @

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ them interoperate. NextTeX puts the model in the format.
 \section{Introduction} @id(sec:intro)
 
 We argue the opposite in @ref(sec:model).
-@cite(knuth1984, style=textual) showed that cost grows with $n$.
+@citet(knuth1984) showed that cost grows with $n$.
 
 The architecture is shown in @ref(fig:runtime).
 

--- a/crates/nextex-core/src/scanner.rs
+++ b/crates/nextex-core/src/scanner.rs
@@ -161,6 +161,18 @@ const AT_TOKENS: &[EntryToken] = &[
     EntryToken::Id,
 ];
 
+/// The citation commands a construct may name, longest first.
+///
+/// A citation construct is a LaTeX citation command written with `@`, so this
+/// is a list of real command names rather than a vocabulary of our own. The
+/// kernel provides `cite`; `natbib` provides `citep` and `citet`; `biblatex`
+/// provides `textcite` and `parencite`. `docs/grammar.md` §4.
+///
+/// All five map to one [`EntryToken::Cite`]. Which command was written is in
+/// the construct's own bytes, and the emitter reads it there — a variant per
+/// command would put the same information in two places.
+pub const DEFAULT_CITE_COMMANDS: &[&str] = &["parencite", "textcite", "citep", "citet", "cite"];
+
 /// Splits a source into text and constructs.
 ///
 /// The result covers every byte exactly once and in order, so concatenating the
@@ -522,6 +534,12 @@ fn entry_token_at(bytes: &[u8], at: usize) -> Option<(EntryToken, usize)> {
             let end = at + keyword.len();
             if bytes[at..].starts_with(keyword) && bytes.get(end) == Some(&b'(') {
                 return Some((*token, end + 1));
+            }
+        }
+        for command in DEFAULT_CITE_COMMANDS {
+            let end = at + 1 + command.len();
+            if bytes[at + 1..].starts_with(command.as_bytes()) && bytes.get(end) == Some(&b'(') {
+                return Some((EntryToken::Cite, end + 1));
             }
         }
         return None;

--- a/crates/nextex-core/src/symbols.rs
+++ b/crates/nextex-core/src/symbols.rs
@@ -105,12 +105,30 @@ impl SymbolTable {
             let Some(payload) = payload_of(sources, node.source(), construct, kind) else {
                 continue;
             };
-            let Some(text) = text_of(sources, payload) else {
-                continue;
-            };
-
             match kind {
+                EntryToken::Cite => {
+                    // One reference per key, so an absent key is a diagnostic
+                    // naming that key rather than the whole construct.
+                    let keys = keys_of(sources, payload);
+                    if keys.is_empty() {
+                        self.errors.push(SymbolError::Malformed { construct });
+                        continue;
+                    }
+                    for key in keys {
+                        self.references.push((
+                            key,
+                            Reference {
+                                kind,
+                                payload,
+                                construct,
+                            },
+                        ));
+                    }
+                }
                 EntryToken::Id | EntryToken::Figure | EntryToken::Table => {
+                    let Some(text) = text_of(sources, payload) else {
+                        continue;
+                    };
                     if !is_identifier(text.as_bytes()) {
                         self.errors.push(SymbolError::Malformed { construct });
                         continue;
@@ -126,7 +144,10 @@ impl SymbolTable {
                     self.declarations
                         .insert(text, Declaration { payload, construct });
                 }
-                EntryToken::Ref | EntryToken::Cite => {
+                EntryToken::Ref => {
+                    let Some(text) = text_of(sources, payload) else {
+                        continue;
+                    };
                     if text.is_empty() {
                         self.errors.push(SymbolError::Malformed { construct });
                         continue;
@@ -191,10 +212,27 @@ fn payload_of(
     construct: Span,
     kind: EntryToken,
 ) -> Option<Payload> {
+    // A citation names its own command, so its keyword is not fixed: the
+    // payload starts after the construct's first `(`.
+    if kind == EntryToken::Cite {
+        let bytes = sources.get(source)?.slice(construct)?;
+        if !bytes.ends_with(b")") {
+            return None;
+        }
+        let open = construct.start() + bytes.iter().position(|b| *b == b'(')? + 1;
+        let end = construct.end() - 1;
+        if open > end {
+            return None;
+        }
+        return Some(Payload {
+            source,
+            span: Span::new(u32::try_from(open).ok()?, u32::try_from(end).ok()?),
+        });
+    }
+
     let keyword = match kind {
         EntryToken::Id => "@id(",
         EntryToken::Ref => "@ref(",
-        EntryToken::Cite => "@cite(",
         EntryToken::Import => "@import(",
         // A block declares its identifier just as `@id` does: the name between
         // its parentheses is what a reference resolves to.
@@ -231,20 +269,41 @@ fn payload_of(
 /// is not an identifier and is reported rather than lossily converted.
 fn text_of(sources: &Sources, payload: Payload) -> Option<String> {
     let bytes = sources.get(payload.source)?.slice(payload.span)?;
-    // A citation key may carry a comma and fields after it; the key is what
-    // precedes the first comma.
-    let key = bytes.split(|b| *b == b',').next().unwrap_or(bytes);
-    let trimmed = key
+    std::str::from_utf8(trim(bytes)).ok().map(str::to_owned)
+}
+
+/// Every comma-separated key in a citation payload.
+///
+/// `\cite{a,b}` is ordinary LaTeX and 13% of measured citations use it, one of
+/// them with seven keys. Reading only the first would leave the rest unchecked
+/// while reporting success, which is worse than not checking at all.
+fn keys_of(sources: &Sources, payload: Payload) -> Vec<String> {
+    let Some(bytes) = sources
+        .get(payload.source)
+        .and_then(|s| s.slice(payload.span))
+    else {
+        return Vec::new();
+    };
+    bytes
+        .split(|b| *b == b',')
+        .filter_map(|key| std::str::from_utf8(trim(key)).ok())
+        .filter(|key| !key.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// `bytes` without leading or trailing ASCII whitespace.
+fn trim(bytes: &[u8]) -> &[u8] {
+    bytes
         .iter()
         .position(|b| !b.is_ascii_whitespace())
         .map_or(&[][..], |start| {
-            let end = key
+            let end = bytes
                 .iter()
                 .rposition(|b| !b.is_ascii_whitespace())
                 .unwrap_or(start);
-            &key[start..=end]
-        });
-    std::str::from_utf8(trimmed).ok().map(str::to_owned)
+            &bytes[start..=end]
+        })
 }
 
 fn is_identifier(bytes: &[u8]) -> bool {
@@ -332,11 +391,28 @@ mod tests {
     }
 
     #[test]
-    fn a_citation_key_stops_at_its_first_field() {
-        let (_, t) = table(&[("a.ntex", "@cite(knuth1984, style=textual)")]);
+    fn a_citation_may_name_several_keys() {
+        // Replaces a test that asserted the key stopped at the first comma,
+        // because a `style` field followed it. The grammar no longer has
+        // fields: `\\cite{a,b}` is ordinary LaTeX, 13% of measured citations
+        // use it, and one names seven keys. Reading only the first would leave
+        // the rest unchecked while reporting success.
+        let (_, t) = table(&[("a.ntex", "@citep(knuth1984, lamport1994)")]);
         assert_eq!(
             t.citations().map(|(n, _)| n).collect::<Vec<_>>(),
-            ["knuth1984"]
+            ["knuth1984", "lamport1994"]
+        );
+    }
+
+    #[test]
+    fn every_citation_command_is_a_construct() {
+        let (_, t) = table(&[(
+            "a.ntex",
+            "@cite(a) @citep(b) @citet(c) @textcite(d) @parencite(e)",
+        )]);
+        assert_eq!(
+            t.citations().map(|(n, _)| n).collect::<Vec<_>>(),
+            ["a", "b", "c", "d", "e"]
         );
     }
 

--- a/crates/nextex-core/tests/fixtures.rs
+++ b/crates/nextex-core/tests/fixtures.rs
@@ -278,6 +278,7 @@ fn ordinary_latex_yields_no_constructs() {
         br"\newcommand{\ref}[1]{see #1} % a package redefining \ref",
         br"\makeatletter \@ifpackageloaded{amsmath}{}{} \makeatother",
         br"An email @ the start of a line, and a lone @ mid-sentence.",
+        br"We cite with \citep{k} and mention citep and @citep without a paren.",
         br"\definecolor[named]{@id(a)}{rgb}{1,0,0} % xcolor form",
         br"latex, plain prose about the word, with no brace after it.",
     ];

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -76,8 +76,11 @@ at-entry        = "@" at-keyword "("
 block-entry     = "\" block-keyword "("
 raw-entry       = "latex" ws* "{"
 
-at-keyword      = "id" | "ref" | "cite" | "import"
+at-keyword      = "id" | "ref" | "import"
+                | cite-command
                 | "add" | "del" | "sub" | "note"
+
+cite-command    = "cite" | "citep" | "citet" | "textcite" | "parencite"
 
 block-keyword   = "figure" | "table"
 ```
@@ -126,10 +129,10 @@ at-construct = id-decl | reference | citation | import
 
 id-decl      = "@id"     "(" ident ")"
 reference    = "@ref"    "(" ident ")"
-citation     = "@cite"   "(" bibkey citation-field* ")"
+citation     = "@" cite-command "(" bibkey ( "," ws* bibkey )* ")"
 import       = "@import" "(" string ")"
 
-citation-field = "," ws* field
+cite-command = "cite" | "citep" | "citet" | "textcite" | "parencite"
 
 ident        = [A-Za-z] [A-Za-z0-9_:.-]*
 bibkey       = [A-Za-z0-9] [A-Za-z0-9_:.+/-]*
@@ -151,12 +154,61 @@ NextTeX does not generate `Definition`, `Table`, `Section`, `Appendix`, or a non
 them would inject bytes absent from the source and would violate the binding erasure rule. v0.1 makes no
 exception to that rule.
 
-`@cite` accepts named fields so that a rendering distinction is not carried by a single character:
+### Citations
 
-```latex
-@cite(knuth1984)
-@cite(knuth1984, style=textual)
+**A citation construct is a LaTeX citation command written with `@`.** That is the whole rule, and it is
+the same one `@ref` follows: NextTeX emits the command you named and knows nothing about the package that
+defines it.
+
 ```
+@cite(knuth1984)        emits  \cite{knuth1984}
+@citep(knuth1984)       emits  \citep{knuth1984}
+@citet(knuth1984)       emits  \citet{knuth1984}
+@textcite(knuth1984)    emits  \textcite{knuth1984}
+@parencite(knuth1984)   emits  \parencite{knuth1984}
+```
+
+A citation may name several keys, because 13% of measured citations do and one names seven:
+
+```
+@citep(knuth1984, lamport1994)   emits  \citep{knuth1984,lamport1994}
+```
+
+**Each key is checked separately.** One absent key is one diagnostic naming that key, not a diagnostic about
+the construct.
+
+Nothing else is emitted — no brackets, no `~`, no package. Checking the keys against the bibliography under
+[`checking.md`](checking.md) §7 is the only thing the construct buys over writing the command directly.
+
+The default set covers the LaTeX kernel (`\cite`), `natbib` (`\citep`, `\citet`) and `biblatex`
+(`\textcite`, `\parencite`). A project using another command adds it in `nextex.toml`:
+
+```toml
+cite_commands = ["cite", "citep", "citet", "citealp"]
+```
+
+The list replaces the default rather than extending it, like every other map here.
+
+#### Why a construct per command, and not one construct with a style field
+
+A figure is one environment whose variants are fields, so `\figure` takes `src`, `width` and `caption`. A
+citation is not one command with options: `\citep` and `\citet` are different commands producing different
+output. Modelling them as one construct means inventing a vocabulary for the difference — `style=textual` —
+and then mapping that vocabulary back onto a command, which cannot be done without knowing which package the
+document loads. That is not knowable: `\usepackage` is absent in 17–50% of real projects that use a package,
+because a class loads it (`tests/experiments/package-loading/`).
+
+Naming the command directly removes the question. It also removes the vocabulary: an author who writes
+`\citep` already knows what `@citep` is.
+
+The earlier draft admitted `@cite(key, style=textual)` and never said what it emitted. Settled by the
+director on 2026-08-29.
+
+#### Migrating an existing project
+
+Mechanical, and partial by design. Change `\citep{` to `@citep(` wherever you want the key checked. Every
+citation you do not touch keeps working exactly as it does now, transported byte for byte and unchecked —
+which is the same trade every other construct offers.
 
 ### `@id` attachment
 

--- a/tests/fixtures/inline/09-citation-commands/expect.txt
+++ b/tests/fixtures/inline/09-citation-commands/expect.txt
@@ -1,0 +1,5 @@
+transport: identical
+scanner: cite cite cite cite cite
+constructs: five citations — one per command. All five map to one entry-token
+  kind; which command was written stays in the construct's own bytes, where the
+  emitter reads it.

--- a/tests/fixtures/inline/09-citation-commands/input.ntex
+++ b/tests/fixtures/inline/09-citation-commands/input.ntex
@@ -1,0 +1,3 @@
+Plain @cite(knuth1984), natbib @citep(a) and @citet(b),
+biblatex @textcite(c) and @parencite(d).
+Ordinary \citep{e} and the word citep in prose are untouched.

--- a/tests/fixtures/inline/10-several-citation-keys/expect.txt
+++ b/tests/fixtures/inline/10-several-citation-keys/expect.txt
@@ -1,0 +1,5 @@
+transport: identical
+scanner: cite cite
+constructs: two citations carrying four keys. 13% of measured citations name
+  more than one and one names seven, so each key is checked separately and an
+  absent key names itself rather than the construct.

--- a/tests/fixtures/inline/10-several-citation-keys/input.ntex
+++ b/tests/fixtures/inline/10-several-citation-keys/input.ntex
@@ -1,0 +1,1 @@
+@citep(knuth1984, lamport1994, dijkstra1968) and @cite(single).


### PR DESCRIPTION
Settles the open decision that blocked #13. The emitter itself follows.

## The question

The grammar said what `@ref` and `@id` emit and never said what `@cite` emits. The draft admitted `@cite(key, style=textual)`, and `textual` had no answer:

| | natbib | biblatex |
|---|---|---|
| Knuth (1984) | `\citet` | `\textcite` |
| (Knuth, 1984) | `\citep` | `\parencite` |
| [12] | `\cite` | `\cite` |

Emitting `style=textual` means knowing which package the document loads. It cannot: `\usepackage` is absent in 17–50% of real projects that use a package, because a class loads it (`tests/experiments/package-loading/`).

## The decision: remove the question

```
@cite(k)        emits  \cite{k}
@citep(k)       emits  \citep{k}
@citet(k)       emits  \citet{k}
@textcite(k)    emits  \textcite{k}
@parencite(k)   emits  \parencite{k}
```

No style vocabulary, no config, no package inference. NextTeX emits the command you named and knows nothing about who defines it — exactly as `@ref` emits `\ref` without knowing about cleveref.

Someone who writes `\citep` already knows what `@citep` is. That is the whole argument for it over a vocabulary of ours: `textual` is a word I invented and nobody has seen.

**Why not one construct with fields, like `\figure`?** A figure is one environment whose variants *are* fields. A citation is not one command with options — `\citep` and `\citet` are different commands producing different output. Modelling them as one construct is what forced the invented vocabulary.

## Several keys

13% of measured citations name more than one, and one names seven.

```
@citep(knuth1984, lamport1994)   emits  \citep{knuth1984,lamport1994}
```

Each key is checked separately, so an absent key is a diagnostic naming *that key*, not the construct.

## A test was replaced, and here is why

`a_citation_key_stops_at_its_first_field` asserted the payload ended at the first comma. That was true only because a `style` field could follow it. **The grammar no longer has fields, so the rule the test asserted no longer exists** — and keeping it would have meant reading one key of seven while reporting success, which is the failure mode `checking.md` exists to prevent.

Replaced by `a_citation_may_name_several_keys` and `every_citation_command_is_a_construct`, with the reason in the test's own comment.

## Working end to end

```
$ nextex symbols cites.ntex
  citations            ["knuth1984", "lamport1994", "knuth1984", "knuth1984",
                        "lamport1994", "knuth1984", "lamport1994", "invented2026"]
  bibliography         2 keys
  missing citations    ["invented2026"]
```

The `\citep{alsoInvented}` on the last line of that document is plain LaTeX and correctly says nothing.

## Implementation note

All five map to one `EntryToken::Cite`. Which command was written stays in the construct's own bytes and the emitter reads it there — a variant per command would put the same fact in two places.

## Migration

Mechanical and partial by design. Change `\citep{` to `@citep(` where you want the key checked; every citation you leave alone keeps working, transported byte for byte and unchecked.

## Checks

93 tests pass, clippy clean, transport byte-identical at every truncation. Two new fixtures, and the negative corpus gains a line covering `\citep{k}`, the bare word `citep`, and `@citep` without a paren.