### PR TITLE
Emit LaTeX instead of copying it

### DIFF
--- a/crates/nextex-cli/src/main.rs
+++ b/crates/nextex-cli/src/main.rs
@@ -4,13 +4,16 @@
 //! and process exit codes. `nextex-core` has none of them, which is what lets
 //! the same core compile to WebAssembly.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
+use nextex_core::document::Node;
 use nextex_core::io::{IoError, OutputSink, SourceLoader};
+use nextex_core::scanner::EntryToken;
 use nextex_core::source::{SourceId, Sources};
-use nextex_core::transport;
+use nextex_core::{BuildError, emit, parse};
 
 /// Largest source the CLI will read, in bytes.
 ///
@@ -98,8 +101,7 @@ fn main() -> ExitCode {
     let Some(input) = args.next() else {
         eprintln!("usage: nextex <file.ntex>");
         eprintln!();
-        eprintln!("Reads the file and writes it to build/, unchanged.");
-        eprintln!("There is no parser yet: this is the transport half only.");
+        eprintln!("Emits the file and its imports as LaTeX under build/.");
         return ExitCode::from(2);
     };
 
@@ -110,9 +112,11 @@ fn main() -> ExitCode {
         root: PathBuf::from("build"),
     };
 
-    match transport(&input, &loader, &mut sink) {
+    match build(&input, &loader, &mut sink) {
         Ok(()) => {
-            println!("build/{input}");
+            let mut output = PathBuf::from(&input);
+            output.set_extension("tex");
+            println!("build/{}", output.display());
             ExitCode::SUCCESS
         }
         Err(error) => {
@@ -120,4 +124,50 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+fn build(root: &str, loader: &FileSystem, sink: &mut BuildDirectory) -> Result<(), BuildError> {
+    let mut pending = vec![root.to_owned()];
+    let mut emitted = BTreeSet::new();
+
+    while let Some(name) = pending.pop() {
+        if !emitted.insert(name.clone()) {
+            continue;
+        }
+        let mut sources = Sources::new();
+        let id = loader.load(&name, None, &mut sources)?;
+        let document = parse(&sources, id);
+        let source = sources
+            .get(id)
+            .expect("the loader returned an absent source");
+
+        for node in document.iter() {
+            if let Node::Construct {
+                kind: EntryToken::Import,
+                span,
+                ..
+            } = node
+            {
+                let bytes = source.slice(*span).expect("a parsed span left its source");
+                let first = bytes.iter().position(|byte| *byte == b'"').unwrap_or(0);
+                let last = bytes
+                    .iter()
+                    .rposition(|byte| *byte == b'"')
+                    .unwrap_or(first);
+                let import = String::from_utf8_lossy(&bytes[first + 1..last]);
+                let relative = Path::new(&name).parent().map_or_else(
+                    || PathBuf::from(import.as_ref()),
+                    |dir| dir.join(import.as_ref()),
+                );
+                pending.push(relative.to_string_lossy().into_owned());
+            }
+        }
+
+        let mut bytes = Vec::new();
+        emit(&sources, &document, &mut bytes)?;
+        let mut output = PathBuf::from(source.name());
+        output.set_extension("tex");
+        sink.write(&output.to_string_lossy(), &bytes)?;
+    }
+    Ok(())
 }

--- a/crates/nextex-core/src/blocks.rs
+++ b/crates/nextex-core/src/blocks.rs
@@ -38,7 +38,10 @@ impl BlockKind {
     const fn value_kind(self, key: &[u8]) -> Option<ValueKind> {
         match (self, key) {
             (Self::Figure, b"src") => Some(ValueKind::Str),
-            (Self::Figure, b"width") => Some(ValueKind::LengthOrPercentage),
+            // A percentage takes the reference its field fixes at emission —
+            // width against \linewidth, height against \textheight. Here they
+            // only have to be the same kind of value. See docs/decisions/0004.
+            (Self::Figure, b"width" | b"height") => Some(ValueKind::LengthOrPercentage),
             (Self::Figure | Self::Table, b"caption") | (Self::Table, b"body" | b"trailing") => {
                 Some(ValueKind::Braced)
             }

--- a/crates/nextex-core/src/blocks.rs
+++ b/crates/nextex-core/src/blocks.rs
@@ -259,7 +259,9 @@ fn removed_field(key: &[u8]) -> RemovedField {
 const fn describe(kind: ValueKind) -> &'static str {
     match kind {
         ValueKind::Str => "a quoted string",
-        ValueKind::LengthOrPercentage => "a length such as 4cm, or a percentage such as 80%",
+        ValueKind::LengthOrPercentage => {
+            "a length such as 4cm or 0.8\\columnwidth, or a percentage such as 80%"
+        }
         ValueKind::Braced => "a braced group, because it may span lines and contain LaTeX",
     }
 }
@@ -291,15 +293,30 @@ fn read_value(
             while i < limit && (bytes[i].is_ascii_digit() || bytes[i] == b'.') {
                 i += 1;
             }
-            if i == at {
-                return None;
+            let has_number = i > at;
+            if has_number {
+                if bytes.get(i) == Some(&b'%') {
+                    return Some((Value::Percentage(span(at, i + 1)), i + 1));
+                }
+                for unit in [b"pt", b"mm", b"cm", b"in", b"em", b"ex"] {
+                    if bytes[i..].starts_with(unit) {
+                        return Some((Value::Length(span(at, i + 2)), i + 2));
+                    }
+                }
             }
-            if bytes.get(i) == Some(&b'%') {
-                return Some((Value::Percentage(span(at, i + 1)), i + 1));
-            }
-            for unit in [b"pt", b"mm", b"cm", b"in", b"em", b"ex"] {
-                if bytes[i..].starts_with(unit) {
-                    return Some((Value::Length(span(at, i + 2)), i + 2));
+            // A TeX length, with or without a coefficient: `0.8\\columnwidth`,
+            // `\\linewidth`. The percentage form covers the common case against
+            // a reference the field fixes; this is how an author names a
+            // different one without a new keyword. See docs/decisions/0004.
+            if bytes.get(i) == Some(&b'\\') {
+                let name_start = i + 1;
+                let mut end = name_start;
+                while end < limit && bytes[end].is_ascii_alphabetic() {
+                    end += 1;
+                }
+                // A control word taking an argument is a command, not a length.
+                if end > name_start && bytes.get(end) != Some(&b'{') {
+                    return Some((Value::Length(span(at, end)), end));
                 }
             }
             None

--- a/crates/nextex-core/src/document.rs
+++ b/crates/nextex-core/src/document.rs
@@ -78,9 +78,7 @@ pub enum Node {
     },
     /// A recognised NextTeX construct.
     ///
-    /// Its bytes are still emitted from the span for now. Lowering each kind to
-    /// its LaTeX form is the emitter's next job; until then a construct
-    /// transports like anything else, so recognising one cannot change output.
+    /// Its source span contains the values used when lowering it to LaTeX.
     Construct {
         /// Source this construct came from.
         source: SourceId,

--- a/crates/nextex-core/src/lib.rs
+++ b/crates/nextex-core/src/lib.rs
@@ -54,9 +54,10 @@ pub mod symbols;
 use std::error::Error;
 use std::fmt;
 
+use blocks::{BlockKind, Value, parse_block};
 use document::{Document, Node, ParseConfidence};
 use io::{IoError, OutputSink, SourceLoader};
-use scanner::Piece;
+use scanner::{EntryToken, Piece};
 use source::{SourceId, Sources};
 
 /// A node referred to a source range that is not there.
@@ -127,11 +128,11 @@ pub fn parse(sources: &Sources, id: SourceId) -> Document {
     document
 }
 
-/// Writes a document's bytes in emission order.
+/// Writes a document as LaTeX in emission order.
 ///
-/// Every node's bytes are copied from the source slice its span indexes. No
-/// node's content is reconstructed, so an emitter cannot reformat what it was
-/// asked to transport.
+/// Opaque and malformed nodes are copied from their source spans. Recognised
+/// constructs lower to their specified LaTeX form; braced field content is
+/// still copied from its source span rather than decoded or reconstructed.
 ///
 /// # Errors
 ///
@@ -148,9 +149,176 @@ pub fn emit(sources: &Sources, document: &Document, out: &mut Vec<u8>) -> Result
                 start: span.start(),
                 end: span.end(),
             })?;
-        out.extend_from_slice(bytes);
+        match node {
+            Node::Construct { kind, .. } => emit_construct(*kind, bytes, out),
+            Node::Opaque { .. } | Node::Malformed { .. } => out.extend_from_slice(bytes),
+        }
     }
     Ok(())
+}
+
+fn emit_construct(kind: EntryToken, bytes: &[u8], out: &mut Vec<u8>) {
+    match kind {
+        EntryToken::Id => emit_inline(bytes, b"\\label{", out),
+        EntryToken::Ref => emit_inline(bytes, b"\\ref{", out),
+        EntryToken::Cite => {
+            out.push(b'\\');
+            let open = bytes.iter().position(|byte| *byte == b'(').unwrap_or(1);
+            out.extend_from_slice(&bytes[1..open]);
+            out.push(b'{');
+            emit_citation_keys(&bytes[open + 1..bytes.len() - 1], out);
+            out.push(b'}');
+        }
+        EntryToken::Import => emit_import(bytes, out),
+        EntryToken::Raw => {
+            let open = bytes.iter().position(|byte| *byte == b'{').unwrap_or(0);
+            out.extend_from_slice(&bytes[open + 1..bytes.len() - 1]);
+        }
+        EntryToken::Figure | EntryToken::Table => emit_block(kind, bytes, out),
+    }
+}
+
+fn emit_inline(bytes: &[u8], prefix: &[u8], out: &mut Vec<u8>) {
+    let open = bytes.iter().position(|byte| *byte == b'(').unwrap_or(0);
+    out.extend_from_slice(prefix);
+    out.extend_from_slice(&bytes[open + 1..bytes.len() - 1]);
+    out.push(b'}');
+}
+
+fn emit_citation_keys(keys: &[u8], out: &mut Vec<u8>) {
+    let mut first = true;
+    for key in keys.split(|byte| *byte == b',') {
+        if !first {
+            out.push(b',');
+        }
+        let start = key
+            .iter()
+            .position(|byte| !byte.is_ascii_whitespace())
+            .unwrap_or(key.len());
+        let end = key
+            .iter()
+            .rposition(|byte| !byte.is_ascii_whitespace())
+            .map_or(start, |i| i + 1);
+        out.extend_from_slice(&key[start..end]);
+        first = false;
+    }
+}
+
+fn emit_import(bytes: &[u8], out: &mut Vec<u8>) {
+    let first_quote = bytes.iter().position(|byte| *byte == b'"').unwrap_or(0);
+    let last_quote = bytes
+        .iter()
+        .rposition(|byte| *byte == b'"')
+        .unwrap_or(first_quote);
+    out.extend_from_slice(b"\\input{");
+    let path = &bytes[first_quote + 1..last_quote];
+    let stem = path.strip_suffix(b".ntex").unwrap_or(path);
+    out.extend_from_slice(stem);
+    out.extend_from_slice(b".tex}");
+}
+
+fn emit_block(token: EntryToken, bytes: &[u8], out: &mut Vec<u8>) {
+    let (kind, entry_len, environment) = match token {
+        EntryToken::Figure => (BlockKind::Figure, b"\\figure(".len(), b"figure".as_slice()),
+        EntryToken::Table => (BlockKind::Table, b"\\table(".len(), b"table".as_slice()),
+        _ => return,
+    };
+    let Ok(block) = parse_block(bytes, kind, 0, entry_len) else {
+        out.extend_from_slice(bytes);
+        return;
+    };
+    let field = |name: &[u8]| {
+        block
+            .fields
+            .iter()
+            .find(|field| bytes.get(field.key.start()..field.key.end()) == Some(name))
+    };
+
+    out.extend_from_slice(b"\\begin{");
+    out.extend_from_slice(environment);
+    out.extend_from_slice(b"}\n");
+    if kind == BlockKind::Table || field(b"src").is_some() || field(b"width").is_some() {
+        out.extend_from_slice(b"  \\centering\n");
+    }
+    if let Some(src) = field(b"src") {
+        out.extend_from_slice(b"  \\includegraphics");
+        if let Some(width) = field(b"width") {
+            out.extend_from_slice(b"[width=");
+            if matches!(width.value, Value::Percentage(_)) {
+                emit_percentage(bytes, width.value.span(), out);
+                out.extend_from_slice(b"\\linewidth");
+            } else {
+                copy_value(bytes, width.value, false, out);
+            }
+            out.push(b']');
+        }
+        out.push(b'{');
+        copy_value(bytes, src.value, false, out);
+        out.extend_from_slice(b"}\n");
+    }
+    if let Some(caption) = field(b"caption") {
+        out.extend_from_slice(b"  \\caption{");
+        copy_value(bytes, caption.value, true, out);
+        out.extend_from_slice(b"}\n");
+    }
+    if let Some(body) = field(b"body") {
+        copy_value(bytes, body.value, true, out);
+        out.push(b'\n');
+    }
+    if let Some(trailing) = field(b"trailing") {
+        copy_value(bytes, trailing.value, true, out);
+        out.push(b'\n');
+    }
+    out.extend_from_slice(b"  \\label{");
+    out.extend_from_slice(&bytes[block.id.start()..block.id.end()]);
+    out.extend_from_slice(b"}\n\\end{");
+    out.extend_from_slice(environment);
+    out.push(b'}');
+}
+
+fn emit_percentage(bytes: &[u8], span: source::Span, out: &mut Vec<u8>) {
+    let number = &bytes[span.start()..span.end() - 1];
+    let dot = number
+        .iter()
+        .position(|byte| *byte == b'.')
+        .unwrap_or(number.len());
+    let mut digits = number.to_vec();
+    if dot < digits.len() {
+        digits.remove(dot);
+    }
+    while digits.first() == Some(&b'0') && digits.len() > 1 {
+        digits.remove(0);
+    }
+    let fractional = if dot == number.len() {
+        0
+    } else {
+        number.len() - dot - 1
+    };
+    let decimal = digits.len().saturating_sub(fractional + 2);
+    if decimal == 0 {
+        out.extend_from_slice(b"0.");
+        for _ in digits.len()..fractional + 2 {
+            out.push(b'0');
+        }
+        out.extend_from_slice(&digits);
+    } else {
+        out.extend_from_slice(&digits[..decimal]);
+        if decimal < digits.len() {
+            out.push(b'.');
+            out.extend_from_slice(&digits[decimal..]);
+        }
+    }
+}
+
+fn copy_value(bytes: &[u8], value: Value, strip_delimiters: bool, out: &mut Vec<u8>) {
+    let span = value.span();
+    let mut start = span.start();
+    let mut end = span.end();
+    if strip_delimiters || matches!(value, Value::Str(_)) {
+        start += 1;
+        end -= 1;
+    }
+    out.extend_from_slice(&bytes[start..end]);
 }
 
 /// What went wrong running the pipeline over one source.
@@ -192,11 +360,10 @@ impl From<EmitError> for BuildError {
     }
 }
 
-/// Loads `name`, parses it, and emits the result.
+/// Loads `name`, parses it, and emits one LaTeX file.
 ///
-/// The pipeline is load, parse, emit. For input carrying no NextTeX construct
-/// the bytes written are the bytes read, and that holds while the middle of the
-/// pipeline grows.
+/// For input carrying no NextTeX construct the bytes written are the bytes
+/// read. Project traversal and output-name mapping belong to the host front end.
 ///
 /// # Errors
 ///
@@ -386,5 +553,22 @@ mod tests {
 
         assert!(document.coverage() > 0.0);
         assert!(document.iter().any(|n| !n.is_opaque()));
+    }
+
+    #[test]
+    fn braced_field_bytes_are_copied_without_utf8_decoding() {
+        let input =
+            b"before \\table(t) { caption = {Caf\xE9 \\% {nested}} body = {a\xFF\\\\b} } after";
+        let mut sources = Sources::new();
+        let id = sources.add("main.ntex", input.as_slice());
+        let document = parse(&sources, id);
+        let mut out = Vec::new();
+        emit(&sources, &document, &mut out).unwrap();
+
+        assert!(out.starts_with(b"before \\begin{table}"));
+        for needle in [b"Caf\xE9 \\% {nested}".as_slice(), b"a\xFF\\\\b".as_slice()] {
+            assert!(out.windows(needle.len()).any(|part| part == needle));
+        }
+        assert!(out.ends_with(b"\\end{table} after"));
     }
 }

--- a/crates/nextex-core/src/lib.rs
+++ b/crates/nextex-core/src/lib.rs
@@ -237,19 +237,36 @@ fn emit_block(token: EntryToken, bytes: &[u8], out: &mut Vec<u8>) {
     out.extend_from_slice(b"\\begin{");
     out.extend_from_slice(environment);
     out.extend_from_slice(b"}\n");
-    if kind == BlockKind::Table || field(b"src").is_some() || field(b"width").is_some() {
+    if kind == BlockKind::Table || field(b"src").is_some() {
         out.extend_from_slice(b"  \\centering\n");
     }
     if let Some(src) = field(b"src") {
         out.extend_from_slice(b"  \\includegraphics");
-        if let Some(width) = field(b"width") {
-            out.extend_from_slice(b"[width=");
-            if matches!(width.value, Value::Percentage(_)) {
-                emit_percentage(bytes, width.value.span(), out);
-                out.extend_from_slice(b"\\linewidth");
-            } else {
-                copy_value(bytes, width.value, false, out);
+        // A percentage becomes a fraction of a reference fixed by the field,
+        // never one the author selects. `\\linewidth` is the only width correct
+        // both inside a single-column float and inside a spanning one; for
+        // height TeX offers no adaptive reference at all. `decisions/0004`.
+        let mut options: Vec<u8> = Vec::new();
+        for (name, reference) in [
+            (&b"width"[..], &b"\\linewidth"[..]),
+            (&b"height"[..], &b"\\textheight"[..]),
+        ] {
+            let Some(field) = field(name) else { continue };
+            if !options.is_empty() {
+                options.push(b',');
             }
+            options.extend_from_slice(name);
+            options.push(b'=');
+            if matches!(field.value, Value::Percentage(_)) {
+                emit_percentage(bytes, field.value.span(), &mut options);
+                options.extend_from_slice(reference);
+            } else {
+                copy_value(bytes, field.value, false, &mut options);
+            }
+        }
+        if !options.is_empty() {
+            out.push(b'[');
+            out.extend_from_slice(&options);
             out.push(b']');
         }
         out.push(b'{');

--- a/crates/nextex-core/src/scanner.rs
+++ b/crates/nextex-core/src/scanner.rs
@@ -245,7 +245,12 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                     flush!(at);
                     // A construct that never closes on its line is reported at
                     // its entry token, and its bytes are still transported.
-                    let (piece, resume) = match close_paren(bytes, end) {
+                    let close = if token == EntryToken::Import {
+                        close_import(bytes, end)
+                    } else {
+                        close_paren(bytes, end)
+                    };
+                    let (piece, resume) = match close {
                         Some(close) => (
                             Piece::Construct {
                                 kind: token,
@@ -580,6 +585,22 @@ fn close_paren(bytes: &[u8], from: usize) -> Option<usize> {
         match bytes[i] {
             b')' => return Some(i),
             b'\n' => return None,
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+fn close_import(bytes: &[u8], from: usize) -> Option<usize> {
+    if bytes.get(from) != Some(&b'"') {
+        return None;
+    }
+    let mut i = from + 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 2,
+            b'"' if bytes.get(i + 1) == Some(&b')') => return Some(i + 1),
+            b'"' | b'\n' => return None,
             _ => i += 1,
         }
     }

--- a/crates/nextex-core/tests/fixtures.rs
+++ b/crates/nextex-core/tests/fixtures.rs
@@ -101,19 +101,19 @@ fn every_fixture_declares_what_it_expects() {
 }
 
 #[test]
-fn every_fixture_transports_byte_identical() {
+fn fixtures_without_constructs_transport_byte_identical() {
     let mut checked = 0usize;
 
     for input in all_fixtures() {
         let name = label(&input);
         let raw = fs::read(&input).unwrap_or_else(|e| panic!("{name}: cannot read ({e})"));
 
-        let declared = fs::read_to_string(input.with_file_name("expect.txt"))
-            .unwrap_or_else(|e| panic!("{name}: cannot read expect.txt ({e})"));
-        assert!(
-            declared.contains("transport: identical"),
-            "{name}: this harness only knows how to check identical transport"
-        );
+        if scan(&raw)
+            .iter()
+            .any(|piece| matches!(piece, Piece::Construct { .. }))
+        {
+            continue;
+        }
 
         let mut store = Memory::new().with_input(name.clone(), raw.clone());
         transport(&name, &store.clone(), &mut store)
@@ -130,11 +130,11 @@ fn every_fixture_transports_byte_identical() {
         checked += 1;
     }
 
-    assert!(checked >= 40, "only {checked} fixtures ran");
+    assert!(checked >= 20, "only {checked} fixtures ran");
 }
 
 #[test]
-fn every_fixture_transports_at_every_truncation() {
+fn every_construct_free_truncation_transports_byte_identical() {
     // Truncating manufactures unterminated constructs of every shape from
     // inputs that already contain the awkward ones. It is the cheapest
     // generator that finds boundary bugs, and it will keep finding them once
@@ -145,6 +145,12 @@ fn every_fixture_transports_at_every_truncation() {
 
         for cut in 0..=raw.len() {
             let slice = &raw[..cut];
+            if scan(slice)
+                .iter()
+                .any(|piece| matches!(piece, Piece::Construct { .. }))
+            {
+                continue;
+            }
             let mut store = Memory::new().with_input(name.clone(), slice.to_vec());
             transport(&name, &store.clone(), &mut store)
                 .unwrap_or_else(|e| panic!("{name}: transport failed at cut {cut} ({e})"));
@@ -156,6 +162,93 @@ fn every_fixture_transports_at_every_truncation() {
             );
         }
     }
+}
+
+#[test]
+fn emission_leaves_every_byte_outside_a_construct_alone() {
+    // Property A says untouched LaTeX comes out byte-identical, and a fixture
+    // holding a construct cannot satisfy it — emitting the construct is the
+    // point. But the invariant underneath it still applies to every fixture:
+    // bytes the author wrote and the parser did not model are copied, never
+    // reformatted.
+    //
+    // This asserts exactly that. Walk the pieces in order; every non-construct
+    // piece must appear in the output, unchanged and in sequence, with the
+    // emitted constructs free to be any length in between.
+    //
+    // It exists because the byte-identity test was narrowed to construct-free
+    // fixtures when emission landed, which left 33 of 56 fixtures with no
+    // assertion on their output at all. Narrowing was right; leaving the gap
+    // was not.
+    let mut checked = 0usize;
+
+    for input in all_fixtures() {
+        let name = label(&input);
+        let raw = fs::read(&input).unwrap_or_else(|e| panic!("{name}: cannot read ({e})"));
+
+        let mut store = Memory::new().with_input(name.clone(), raw.clone());
+        transport(&name, &store.clone(), &mut store)
+            .unwrap_or_else(|e| panic!("{name}: emission failed ({e})"));
+        let out = store.output(&name).unwrap_or_default().to_vec();
+
+        let mut at = 0usize;
+        for piece in scan(&raw) {
+            let span = match piece {
+                Piece::Construct { .. } => continue,
+                Piece::Text(s) | Piece::Excluded(s) | Piece::Malformed { span: s, .. } => s,
+            };
+            let carried = &raw[span.start()..span.end()];
+            if carried.is_empty() {
+                continue;
+            }
+            let found = out[at..]
+                .windows(carried.len())
+                .position(|w| w == carried)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{name}: emission changed bytes the parser did not model, at {}..{}: {:?}",
+                        span.start(),
+                        span.end(),
+                        String::from_utf8_lossy(carried)
+                    )
+                });
+            at += found + carried.len();
+        }
+        checked += 1;
+    }
+
+    assert!(checked >= 50, "only {checked} fixtures ran");
+}
+
+#[test]
+fn emission_fixtures_match_their_expected_output() {
+    // Exact bytes, hand-written. The test above pins what emission must leave
+    // alone; this one pins what it must produce.
+    let mut checked = 0usize;
+
+    for input in all_fixtures() {
+        let expected = input.with_file_name("emitted.tex");
+        if !expected.exists() {
+            continue;
+        }
+        let name = label(&input);
+        let raw = fs::read(&input).unwrap_or_else(|e| panic!("{name}: cannot read ({e})"));
+        let want =
+            fs::read(&expected).unwrap_or_else(|e| panic!("{name}: cannot read emitted.tex ({e})"));
+
+        let mut store = Memory::new().with_input(name.clone(), raw);
+        transport(&name, &store.clone(), &mut store)
+            .unwrap_or_else(|e| panic!("{name}: emission failed ({e})"));
+
+        assert_eq!(
+            String::from_utf8_lossy(store.output(&name).unwrap_or_default()),
+            String::from_utf8_lossy(&want),
+            "{name}: emitted output differs from emitted.tex"
+        );
+        checked += 1;
+    }
+
+    assert!(checked >= 3, "only {checked} emission fixtures ran");
 }
 
 /// The pieces an `expect.txt` declares, in order.

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -190,8 +190,13 @@ are compared by rendering both and diffing the rasters. If emission injected any
 differ by construction and the property would be untestable rather than merely violated.
 
 Practical consequence for anyone extending the emitter: a typed block lowers to the LaTeX its fields
-describe and nothing else. A block that "helpfully" adds `\centering`, or loads a package its body needs, has
-broken the contract even when the PDF happens to look right.
+describe, plus `\centering` and nothing more. A block that "helpfully" adds a `\FloatBarrier`, or loads a
+package its body needs, has broken the contract even when the PDF happens to look right.
+
+`\centering` is the one exception and it is not an oversight in this list. It is part of what `\figure` and
+`\table` *mean* here — the construct is a centred float, and an author who does not want one writes the
+environment in LaTeX. The reasoning, and the rule that a second exception needs its own decision record, are
+in [`decisions/0001`](decisions/0001-typed-emission-and-no-injection.md).
 
 ---
 

--- a/docs/decisions/0004-lengths-and-inclusion.md
+++ b/docs/decisions/0004-lengths-and-inclusion.md
@@ -1,0 +1,73 @@
+# 0004 · What a percentage becomes, and what `@import` becomes
+
+**Status:** accepted, 2026-08-29. Decided by the director.
+**Constraint he set:** resolve both without adding a keyword.
+**Issue:** [#13](https://github.com/camilochs/nexttex/issues/13)
+
+---
+
+Three questions the emitter could not answer from the specification. None of the answers adds syntax: each
+is a fixed rule attached to a field or a construct that already exists.
+
+## 1 · `width = 80%` becomes `0.80\linewidth`
+
+A percentage has to become a TeX length, and the reference changes the PDF. Compiled in a two-column
+document rather than recalled:
+
+| Inside | `\linewidth` | `\textwidth` | `\columnwidth` |
+|---|---|---|---|
+| `figure` — one column | **229.5pt** | 469.0pt | 229.5pt |
+| `figure*` — spanning | **469.0pt** | 469.0pt | 229.5pt |
+
+`\textwidth` overflows a single-column float. `\columnwidth` under-fills a spanning one. **`\linewidth` is
+the only reference correct in both**, because it is the width of the line the float is actually set on.
+
+Frequency in a corpus is the wrong metric here and was used at first: the author's papers write `\textwidth`
+124 times, `\columnwidth` 65 and `\linewidth` 49, and that says nothing about which is correct. A rule the
+compiler applies everywhere has to hold everywhere.
+
+An author who wants a different reference writes an absolute length, or writes the `\includegraphics` in
+LaTeX. The percentage form is for the common case and takes no argument about it.
+
+## 2 · `height = 40%` becomes `0.40\textheight`
+
+`height` is admitted as a figure field, with the same value kinds as `width`.
+
+There is no `\lineheight`. TeX exposes no "space available in this float", so no adaptive reference exists
+the way `\linewidth` does for width. `\textheight` — the page's text height — is what the corpus uses
+whenever a relative height appears, and it is the only length with a defensible meaning here.
+
+The asymmetry with `width` is real and it is not a design choice. It is what TeX offers.
+
+## 3 · `@import` becomes `\input`, and could not have become `\include`
+
+Not a preference. LaTeX settles it:
+
+```
+error: middle.tex:1: LaTeX Error: \include cannot be nested.
+```
+
+`@import` nests by definition — [`grammar.md`](../grammar.md) §4 defines a document root as its root file
+plus the **transitive closure** of files reached by `@import`. A construct that nests cannot lower to a
+command that refuses to.
+
+`\input` also imposes no page break, which `\include` does. Emitting a page break the author did not ask for
+would be injection under [`decisions/0001`](0001-typed-emission-and-no-injection.md), so the two reasons
+agree.
+
+## What is still open: `keepaspectratio`
+
+Giving `\includegraphics` both `width` and `height` stretches the image to fit unless `keepaspectratio` is
+also given. In the measured corpus, of 243 `\includegraphics` calls:
+
+| | Count |
+|---|---|
+| Give both `width` and `height` | 17 |
+| …of those, also give `keepaspectratio` | **15** |
+
+So an author who gives both almost always means a bounding box rather than a stretch. Emitting
+`keepaspectratio` when a block gives both would follow that intent — and would be a **second exception to
+no-injection**, which `decisions/0001` says needs its own record.
+
+Not settled here. Until it is, a block giving both fields emits both and nothing else, and the image is
+stretched exactly as plain LaTeX would stretch it.

--- a/docs/decisions/0004-lengths-and-inclusion.md
+++ b/docs/decisions/0004-lengths-and-inclusion.md
@@ -26,8 +26,28 @@ Frequency in a corpus is the wrong metric here and was used at first: the author
 124 times, `\columnwidth` 65 and `\linewidth` 49, and that says nothing about which is correct. A rule the
 compiler applies everywhere has to hold everywhere.
 
-An author who wants a different reference writes an absolute length, or writes the `\includegraphics` in
-LaTeX. The percentage form is for the common case and takes no argument about it.
+### Naming a different reference
+
+The percentage is a shorthand for the common case and its reference is fixed. An author who needs another
+one names it, and a `length` therefore admits a TeX length:
+
+```
+width = 80%                shorthand, 0.80\linewidth
+width = 0.8\columnwidth     the reference named
+width = \textwidth          no coefficient
+width = 12cm                absolute
+```
+
+This was a hole rather than a trade. The first draft defined a `length` as a number plus one of six units,
+which left `\columnwidth` unreachable without abandoning the typed block for plain LaTeX — and inside a
+float spanning both columns, `\linewidth` is the full page width, so a column-width image there has no
+percentage form at all. The restriction was written without anyone asking whether it should hold. The
+director asked.
+
+A control word followed by `{` is a command taking an argument, not a length, and is rejected.
+
+Checked before implementing: a backslash inside a field value does not disturb the block's brace counting.
+The boundary is found at the same offset with and without one.
 
 ## 2 · `height = 40%` becomes `0.40\textheight`
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -987,8 +987,17 @@ The following decisions remain open because the available evidence does not sele
    title-specific check or reference would justify the latter.
 6. **Typed algorithm and panel blocks.** Light annotations admit both. A demonstrated typed check with a
    stable field set would justify new blocks.
-7. ~~**What `@cite` emits.**~~ Settled 2026-08-29 by the director: a citation construct is a LaTeX
+7. **What a percentage width lowers to.** `width = 80%` has to become a TeX length, and the choice of
+   reference width changes the PDF. The corpus uses `\textwidth` 124 times, `\columnwidth` 65 and
+   `\linewidth` 49, so it is not settled by practice either. The emitter currently writes
+   `0.80\linewidth` because something had to be written; that is a placeholder, not a decision. A field
+   naming the reference, or a project-wide default in `nextex.toml`, are the obvious shapes.
+8. **Whether `@import` lowers to `\input` or `\include`.** They differ: `\include` starts a new page and
+   cannot nest, `\input` does neither. The emitter currently writes `\input` because it preserves file
+   boundaries without imposing page breaks, and that reasoning is worth keeping, but the choice is not
+   recorded anywhere as accepted.
+9. ~~**What `@cite` emits.**~~ Settled 2026-08-29 by the director: a citation construct is a LaTeX
    citation command written with `@`, and it emits that command. No style vocabulary, no package
    inference, no fields. See §4.
-8. ~~**Package requirements.**~~ Settled 2026-08-29: `needs` is not a field, packages are source-authored.
+10. ~~**Package requirements.**~~ Settled 2026-08-29: `needs` is not a field, packages are source-authored.
    See `decisions/0001-typed-emission-and-no-injection.md`.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -423,7 +423,7 @@ until one succeeds.
 | Kind | Form | Ends at |
 |---|---|---|
 | `string` | `"` followed by bytes using `\"` and `\\` escapes | unescaped closing `"` |
-| `length` | decimal number plus `pt`, `mm`, `cm`, `in`, `em` or `ex` | first byte outside that token |
+| `length` | a decimal number plus `pt`, `mm`, `cm`, `in`, `em` or `ex`; **or** a TeX length such as `\linewidth`, with an optional coefficient before it | first byte outside that token |
 | `percentage` | decimal number plus `%` | byte after `%` |
 | `integer` | one or more ASCII digits | first non-digit byte |
 | `bare` | bytes other than a line ending | immediately before the line ending |
@@ -521,8 +521,23 @@ by compiling, `\textwidth` overflows the first and `\columnwidth` under-fills th
 adaptive reference exists — TeX exposes no "space available in this float" — so `\textheight` is used, and
 the asymmetry is what TeX offers rather than a choice.
 
-An author who needs a different reference writes an absolute length or writes the `\includegraphics` in
-LaTeX. See [`decisions/0004`](decisions/0004-lengths-and-inclusion.md).
+**An author who needs a different reference names it, and that is why a `length` admits a TeX length:**
+
+```
+width = 80%                shorthand, 0.80\linewidth
+width = 0.8\columnwidth     the reference named
+width = \textwidth          no coefficient
+width = 12cm                absolute
+```
+
+`\columnwidth` cannot be reached any other way. Inside a float that spans both columns, `\linewidth` is the
+full page width, so a column-width image there has no percentage form. Restricting `length` to a number and
+a unit made that unreachable without abandoning the block for plain LaTeX, and the restriction was written
+without anyone asking whether it should hold.
+
+A control word followed by `{` is a command taking an argument, not a length, and is rejected.
+
+See [`decisions/0004`](decisions/0004-lengths-and-inclusion.md).
 
 ### Package requirements
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -438,6 +438,7 @@ until one succeeds.
 figure-fields:
   src       = string
   width     = length | percentage
+  height    = length | percentage
   caption   = braced
 ```
 
@@ -504,6 +505,24 @@ field.
 
 This decision removes duplicated information. The hand annotation restated
 `\begin{tabular}{@{}lcccccc@{}}` as `columns = 7`, allowing the two annotations to disagree.
+
+### Lengths
+
+A `length` is emitted as written. A `percentage` becomes a fraction of a fixed reference, and the reference
+is part of the field's meaning rather than something the author selects:
+
+| Field | `80%` becomes |
+|---|---|
+| `width` | `0.80\linewidth` |
+| `height` | `0.80\textheight` |
+
+`\linewidth` is the only width correct both inside a single-column float and inside a spanning one; measured
+by compiling, `\textwidth` overflows the first and `\columnwidth` under-fills the second. For height no
+adaptive reference exists — TeX exposes no "space available in this float" — so `\textheight` is used, and
+the asymmetry is what TeX offers rather than a choice.
+
+An author who needs a different reference writes an absolute length or writes the `\includegraphics` in
+LaTeX. See [`decisions/0004`](decisions/0004-lengths-and-inclusion.md).
 
 ### Package requirements
 
@@ -987,15 +1006,14 @@ The following decisions remain open because the available evidence does not sele
    title-specific check or reference would justify the latter.
 6. **Typed algorithm and panel blocks.** Light annotations admit both. A demonstrated typed check with a
    stable field set would justify new blocks.
-7. **What a percentage width lowers to.** `width = 80%` has to become a TeX length, and the choice of
-   reference width changes the PDF. The corpus uses `\textwidth` 124 times, `\columnwidth` 65 and
-   `\linewidth` 49, so it is not settled by practice either. The emitter currently writes
-   `0.80\linewidth` because something had to be written; that is a placeholder, not a decision. A field
-   naming the reference, or a project-wide default in `nextex.toml`, are the obvious shapes.
-8. **Whether `@import` lowers to `\input` or `\include`.** They differ: `\include` starts a new page and
-   cannot nest, `\input` does neither. The emitter currently writes `\input` because it preserves file
-   boundaries without imposing page breaks, and that reasoning is worth keeping, but the choice is not
-   recorded anywhere as accepted.
+7. ~~**What a percentage lowers to.**~~ Settled 2026-08-29: `width` against `\linewidth`, `height` against
+   `\textheight`, no keyword. See §5 and `decisions/0004`.
+8. ~~**Whether `@import` lowers to `\input` or `\include`.**~~ Settled 2026-08-29: `\input`, and
+   `\include` was never available — it cannot be nested and `@import` nests. See `decisions/0004`.
+11. **Whether `keepaspectratio` is emitted when a block gives both `width` and `height`.** Of 243 measured
+    `\includegraphics` calls, 17 give both and 15 of those also give `keepaspectratio`, so the intent is
+    almost always a bounding box rather than a stretch. Following it would be a second exception to
+    no-injection and needs its own decision record.
 9. ~~**What `@cite` emits.**~~ Settled 2026-08-29 by the director: a citation construct is a LaTeX
    citation command written with `@`, and it emits that command. No style vocabulary, no package
    inference, no fields. See §4.

--- a/tests/fixtures/emission/01-inline-constructs/emitted.tex
+++ b/tests/fixtures/emission/01-inline-constructs/emitted.tex
@@ -1,0 +1,1 @@
+BEFORE<\label{sec:intro}|\ref{fig:main}|\cite{k}|\citep{a,b}|\citet{c}|\textcite{d}|\parencite{e}>AFTER

--- a/tests/fixtures/emission/01-inline-constructs/expect.txt
+++ b/tests/fixtures/emission/01-inline-constructs/expect.txt
@@ -1,0 +1,3 @@
+transport: lowered
+scanner: id ref cite cite cite cite cite
+constructs: all inline constructs lower without changing the sentinel bytes around them

--- a/tests/fixtures/emission/01-inline-constructs/input.ntex
+++ b/tests/fixtures/emission/01-inline-constructs/input.ntex
@@ -1,0 +1,1 @@
+BEFORE<@id(sec:intro)|@ref(fig:main)|@cite(k)|@citep(a, b)|@citet(c)|@textcite(d)|@parencite(e)>AFTER

--- a/tests/fixtures/emission/02-typed-blocks/emitted.tex
+++ b/tests/fixtures/emission/02-typed-blocks/emitted.tex
@@ -1,0 +1,20 @@
+BEFORE
+\begin{figure}
+  \centering
+  \includegraphics[width=0.80\linewidth]{plot.pdf}
+  \caption{A {nested} caption\\
+with bytes}
+  \label{fig:main}
+\end{figure}
+MIDDLE
+\begin{table}
+  \centering
+  \caption{Data}
+\begin{tabular}{ll}
+a & b \\
+\end{tabular}
+% keep this comment
+{\small trailing}
+  \label{tab:data}
+\end{table}
+AFTER

--- a/tests/fixtures/emission/02-typed-blocks/expect.txt
+++ b/tests/fixtures/emission/02-typed-blocks/expect.txt
@@ -1,0 +1,3 @@
+transport: lowered
+scanner: figure table
+constructs: braced content is copied and recognition resumes after both blocks

--- a/tests/fixtures/emission/02-typed-blocks/input.ntex
+++ b/tests/fixtures/emission/02-typed-blocks/input.ntex
@@ -1,0 +1,17 @@
+BEFORE
+\figure(fig:main) {
+  src = "plot.pdf"
+  width = 80%
+  caption = {A {nested} caption\\
+with bytes}
+}
+MIDDLE
+\table(tab:data) {
+  caption = {Data}
+  body = {\begin{tabular}{ll}
+a & b \\
+\end{tabular}}
+  trailing = {% keep this comment
+{\small trailing}}
+}
+AFTER

--- a/tests/fixtures/emission/03-raw-and-import/emitted.tex
+++ b/tests/fixtures/emission/03-raw-and-import/emitted.tex
@@ -1,0 +1,1 @@
+BEFORE<@ref(literal) {nested}|\input{sections/model.tex}>AFTER

--- a/tests/fixtures/emission/03-raw-and-import/expect.txt
+++ b/tests/fixtures/emission/03-raw-and-import/expect.txt
@@ -1,0 +1,3 @@
+transport: lowered
+scanner: latex import
+constructs: raw erases only its wrapper and import remains a file inclusion

--- a/tests/fixtures/emission/03-raw-and-import/input.ntex
+++ b/tests/fixtures/emission/03-raw-and-import/input.ntex
@@ -1,0 +1,1 @@
+BEFORE<latex {@ref(literal) {nested}}|@import("sections/model.ntex")>AFTER

--- a/tests/fixtures/emission/04-lengths/emitted.tex
+++ b/tests/fixtures/emission/04-lengths/emitted.tex
@@ -1,0 +1,15 @@
+BEFORE
+\begin{figure}
+  \centering
+  \includegraphics[width=0.80\linewidth,height=0.40\textheight]{a.pdf}
+  \caption{Both relative}
+  \label{fig:pct}
+\end{figure}
+MIDDLE
+\begin{figure}
+  \centering
+  \includegraphics[width=12cm]{b.pdf}
+  \caption{Absolute}
+  \label{fig:abs}
+\end{figure}
+AFTER

--- a/tests/fixtures/emission/04-lengths/expect.txt
+++ b/tests/fixtures/emission/04-lengths/expect.txt
@@ -1,0 +1,5 @@
+transport: lowered
+scanner: figure figure
+constructs: two figures. A percentage takes the reference its field fixes —
+  width against \linewidth, height against \textheight — and an absolute length
+  is emitted as written. No keepaspectratio: grammar §11.11 is open.

--- a/tests/fixtures/emission/04-lengths/input.ntex
+++ b/tests/fixtures/emission/04-lengths/input.ntex
@@ -1,0 +1,14 @@
+BEFORE
+\figure(fig:pct) {
+  src = "a.pdf"
+  width = 80%
+  height = 40%
+  caption = {Both relative}
+}
+MIDDLE
+\figure(fig:abs) {
+  src = "b.pdf"
+  width = 12cm
+  caption = {Absolute}
+}
+AFTER

--- a/tests/fixtures/emission/05-tex-lengths/emitted.tex
+++ b/tests/fixtures/emission/05-tex-lengths/emitted.tex
@@ -1,0 +1,15 @@
+BEFORE
+\begin{figure}
+  \centering
+  \includegraphics[width=0.8\columnwidth]{a.pdf}
+  \caption{A column-width image in a spanning float}
+  \label{fig:col}
+\end{figure}
+MIDDLE
+\begin{figure}
+  \centering
+  \includegraphics[width=\textwidth,height=6cm]{b.pdf}
+  \caption{No coefficient}
+  \label{fig:bare}
+\end{figure}
+AFTER

--- a/tests/fixtures/emission/05-tex-lengths/expect.txt
+++ b/tests/fixtures/emission/05-tex-lengths/expect.txt
@@ -1,0 +1,6 @@
+transport: lowered
+scanner: figure figure
+constructs: two figures naming their own reference. A TeX length is emitted as
+  written, with or without a coefficient. This is how an author reaches
+  \columnwidth, which the percentage form cannot express because its reference
+  is fixed at \linewidth.

--- a/tests/fixtures/emission/05-tex-lengths/input.ntex
+++ b/tests/fixtures/emission/05-tex-lengths/input.ntex
@@ -1,0 +1,14 @@
+BEFORE
+\figure(fig:col) {
+  src = "a.pdf"
+  width = 0.8\columnwidth
+  caption = {A column-width image in a spanning float}
+}
+MIDDLE
+\figure(fig:bare) {
+  src = "b.pdf"
+  width = \textwidth
+  height = 6cm
+  caption = {No coefficient}
+}
+AFTER


### PR DESCRIPTION
Closes #13. Both open decisions it raised are now settled in this branch.

## What it does

Until now `emit` transported. Nothing derived from a construct had ever been produced.

```
\section{Results} @id(sec:results)                \section{Results} \label{sec:results}
As shown in @ref(fig:plot), see @citep(a, b).     As shown in \ref{fig:plot}, see \citep{a,b}.
\figure(fig:plot) {                               \begin{figure}
  src = "plot.pdf"                    ──►           \centering
  width = 80%                                       \includegraphics[width=0.80\linewidth]{plot.pdf}
  height = 40%                                      \caption{Runtime by backend}
  caption = {Runtime by backend}                    \label{fig:plot}
}                                                 \end{figure}
Ordinary \ref{legacy} untouched.                  Ordinary \ref{legacy} untouched.
```

One `.tex` per `.ntex` under `build/`, mirroring the layout. An `@import` becomes an inclusion of the emitted file, never its contents spliced in. It also exposed a scanner bug: a `)` inside a quoted import path truncated the construct.

---

## Three decisions, none adding a keyword

### `width = 80%` → `0.80\linewidth`

I argued this wrong at first, from corpus frequency. Frequency is the wrong metric for a rule the compiler applies everywhere. Compiled in a two-column document instead:

| Inside | `\linewidth` | `\textwidth` | `\columnwidth` |
|---|---|---|---|
| `figure` — one column | **229.5pt** | 469.0pt | 229.5pt |
| `figure*` — spanning | **469.0pt** | 469.0pt | 229.5pt |

`\textwidth` overflows a single-column float; `\columnwidth` under-fills a spanning one. `\linewidth` is the only reference correct in both.

### `height = 40%` → `0.40\textheight`

`height` is now a figure field with the same value kinds as `width`. There is no `\lineheight` — TeX exposes no "space available in this float" — so no adaptive reference exists the way it does for width. The asymmetry is what TeX offers, not a choice.

### `@import` → `\input`, and `\include` was never available

Not a preference. LaTeX settles it:

```
error: middle.tex:1: LaTeX Error: \include cannot be nested.
```

`grammar.md` §4 defines a document root as its root file plus the **transitive closure** of files reached by `@import`. A construct that nests cannot lower to a command that refuses to. `\input` also imposes no page break, so both reasons agree.

---

## A length can name its own reference

The percentage form fixes its reference, which left `\columnwidth` **unreachable** — and inside a float spanning both columns, `\linewidth` is the full page width, so a column-width image there had no percentage form at all. Reaching it meant abandoning the typed block for plain LaTeX.

```
width = 80%                shorthand, 0.80\linewidth
width = 0.8\columnwidth     the reference named
width = \textwidth          no coefficient
width = 12cm                absolute
```

A control word followed by `{` is a command taking an argument, not a length, and is rejected.

The old restriction — a number plus one of six units — went into the specification without anyone asking whether it should hold, and it silently removed a capability LaTeX has.

Checked before implementing: a backslash inside a field value does not disturb the block's brace counting. Probed with escaped braces, a coefficient and a bare control word; the boundary is found at the same offset in every case.

---

## The test suite lost coverage and got it back

Property A says untouched LaTeX comes out byte-identical. A fixture holding a construct cannot satisfy that once constructs are lowered. So the byte-identity tests were narrowed to construct-free inputs — **right** — and what they had covered was not replaced — **not right**. Measured before fixing:

| | |
|---|---|
| Fixtures left with no assertion on their output | **33 of 56** |
| Truncations no longer checked | **15%** |

What replaces it is the invariant that holds for all of them, and is the one `AGENTS.md` §4 states — *opaque bytes are never normalised*:

> Walk the pieces in order. Every non-construct piece must appear in the output unchanged and in sequence, with the emitted constructs free to be any length in between.

Verified by breaking emission on purpose rather than assuming it works:

```
emission_leaves_every_byte_outside_a_construct_alone ... FAILED
  blocks/08-fields-that-no-longer-exist: emission changed bytes the parser
  did not model, at 0..7: "\\table("
```

Five emission fixtures pin exact output. Each carries sentinel bytes `BEFORE`, `MIDDLE`, `AFTER` — a fixture that only asserts what a construct *became* would pass a change that ate its surroundings, which is the trap that caught #39 this morning. One of them caught `height` being admitted in the specification and not in the block parser.

---

## Left open rather than decided

Giving `\includegraphics` both width and height stretches the image unless `keepaspectratio` is given too. Of 243 measured calls, 17 give both and **15 of those also give `keepaspectratio`** — so the intent is almost always a bounding box.

Emitting it would be a **second exception to no-injection**, and `decisions/0001` says that needs its own record. Recorded as grammar §11.11. Until then a block giving both emits both, and the image stretches exactly as plain LaTeX would.

## Also fixed

`checking.md` §6 said adding `\centering` breaks the contract, while `decisions/0001` names it the sole exception. The document now says what the decision says, and why the exception is not an oversight.

## Checks

95 tests pass, clippy clean at `-D warnings`, `cargo fmt --check` clean.