### PR TITLE
Recognise constructs inside a block's braced fields

### DIFF
--- a/crates/nextex-cli/examples/pieces.rs
+++ b/crates/nextex-cli/examples/pieces.rs
@@ -5,27 +5,31 @@ fn main() {
     let path = std::env::args().nth(1).expect("usage: pieces <file>");
     let bytes = std::fs::read(&path).expect("readable");
     for piece in scan(&bytes) {
-        let (label, span) = match piece {
-            Piece::Text(s) => ("text", s),
-            Piece::Excluded(s) => ("excluded", s),
-            Piece::Construct { kind, span } => (kind.name(), span),
-            Piece::Malformed { kind, span } => {
+        piece.walk(&mut |piece| {
+            let (label, span) = match piece {
+                Piece::Text(s) => ("text", *s),
+                Piece::Excluded(s) => ("excluded", *s),
+                Piece::Construct { kind, span, .. } => (kind.name(), *span),
+                Piece::Malformed { kind, span } => {
+                    println!(
+                        "  MALFORMED {:<10} {:?}",
+                        kind.name(),
+                        String::from_utf8_lossy(
+                            &bytes[span.start()..span.end().min(span.start() + 40)]
+                        )
+                    );
+                    return;
+                }
+            };
+            if label != "text" {
                 println!(
-                    "  MALFORMED {:<10} {:?}",
-                    kind.name(),
+                    "  {:<10} {:?}",
+                    label,
                     String::from_utf8_lossy(
-                        &bytes[span.start()..span.end().min(span.start() + 40)]
+                        &bytes[span.start()..span.end().min(span.start() + 46)]
                     )
                 );
-                continue;
             }
-        };
-        if label != "text" {
-            println!(
-                "  {:<10} {:?}",
-                label,
-                String::from_utf8_lossy(&bytes[span.start()..span.end().min(span.start() + 46)])
-            );
-        }
+        });
     }
 }

--- a/crates/nextex-core/src/document.rs
+++ b/crates/nextex-core/src/document.rs
@@ -86,6 +86,8 @@ pub enum Node {
         span: Span,
         /// Which construct it is.
         kind: EntryToken,
+        /// Constructs nested in document-content fields.
+        children: Vec<Node>,
     },
     /// An entry token whose construct could not be closed.
     ///
@@ -176,6 +178,21 @@ impl Document {
     /// Iterates over every node in emission order.
     pub fn iter(&self) -> impl Iterator<Item = &Node> {
         self.nodes.iter()
+    }
+
+    /// Visits every node, including constructs nested in block fields.
+    pub fn walk(&self, mut visit: impl FnMut(&Node)) {
+        fn walk_node(node: &Node, visit: &mut impl FnMut(&Node)) {
+            visit(node);
+            if let Node::Construct { children, .. } = node {
+                for child in children {
+                    walk_node(child, visit);
+                }
+            }
+        }
+        for node in &self.nodes {
+            walk_node(node, &mut visit);
+        }
     }
 
     /// Number of nodes.

--- a/crates/nextex-core/src/lib.rs
+++ b/crates/nextex-core/src/lib.rs
@@ -112,10 +112,18 @@ pub fn parse(sources: &Sources, id: SourceId) -> Document {
                 // end, it is simply not modelled. Nothing has given up.
                 confidence: ParseConfidence::OpaqueBalanced,
             },
-            Piece::Construct { kind, span } => Node::Construct {
+            Piece::Construct {
+                kind,
+                span,
+                children,
+            } => Node::Construct {
                 source: id,
                 span,
                 kind,
+                children: children
+                    .into_iter()
+                    .map(|piece| node_from_piece(piece, id))
+                    .collect(),
             },
             Piece::Malformed { kind, span } => Node::Malformed {
                 source: id,
@@ -126,6 +134,30 @@ pub fn parse(sources: &Sources, id: SourceId) -> Document {
         document.push(node);
     }
     document
+}
+
+fn node_from_piece(piece: Piece, source: SourceId) -> Node {
+    match piece {
+        Piece::Text(span) | Piece::Excluded(span) => Node::Opaque {
+            source,
+            span,
+            confidence: ParseConfidence::OpaqueBalanced,
+        },
+        Piece::Construct {
+            kind,
+            span,
+            children,
+        } => Node::Construct {
+            source,
+            span,
+            kind,
+            children: children
+                .into_iter()
+                .map(|piece| node_from_piece(piece, source))
+                .collect(),
+        },
+        Piece::Malformed { kind, span } => Node::Malformed { source, span, kind },
+    }
 }
 
 /// Writes a document as LaTeX in emission order.
@@ -175,6 +207,19 @@ fn emit_construct(kind: EntryToken, bytes: &[u8], out: &mut Vec<u8>) {
             out.extend_from_slice(&bytes[open + 1..bytes.len() - 1]);
         }
         EntryToken::Figure | EntryToken::Table => emit_block(kind, bytes, out),
+    }
+}
+
+fn emit_content(bytes: &[u8], out: &mut Vec<u8>) {
+    for piece in scanner::scan(bytes) {
+        match piece {
+            Piece::Construct { kind, span, .. } => {
+                emit_construct(kind, &bytes[span.start()..span.end()], out);
+            }
+            Piece::Text(span) | Piece::Excluded(span) | Piece::Malformed { span, .. } => {
+                out.extend_from_slice(&bytes[span.start()..span.end()]);
+            }
+        }
     }
 }
 
@@ -275,15 +320,15 @@ fn emit_block(token: EntryToken, bytes: &[u8], out: &mut Vec<u8>) {
     }
     if let Some(caption) = field(b"caption") {
         out.extend_from_slice(b"  \\caption{");
-        copy_value(bytes, caption.value, true, out);
+        emit_braced_content(bytes, caption.value, out);
         out.extend_from_slice(b"}\n");
     }
     if let Some(body) = field(b"body") {
-        copy_value(bytes, body.value, true, out);
+        emit_braced_content(bytes, body.value, out);
         out.push(b'\n');
     }
     if let Some(trailing) = field(b"trailing") {
-        copy_value(bytes, trailing.value, true, out);
+        emit_braced_content(bytes, trailing.value, out);
         out.push(b'\n');
     }
     out.extend_from_slice(b"  \\label{");
@@ -291,6 +336,11 @@ fn emit_block(token: EntryToken, bytes: &[u8], out: &mut Vec<u8>) {
     out.extend_from_slice(b"}\n\\end{");
     out.extend_from_slice(environment);
     out.push(b'}');
+}
+
+fn emit_braced_content(bytes: &[u8], value: Value, out: &mut Vec<u8>) {
+    let span = value.span();
+    emit_content(&bytes[span.start() + 1..span.end() - 1], out);
 }
 
 fn emit_percentage(bytes: &[u8], span: source::Span, out: &mut Vec<u8>) {

--- a/crates/nextex-core/src/scanner.rs
+++ b/crates/nextex-core/src/scanner.rs
@@ -75,7 +75,7 @@ pub const DEFAULT_VERBATIM_ENVIRONMENTS: &[&str] = &[
 ];
 
 /// A stretch of the source, classified.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Piece {
     /// Prose: bytes in which a construct would have been recognised, and none
     /// was.
@@ -92,6 +92,11 @@ pub enum Piece {
         kind: EntryToken,
         /// The whole construct, entry token through closing delimiter.
         span: Span,
+        /// Constructs recognised inside this construct's document content.
+        ///
+        /// Typed block fields use this to keep their outer boundary as one
+        /// piece while exposing constructs in braced values.
+        children: Vec<Piece>,
     },
     /// An entry token whose construct could not be closed.
     ///
@@ -220,6 +225,7 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                             Ok(block) => Piece::Construct {
                                 kind: token,
                                 span: block.span,
+                                children: block_children(bytes, &block),
                             },
                             Err(_) => Piece::Malformed {
                                 kind: token,
@@ -255,6 +261,7 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                             Piece::Construct {
                                 kind: token,
                                 span: span(at, close + 1),
+                                children: Vec::new(),
                             },
                             close + 1,
                         ),
@@ -396,6 +403,7 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                     pieces.push(Piece::Construct {
                         kind: EntryToken::Raw,
                         span: span(text_start, at),
+                        children: Vec::new(),
                     });
                     text_start = at;
                     region = Region::Prose;
@@ -423,6 +431,66 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
     }
 
     pieces
+}
+
+fn block_children(bytes: &[u8], block: &crate::blocks::Block) -> Vec<Piece> {
+    block
+        .fields
+        .iter()
+        .filter_map(|field| match field.value {
+            crate::blocks::Value::Braced(value) => Some(value),
+            _ => None,
+        })
+        .flat_map(|value| {
+            let start = value.start() + 1;
+            scan(&bytes[start..value.end() - 1])
+                .into_iter()
+                .map(move |piece| piece.shifted(start))
+        })
+        .collect()
+}
+
+impl Piece {
+    fn shifted(self, by: usize) -> Self {
+        let shift = |span: Span| span_at(span.start() + by, span.end() + by);
+        match self {
+            Self::Text(span) => Self::Text(shift(span)),
+            Self::Excluded(span) => Self::Excluded(shift(span)),
+            Self::Construct {
+                kind,
+                span,
+                children,
+            } => Self::Construct {
+                kind,
+                span: shift(span),
+                children: children
+                    .into_iter()
+                    .map(|child| child.shifted(by))
+                    .collect(),
+            },
+            Self::Malformed { kind, span } => Self::Malformed {
+                kind,
+                span: shift(span),
+            },
+        }
+    }
+
+    /// Visits this piece and every nested piece in source order.
+    pub fn walk(&self, visit: &mut impl FnMut(&Self)) {
+        visit(self);
+        if let Self::Construct { children, .. } = self {
+            for child in children {
+                child.walk(visit);
+            }
+        }
+    }
+}
+
+fn span_at(start: usize, end: usize) -> Span {
+    Span::new(
+        u32::try_from(start).unwrap_or(u32::MAX),
+        u32::try_from(end).unwrap_or(u32::MAX),
+    )
 }
 
 /// The block kind an entry token opens, if it opens one.
@@ -901,12 +969,12 @@ mod tests {
     }
 
     /// Where a piece sits, whatever kind it is.
-    fn extent(piece: Piece) -> Span {
+    fn extent(piece: &Piece) -> Span {
         match piece {
             Piece::Text(s)
             | Piece::Excluded(s)
             | Piece::Construct { span: s, .. }
-            | Piece::Malformed { span: s, .. } => s,
+            | Piece::Malformed { span: s, .. } => *s,
         }
     }
 
@@ -939,7 +1007,7 @@ mod tests {
                 let slice = &input[..cut];
                 let mut next = 0usize;
                 for piece in scan(slice) {
-                    let span = extent(piece);
+                    let span = extent(&piece);
                     assert_eq!(
                         span.start(),
                         next,
@@ -962,13 +1030,15 @@ mod tests {
     }
 
     fn constructs(bytes: &[u8]) -> Vec<EntryToken> {
-        scan(bytes)
-            .into_iter()
-            .filter_map(|p| match p {
-                Piece::Construct { kind, .. } => Some(kind),
-                _ => None,
-            })
-            .collect()
+        let mut found = Vec::new();
+        for piece in scan(bytes) {
+            piece.walk(&mut |piece| {
+                if let Piece::Construct { kind, .. } = piece {
+                    found.push(*kind);
+                }
+            });
+        }
+        found
     }
 
     #[test]

--- a/crates/nextex-core/src/symbols.rs
+++ b/crates/nextex-core/src/symbols.rs
@@ -97,13 +97,13 @@ impl SymbolTable {
     /// imported file: the scope is the root, so the two share one namespace and
     /// a clash between them is a real clash.
     pub fn merge(&mut self, sources: &Sources, document: &Document) {
-        for node in document.iter() {
+        document.walk(|node| {
             let (kind, construct) = match node {
                 Node::Construct { kind, span, .. } => (*kind, *span),
-                _ => continue,
+                _ => return,
             };
             let Some(payload) = payload_of(sources, node.source(), construct, kind) else {
-                continue;
+                return;
             };
             match kind {
                 EntryToken::Cite => {
@@ -112,7 +112,7 @@ impl SymbolTable {
                     let keys = keys_of(sources, payload);
                     if keys.is_empty() {
                         self.errors.push(SymbolError::Malformed { construct });
-                        continue;
+                        return;
                     }
                     for key in keys {
                         self.references.push((
@@ -127,11 +127,11 @@ impl SymbolTable {
                 }
                 EntryToken::Id | EntryToken::Figure | EntryToken::Table => {
                     let Some(text) = text_of(sources, payload) else {
-                        continue;
+                        return;
                     };
                     if !is_identifier(text.as_bytes()) {
                         self.errors.push(SymbolError::Malformed { construct });
-                        continue;
+                        return;
                     }
                     if let Some(first) = self.declarations.get(&text) {
                         self.errors.push(SymbolError::Duplicate {
@@ -139,18 +139,18 @@ impl SymbolTable {
                             first: first.construct,
                             second: construct,
                         });
-                        continue;
+                        return;
                     }
                     self.declarations
                         .insert(text, Declaration { payload, construct });
                 }
                 EntryToken::Ref => {
                     let Some(text) = text_of(sources, payload) else {
-                        continue;
+                        return;
                     };
                     if text.is_empty() {
                         self.errors.push(SymbolError::Malformed { construct });
-                        continue;
+                        return;
                     }
                     self.references.push((
                         text,
@@ -163,7 +163,7 @@ impl SymbolTable {
                 }
                 _ => {}
             }
-        }
+        });
     }
 
     /// Declaration of `name`, if one exists.

--- a/crates/nextex-core/tests/fixtures.rs
+++ b/crates/nextex-core/tests/fixtures.rs
@@ -108,10 +108,7 @@ fn fixtures_without_constructs_transport_byte_identical() {
         let name = label(&input);
         let raw = fs::read(&input).unwrap_or_else(|e| panic!("{name}: cannot read ({e})"));
 
-        if scan(&raw)
-            .iter()
-            .any(|piece| matches!(piece, Piece::Construct { .. }))
-        {
+        if has_construct(&raw) {
             continue;
         }
 
@@ -145,10 +142,7 @@ fn every_construct_free_truncation_transports_byte_identical() {
 
         for cut in 0..=raw.len() {
             let slice = &raw[..cut];
-            if scan(slice)
-                .iter()
-                .any(|piece| matches!(piece, Piece::Construct { .. }))
-            {
+            if has_construct(slice) {
                 continue;
             }
             let mut store = Memory::new().with_input(name.clone(), slice.to_vec());
@@ -276,14 +270,23 @@ fn declared_pieces(expect: &str, name: &str) -> Vec<String> {
 
 /// The pieces the scanner produced, named as `expect.txt` names them.
 fn found_pieces(bytes: &[u8]) -> Vec<String> {
-    scan(bytes)
-        .into_iter()
-        .filter_map(|piece| match piece {
-            Piece::Construct { kind, .. } => Some(short(kind)),
-            Piece::Malformed { kind, .. } => Some(format!("!{}", short(kind))),
-            Piece::Text(_) | Piece::Excluded(_) => None,
-        })
-        .collect()
+    let mut found = Vec::new();
+    for piece in scan(bytes) {
+        piece.walk(&mut |piece| match piece {
+            Piece::Construct { kind, .. } => found.push(short(*kind)),
+            Piece::Malformed { kind, .. } => found.push(format!("!{}", short(*kind))),
+            Piece::Text(_) | Piece::Excluded(_) => {}
+        });
+    }
+    found
+}
+
+fn has_construct(bytes: &[u8]) -> bool {
+    scan(bytes).iter().any(|piece| {
+        let mut found = false;
+        piece.walk(&mut |piece| found |= matches!(piece, Piece::Construct { .. }));
+        found
+    })
 }
 
 fn short(kind: nextex_core::scanner::EntryToken) -> String {

--- a/tests/fixtures/emission/06-constructs-in-block-fields/emitted.tex
+++ b/tests/fixtures/emission/06-constructs-in-block-fields/emitted.tex
@@ -1,0 +1,17 @@
+BEFORE
+\begin{figure}
+  \centering
+  \includegraphics{@ref(not-a-reference).pdf}
+  \caption{Scalar path, nested \cite{figure-source}}
+  \label{fig:scalar}
+\end{figure}
+BETWEEN
+\begin{table}
+  \centering
+  \caption{Results for \cite{knuth1984}; \textbf{@cite(hidden-command)}; \verb|@cite(hidden-verb)|; $@cite(hidden-math)$; % @cite(hidden-comment)
+continued}
+row for \ref{fig:a}
+tail \ref{tab:x}
+  \label{tab:x}
+\end{table}
+AFTER \ref{sec:after}

--- a/tests/fixtures/emission/06-constructs-in-block-fields/expect.txt
+++ b/tests/fixtures/emission/06-constructs-in-block-fields/expect.txt
@@ -1,0 +1,3 @@
+transport: lowered
+scanner: figure cite table cite ref ref ref
+constructs: figure(fig:scalar) contains cite(figure-source), while its scalar src contains no construct; table(tab:x) contains cite(knuth1984), ref(fig:a), and ref(tab:x); ref(sec:after) remains after the block; tokens in a command argument, verbatim, math, and a comment remain ordinary text

--- a/tests/fixtures/emission/06-constructs-in-block-fields/input.ntex
+++ b/tests/fixtures/emission/06-constructs-in-block-fields/input.ntex
@@ -1,0 +1,13 @@
+BEFORE
+\figure(fig:scalar) {
+  src = "@ref(not-a-reference).pdf"
+  caption = {Scalar path, nested @cite(figure-source)}
+}
+BETWEEN
+\table(tab:x) {
+  caption = {Results for @cite(knuth1984); \textbf{@cite(hidden-command)}; \verb|@cite(hidden-verb)|; $@cite(hidden-math)$; % @cite(hidden-comment)
+continued}
+  body = {row for @ref(fig:a)}
+  trailing = {tail @ref(tab:x)}
+}
+AFTER @ref(sec:after)


### PR DESCRIPTION
Closes #36.

## The defect, on the file that motivated it

```
$ nextex symbols tests/experiments/coverage/annotated.ntex
  citations   ["hogan2021knowledge", "hogan2021knowledge",
               "hogan2021knowledge", "bordes2013translating"]
```

Four, which is what the file contains. Before this it reported two: the citations living inside a table's `caption` and `body` were invisible — unchecked, unresolved, and out of reach of a future rename.

## Recognition inside a field obeys §8 like anywhere else

```
\table(t) {
  caption = {Results for @cite(knuth1984);      ← found
             \textbf{@cite(hidden-command)};    ← command argument, ordinary text
             \verb|@cite(hidden-verb)|;         ← verbatim, ordinary text
             $@cite(hidden-math)$;              ← math, ordinary text
             % @cite(hidden-comment)            ← comment, ordinary text
             continued}
  body = {row for @ref(fig:a)}                  ← found
}
```

Scalar fields — `src`, `width`, `height` — are not scanned at all, so `src = "@ref(not-a-reference).pdf"` stays a path.

## The boundary is untouched

Brace counting finds where the block ends; that is separate from what is recognised within it. The boundary is found at the same offset before and after, and a construct following a block is still recognised at the same position.

Verified on the built artefact, not the diff — seven shapes, each with a construct *after* the block so that a change swallowing its surroundings would fail:

```
ok  nested cite in caption           ok  comment inside a body
ok  scalar field is not scanned      ok  math inside a caption
ok  verb inside a caption            ok  command argument inside a caption
ok  block with no nested construct
```

## A correction to the issue text

The issue said nested constructs were "not counted in coverage". They were, and are. `checking.md` §5 computes coverage byte-weighted over the document, and the outer typed block already counts its whole span as modelled — so recognising its children does not move the percentage. What they change is what can be **checked and renamed**, which is the actual value.

Caught by the agent implementing it, reading the specification against my prompt.

## Checks

97 tests pass, clippy clean at `-D warnings`, `cargo fmt --check` clean. Transport still byte-identical at every truncation, and the emission fixture pins exact output with sentinel bytes before, between and after.