### PR TITLE
Check entity classes, and report what was checked

### DIFF
--- a/crates/nextex-cli/src/main.rs
+++ b/crates/nextex-cli/src/main.rs
@@ -9,6 +9,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
+use nextex_core::bibliography::{Bibliography, Unavailable, assemble, declared_in};
+use nextex_core::check::{Diagnostic, check};
 use nextex_core::document::Node;
 use nextex_core::io::{IoError, OutputSink, SourceLoader};
 use nextex_core::scanner::EntryToken;
@@ -97,14 +99,18 @@ impl OutputSink for BuildDirectory {
 }
 
 fn main() -> ExitCode {
-    let mut args = std::env::args().skip(1);
-    let Some(input) = args.next() else {
-        eprintln!("usage: nextex <file.ntex>");
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let Some(first) = args.first() else {
+        eprintln!("usage: nextex <file.ntex> | nextex check [--json] [--strict-tex] <file.ntex>");
         eprintln!();
         eprintln!("Emits the file and its imports as LaTeX under build/.");
         return ExitCode::from(2);
     };
 
+    if first == "check" {
+        return check_command(&args[1..]);
+    }
+    let input = first;
     let loader = FileSystem {
         root: PathBuf::from("."),
     };
@@ -112,7 +118,7 @@ fn main() -> ExitCode {
         root: PathBuf::from("build"),
     };
 
-    match build(&input, &loader, &mut sink) {
+    match build(input, &loader, &mut sink) {
         Ok(()) => {
             let mut output = PathBuf::from(&input);
             output.set_extension("tex");
@@ -124,6 +130,168 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+fn check_command(args: &[String]) -> ExitCode {
+    let json = args.iter().any(|arg| arg == "--json");
+    let strict = args.iter().any(|arg| arg == "--strict-tex");
+    let inputs: Vec<&str> = args
+        .iter()
+        .filter(|arg| !arg.starts_with("--"))
+        .map(String::as_str)
+        .collect();
+    if inputs.len() != 1 {
+        eprintln!("usage: nextex check [--json] [--strict-tex] <file.ntex>");
+        return ExitCode::from(2);
+    }
+
+    match run_check(inputs[0]) {
+        Ok((sources, diagnostics, coverage, bibliography)) => {
+            if json {
+                print_json(&sources, &diagnostics, coverage);
+            } else {
+                for diagnostic in &diagnostics {
+                    print_human(&sources, diagnostic);
+                }
+                if strict {
+                    if let Bibliography::Unavailable(reason) = bibliography {
+                        print_bibliography_advisory(&reason);
+                    }
+                }
+                println!("coverage: {:.1}%", coverage * 100.0);
+            }
+            if diagnostics.is_empty() {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }
+        Err(error) => {
+            eprintln!("fatal: {error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography), IoError> {
+    let loader = FileSystem {
+        root: PathBuf::from("."),
+    };
+    let mut sources = Sources::new();
+    let root_id = loader.load(root, None, &mut sources)?;
+    let document = parse(&sources, root_id);
+    let mut table = nextex_core::symbols::SymbolTable::new();
+    table.merge(&sources, &document);
+
+    let declared = declared_in(&sources, root_id);
+    let base = Path::new(root).parent().unwrap_or_else(|| Path::new("."));
+    let bibliography = assemble(&declared, |name| fs::read(base.join(name)).ok());
+    let diagnostics = check(&table, &bibliography);
+    let coverage = document.coverage();
+    Ok((sources, diagnostics, coverage, bibliography))
+}
+
+fn location(
+    sources: &Sources,
+    source: SourceId,
+    span: nextex_core::source::Span,
+) -> (&str, usize, usize) {
+    let Some(source) = sources.get(source) else {
+        return ("<unresolved>", 1, 1);
+    };
+    let before = &source.bytes()[..span.start().min(source.bytes().len())];
+    #[allow(clippy::naive_bytecount)]
+    let line = before.iter().filter(|byte| **byte == b'\n').count() + 1;
+    let column = before
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(before.len() + 1, |at| before.len() - at);
+    (source.name(), line, column)
+}
+
+fn print_human(sources: &Sources, diagnostic: &Diagnostic) {
+    let (file, line, column) = location(sources, diagnostic.source, diagnostic.span);
+    println!("error[{}]: {}", diagnostic.code, diagnostic.message);
+    println!("  --> {file}:{line}:{column}");
+    println!("  entity: {}", diagnostic.entity.name());
+    if let Some(name) = &diagnostic.name {
+        println!("  name: {name}");
+    }
+    println!(
+        "  span: offset {}, length {}",
+        diagnostic.span.start(),
+        diagnostic.span.len()
+    );
+    for related in &diagnostic.related {
+        let (file, line, column) = location(sources, related.source, related.span);
+        println!("  --> {file}:{line}:{column}: {}", related.message);
+    }
+    println!("  blame: nextex-construct");
+}
+
+fn print_json(sources: &Sources, diagnostics: &[Diagnostic], coverage: f64) {
+    print!("{{\"coverage\":{coverage},\"diagnostics\":[");
+    for (index, diagnostic) in diagnostics.iter().enumerate() {
+        if index > 0 {
+            print!(",");
+        }
+        let (file, line, column) = location(sources, diagnostic.source, diagnostic.span);
+        print!(
+            "{{\"code\":\"{}\",\"severity\":\"error\",\"blame\":\"nextex-construct\",\"entity\":\"{}\",\"name\":",
+            diagnostic.code,
+            diagnostic.entity.name()
+        );
+        match &diagnostic.name {
+            Some(name) => print_json_string(name),
+            None => print!("null"),
+        }
+        print!(",\"span\":{{\"file\":");
+        print_json_string(file);
+        print!(
+            ",\"offset\":{},\"length\":{},\"line\":{line},\"column\":{column}}},\"message\":",
+            diagnostic.span.start(),
+            diagnostic.span.len()
+        );
+        print_json_string(&diagnostic.message);
+        print!(",\"related\":[");
+        for (related_index, related) in diagnostic.related.iter().enumerate() {
+            if related_index > 0 {
+                print!(",");
+            }
+            let (file, line, column) = location(sources, related.source, related.span);
+            print!("{{\"span\":{{\"file\":");
+            print_json_string(file);
+            print!(
+                ",\"offset\":{},\"length\":{},\"line\":{line},\"column\":{column}}},\"message\":",
+                related.span.start(),
+                related.span.len()
+            );
+            print_json_string(&related.message);
+            print!("}}");
+        }
+        print!("]}}");
+    }
+    println!("]}}");
+}
+
+fn print_json_string(value: &str) {
+    print!("\"");
+    for character in value.chars() {
+        match character {
+            '\"' => print!("\\\""),
+            '\\' => print!("\\\\"),
+            '\n' => print!("\\n"),
+            '\r' => print!("\\r"),
+            '\t' => print!("\\t"),
+            character if character.is_control() => print!("\\u{:04x}", character as u32),
+            character => print!("{character}"),
+        }
+    }
+    print!("\"");
+}
+
+fn print_bibliography_advisory(reason: &Unavailable) {
+    println!("advisory: citation checking unavailable ({reason:?})");
 }
 
 fn build(root: &str, loader: &FileSystem, sink: &mut BuildDirectory) -> Result<(), BuildError> {

--- a/crates/nextex-core/src/check.rs
+++ b/crates/nextex-core/src/check.rs
@@ -1,0 +1,169 @@
+//! Hard diagnostics substantiated by explicit NextTeX constructs.
+
+use crate::bibliography::{Bibliography, missing_citations};
+use crate::source::{SourceId, Span};
+use crate::symbols::{EntityClass, SymbolError, SymbolTable};
+
+/// A location used to explain a diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Related {
+    /// Source holding the bytes.
+    pub source: SourceId,
+    /// Bytes being referred to.
+    pub span: Span,
+    /// One sentence without a trailing period.
+    pub message: String,
+}
+
+/// One checker finding, independent of its human or JSON rendering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    /// Stable checker code.
+    pub code: &'static str,
+    /// Entity involved in the finding.
+    pub entity: EntityClass,
+    /// Identifier or citation key, when there is one.
+    pub name: Option<String>,
+    /// Source holding the primary span.
+    pub source: SourceId,
+    /// Primary bytes at fault.
+    pub span: Span,
+    /// One sentence without a trailing period.
+    pub message: String,
+    /// Locations that explain the primary finding.
+    pub related: Vec<Related>,
+}
+
+/// Runs the checks whose evidence is already assembled for one document root.
+#[must_use]
+pub fn check(table: &SymbolTable, bibliography: &Bibliography) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    for error in table.errors() {
+        match error {
+            SymbolError::Duplicate {
+                name,
+                first,
+                first_source,
+                second,
+                second_source,
+            } => {
+                let Some(declaration) = table.declaration(name) else {
+                    continue;
+                };
+                diagnostics.push(Diagnostic {
+                    code: "NT1001",
+                    entity: declaration.class,
+                    name: Some(name.clone()),
+                    source: *second_source,
+                    span: *second,
+                    message: format!("identifier `{name}` is already declared"),
+                    related: vec![Related {
+                        source: *first_source,
+                        span: *first,
+                        message: "first declared here".to_owned(),
+                    }],
+                });
+            }
+            SymbolError::Malformed { source, construct } => diagnostics.push(Diagnostic {
+                code: "NT1002",
+                entity: EntityClass::UnknownOpen,
+                name: None,
+                source: *source,
+                span: *construct,
+                message: "identifier is empty or contains unsupported bytes".to_owned(),
+                related: Vec::new(),
+            }),
+        }
+    }
+    for (name, reference) in table.unresolved_references() {
+        diagnostics.push(Diagnostic {
+            code: "NT1003",
+            entity: super::symbols::demand_of(name),
+            name: Some(name.to_owned()),
+            source: reference.payload.source,
+            span: reference.payload.span,
+            message: format!("identifier `{name}` is not declared"),
+            related: Vec::new(),
+        });
+    }
+    for (name, reference, demand, declaration) in table.inconsistent_references() {
+        diagnostics.push(Diagnostic {
+            code: "NT1004",
+            entity: demand,
+            name: Some(name.to_owned()),
+            source: reference.payload.source,
+            span: reference.payload.span,
+            message: format!(
+                "reference `{name}` requires {}, but its target is {}",
+                demand.name(),
+                declaration.class.name()
+            ),
+            related: vec![Related {
+                source: declaration.payload.source,
+                span: declaration.payload.span,
+                message: format!("{} declared here", declaration.class.name()),
+            }],
+        });
+    }
+    for (key, reference) in missing_citations(table, bibliography) {
+        diagnostics.push(Diagnostic {
+            code: "NT1005",
+            entity: EntityClass::Citation,
+            name: Some(key.to_owned()),
+            source: reference.payload.source,
+            span: reference.payload.span,
+            message: format!("citation key `{key}` is not in the bibliography"),
+            related: Vec::new(),
+        });
+    }
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+    use crate::bibliography::Unavailable;
+    use crate::parse;
+    use crate::source::Sources;
+
+    fn diagnostics(source: &str, bibliography: &Bibliography) -> Vec<Diagnostic> {
+        let mut sources = Sources::new();
+        let id = sources.add("main.ntex", source.as_bytes().to_vec());
+        let document = parse(&sources, id);
+        let mut table = SymbolTable::new();
+        table.merge(&sources, &document);
+        check(&table, bibliography)
+    }
+
+    #[test]
+    fn ordinary_latex_with_unresolved_names_has_no_errors() {
+        let found = diagnostics(
+            "See \\ref{missing} and \\cite{invented}.",
+            &Bibliography::Complete(BTreeSet::default()),
+        );
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn an_unreadable_bibliography_silences_missing_citations() {
+        let found = diagnostics(
+            "@cite(invented)",
+            &Bibliography::Unavailable(Unavailable::Unreadable {
+                name: "missing.bib".to_owned(),
+            }),
+        );
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn a_complete_bibliography_substantiates_a_missing_citation() {
+        let found = diagnostics(
+            "@cite(invented)",
+            &Bibliography::Complete(BTreeSet::default()),
+        );
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].code, "NT1005");
+    }
+}

--- a/crates/nextex-core/src/lib.rs
+++ b/crates/nextex-core/src/lib.rs
@@ -44,6 +44,7 @@
 
 pub mod bibliography;
 pub mod blocks;
+pub mod check;
 pub mod document;
 pub mod io;
 pub mod scanner;

--- a/crates/nextex-core/src/symbols.rs
+++ b/crates/nextex-core/src/symbols.rs
@@ -21,6 +21,50 @@ use crate::document::{Document, Node};
 use crate::scanner::EntryToken;
 use crate::source::{SourceId, Sources, Span};
 
+/// The class of a declared entity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EntityClass {
+    /// Unmodelled LaTeX, consistent with every known class.
+    UnknownOpen,
+    /// A typed figure or an annotation attached to a figure.
+    Figure,
+    /// A typed table or an annotation attached to a table.
+    Table,
+    /// A displayed equation.
+    Equation,
+    /// A sectioning command, including an appendix.
+    Section,
+    /// An algorithm environment.
+    Algorithm,
+    /// A citation key.
+    Citation,
+}
+
+impl EntityClass {
+    /// Whether two classes can safely be used together.
+    #[must_use]
+    pub const fn is_consistent_with(self, other: Self) -> bool {
+        matches!(self, Self::UnknownOpen)
+            || matches!(other, Self::UnknownOpen)
+            || self as u8 == other as u8
+    }
+
+    /// Stable spelling used by diagnostics.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::UnknownOpen => "unknown-open",
+            Self::Figure => "figure",
+            Self::Table => "table",
+            Self::Equation => "equation",
+            Self::Section => "section",
+            Self::Algorithm => "algorithm",
+            Self::Citation => "citation",
+        }
+    }
+}
+
 /// The text a construct carries between its parentheses.
 ///
 /// Borrowed from the source rather than copied, because the source outlives the
@@ -40,6 +84,8 @@ pub struct Declaration {
     pub payload: Payload,
     /// The whole `@id(...)` construct, which is what a diagnostic points at.
     pub construct: Span,
+    /// What the declaration names, or the open unknown class for unmodelled LaTeX.
+    pub class: EntityClass,
 }
 
 /// A use of a name, by `@ref` or `@cite`.
@@ -66,11 +112,17 @@ pub enum SymbolError {
         name: String,
         /// The `@id` that declared it first.
         first: Span,
+        /// Source holding the first declaration.
+        first_source: SourceId,
         /// The `@id` being rejected.
         second: Span,
+        /// Source holding the rejected declaration.
+        second_source: SourceId,
     },
     /// An identifier is empty, or contains bytes an identifier may not.
     Malformed {
+        /// Source holding the construct.
+        source: SourceId,
         /// The construct at fault.
         construct: Span,
     },
@@ -111,7 +163,10 @@ impl SymbolTable {
                     // naming that key rather than the whole construct.
                     let keys = keys_of(sources, payload);
                     if keys.is_empty() {
-                        self.errors.push(SymbolError::Malformed { construct });
+                        self.errors.push(SymbolError::Malformed {
+                            source: node.source(),
+                            construct,
+                        });
                         return;
                     }
                     for key in keys {
@@ -130,26 +185,46 @@ impl SymbolTable {
                         return;
                     };
                     if !is_identifier(text.as_bytes()) {
-                        self.errors.push(SymbolError::Malformed { construct });
+                        self.errors.push(SymbolError::Malformed {
+                            source: node.source(),
+                            construct,
+                        });
                         return;
                     }
                     if let Some(first) = self.declarations.get(&text) {
                         self.errors.push(SymbolError::Duplicate {
                             name: text,
                             first: first.construct,
+                            first_source: first.payload.source,
                             second: construct,
+                            second_source: node.source(),
                         });
                         return;
                     }
-                    self.declarations
-                        .insert(text, Declaration { payload, construct });
+                    let class = match kind {
+                        EntryToken::Figure => EntityClass::Figure,
+                        EntryToken::Table => EntityClass::Table,
+                        EntryToken::Id => attached_class(sources, payload.source, construct),
+                        _ => EntityClass::UnknownOpen,
+                    };
+                    self.declarations.insert(
+                        text,
+                        Declaration {
+                            payload,
+                            construct,
+                            class,
+                        },
+                    );
                 }
                 EntryToken::Ref => {
                     let Some(text) = text_of(sources, payload) else {
                         return;
                     };
                     if text.is_empty() {
-                        self.errors.push(SymbolError::Malformed { construct });
+                        self.errors.push(SymbolError::Malformed {
+                            source: node.source(),
+                            construct,
+                        });
                         return;
                     }
                     self.references.push((
@@ -196,10 +271,102 @@ impl SymbolTable {
         })
     }
 
+    /// References whose known prefix contradicts their known target class.
+    pub fn inconsistent_references(
+        &self,
+    ) -> impl Iterator<Item = (&str, &Reference, EntityClass, &Declaration)> {
+        self.references.iter().filter_map(|(name, reference)| {
+            if reference.kind != EntryToken::Ref {
+                return None;
+            }
+            let demand = demand_of(name);
+            let declaration = self.declarations.get(name)?;
+            (!demand.is_consistent_with(declaration.class)).then_some((
+                name.as_str(),
+                reference,
+                demand,
+                declaration,
+            ))
+        })
+    }
+
     /// Problems found while building the table.
     pub fn errors(&self) -> impl Iterator<Item = &SymbolError> {
         self.errors.iter()
     }
+}
+
+/// Class demanded by the prefix before the first colon.
+#[must_use]
+pub fn demand_of(name: &str) -> EntityClass {
+    let Some((prefix, _)) = name.split_once(':') else {
+        return EntityClass::UnknownOpen;
+    };
+    match prefix {
+        "fig" => EntityClass::Figure,
+        "tab" => EntityClass::Table,
+        "sec" | "subsec" | "ch" | "app" => EntityClass::Section,
+        "alg" => EntityClass::Algorithm,
+        "eq" => EntityClass::Equation,
+        _ => EntityClass::UnknownOpen,
+    }
+}
+
+fn attached_class(sources: &Sources, source: SourceId, construct: Span) -> EntityClass {
+    let Some(bytes) = sources.get(source).map(crate::source::Source::bytes) else {
+        return EntityClass::UnknownOpen;
+    };
+    let mut start = construct.start();
+    let mut lines = 0usize;
+    while start > 0 && construct.start() - start < 256 && bytes[start - 1].is_ascii_whitespace() {
+        start -= 1;
+        if bytes[start] == b'\n' {
+            lines += 1;
+            if lines > 2 {
+                return EntityClass::UnknownOpen;
+            }
+        }
+    }
+    let before = &bytes[..start];
+    if before.ends_with(b"\\]") || before.ends_with(b"$$") {
+        return EntityClass::Equation;
+    }
+    for command in [
+        b"\\section".as_slice(),
+        b"\\subsection",
+        b"\\subsubsection",
+        b"\\chapter",
+        b"\\part",
+    ] {
+        if last_command_with_balanced_argument(before, command) {
+            return EntityClass::Section;
+        }
+    }
+    for (environment, class) in [
+        ("algorithm", EntityClass::Algorithm),
+        ("figure", EntityClass::Figure),
+        ("table", EntityClass::Table),
+        ("equation", EntityClass::Equation),
+        ("align", EntityClass::Equation),
+        ("gather", EntityClass::Equation),
+        ("multline", EntityClass::Equation),
+    ] {
+        let opening = format!("\\begin{{{environment}}}");
+        if before.ends_with(opening.as_bytes())
+            || before.ends_with(format!("\\begin{{{environment}*}}").as_bytes())
+        {
+            return class;
+        }
+    }
+    EntityClass::UnknownOpen
+}
+
+fn last_command_with_balanced_argument(bytes: &[u8], command: &[u8]) -> bool {
+    let Some(open) = bytes.iter().rposition(|byte| *byte == b'{') else {
+        return false;
+    };
+    bytes[..open].ends_with(command)
+        && crate::scanner::balanced_end(bytes, open) == Some(bytes.len())
 }
 
 /// The span between `(` and `)` of a construct covering `construct`.
@@ -433,5 +600,39 @@ mod tests {
             "% @id(commented)\n$@id(math)$\n\\begin{verbatim}\n@id(verb)\n\\end{verbatim}\n@id(real)",
         )]);
         assert_eq!(t.declared().collect::<Vec<_>>(), ["real"]);
+    }
+
+    #[test]
+    fn typed_blocks_retain_their_classes() {
+        let (_, t) = table(&[("a.ntex", "\\figure(fig:x) { caption = {X} }")]);
+        assert_eq!(t.declaration("fig:x").unwrap().class, EntityClass::Figure);
+    }
+
+    #[test]
+    fn an_id_takes_a_known_attachment_class() {
+        let (_, t) = table(&[("a.ntex", "\\section{X}\n@id(sec:x)")]);
+        assert_eq!(t.declaration("sec:x").unwrap().class, EntityClass::Section);
+    }
+
+    #[test]
+    fn an_id_on_unmodelled_latex_is_unknown_open() {
+        let (_, t) = table(&[("a.ntex", "\\newtheorem{X}\n@id(fig:x)")]);
+        assert_eq!(
+            t.declaration("fig:x").unwrap().class,
+            EntityClass::UnknownOpen
+        );
+    }
+
+    #[test]
+    fn only_two_known_inconsistent_classes_conflict() {
+        let (_, known) = table(&[("a.ntex", "\\table(fig:x) { caption = {X} } @ref(fig:x)")]);
+        assert_eq!(known.inconsistent_references().count(), 1);
+
+        let (_, unknown_target) = table(&[("a.ntex", "\\newtheorem{X} @id(fig:x) @ref(fig:x)")]);
+        assert_eq!(unknown_target.inconsistent_references().count(), 0);
+
+        let (_, unknown_demand) =
+            table(&[("a.ntex", "\\table(def:x) { caption = {X} } @ref(def:x)")]);
+        assert_eq!(unknown_demand.inconsistent_references().count(), 0);
     }
 }

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -32,7 +32,7 @@ construction, not from care taken case by case.
 Every checked thing has a class:
 
 ```
-Text  Block  Figure  Table  Equation  Section  Citation  Length
+Figure  Table  Section  Appendix  Algorithm  Equation  Citation  Length
 ```
 
 Everything else — every unknown control sequence, every environment the compiler does not model, every


### PR DESCRIPTION
Part of #11. **A slice, not the whole contract** — the gaps are listed at the end.

## The type system has both halves now

The scanner knew `\figure(fig:x)` was a Figure and the symbol table threw it away, because no reference demanded a class and there was nothing to contradict.

```
$ nextex check paper.ntex
error[NT1003]: identifier `nowhere` is not declared
  --> paper.ntex:3:50
  entity: unknown-open
  blame: nextex-construct
error[NT1004]: reference `fig:wrong` requires figure, but its target is table
  --> paper.ntex:3:10
  entity: figure
  name: fig:wrong
  --> paper.ntex:2:8: table declared here
  blame: nextex-construct
coverage: 54.8%
$ echo $?
1
```

`--json` renders the same record with the same fields, per `checking.md` §10 — neither form holds anything the other cannot express.

## The invariant, measured on real files

```
renamed .tex -> check clean:  224 of 224
```

Every `.tex` in your workspace, renamed and checked unaltered, exits 0 with no diagnostic. The unresolved `\ref` and undefined `\cite` in them stay silent because they are ordinary LaTeX — that is the whole point, and it is now evidence rather than an argument.

Comparison is consistency, not equality:

```
Known(Figure) ~ Known(Table)   →  NT1004
Known(Figure) ~ ?O             →  silence
unmapped prefix                →  silence, it demands nothing
```

## A contradiction in my own document, found by the implementer

`checking.md` §2 listed the classes as `Text Block Figure Table Equation Section Citation Length` — while the prose of that same section derives `Algorithm` from `\begin{algorithm}`, and the prefix map three lines below names both `algorithm` and `appendix`.

The list was wrong. It is now the classes actually admitted: `Figure Table Section Appendix Algorithm Equation Citation Length`. `Text` and `Block` were in it and nothing ever declared either.

## What is not wired, named rather than discovered later

| | |
|---|---|
| `NT1001`–`NT1005`, both output forms, exit codes, coverage | wired |
| `NT1006`–`NT1012` | not wired |
| Merging `@import`ed files into one root before checking | not wired |
| Reading a custom `[prefixes]` map from `nextex.toml` | not wired |
| Fixture-level expectation format for checker output | not built — the negative coverage is unit-level |

#11 stays open for those.

## Checks

104 tests pass, clippy clean at `-D warnings`, `cargo fmt --check` clean.