### PR TITLE
Answer an editor: diagnostics, hover, completion, definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,3 +12,10 @@ dependencies = [
 [[package]]
 name = "xtex-core"
 version = "0.0.0"
+
+[[package]]
+name = "xtex-lsp"
+version = "0.0.0"
+dependencies = [
+ "xtex-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/xtex-core", "crates/xtex-cli"]
+members = ["crates/xtex-core", "crates/xtex-cli", "crates/xtex-lsp"]
 # Experiments carry dependencies the compiler must not inherit through the lock
 # file. They are built on their own.
 exclude = ["tests/experiments"]

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ ExactTeX is a document language with LaTeX as its backend. Rename a `.tex` file 
 working — your LaTeX passes through byte for byte. From there you annotate what you want checked, and what
 you annotate is guaranteed.
 
-> **Status: the compiler works; the editor and the browser do not exist yet.** `xtex` parses, checks,
-> emits LaTeX, writes source maps, and applies revisions. There is no language server and no WebAssembly
-> build — those are the next phase. Every claim below is about what is built, and the number beside each is
-> reproducible with the command that produced it.
+> **Status: the compiler and the language server work; the browser does not exist yet.** `xtex` parses,
+> checks, emits LaTeX, writes source maps and applies revisions, and `xtex-lsp` gives an editor diagnostics,
+> hover, completion and go-to-definition. There is no WebAssembly build. Every claim below is about what is
+> built, and each number is reproducible with the command that produced it.
 
 ---
 
@@ -139,6 +139,8 @@ still receives a `.tex` file.
   boundaries, and where constructs are not recognized.
 - [`docs/checking.md`](docs/checking.md) — what the compiler is willing to call an error, and what it
   refuses to: entity classes, the closed list of hard errors, coverage, blame, and the diagnostic fields.
+- [`docs/lsp.md`](docs/lsp.md) — the language server: what it answers, what it deliberately does not,
+  and why the protocol layer holds no logic.
 - [`docs/revisions.md`](docs/revisions.md) — the change model: the four constructs, the three views,
   what accepting rewrites, and what the sidecar holds.
 - [`docs/decisions/`](docs/decisions/) — accepted decisions, one file each, with the evidence behind them.

--- a/crates/xtex-core/src/editor.rs
+++ b/crates/xtex-core/src/editor.rs
@@ -1,0 +1,361 @@
+//! What an editor asks about a position, answered without a protocol.
+//!
+//! An editor asks three questions: what is under the cursor, what may be
+//! written here, and where is this name declared. None of them is about
+//! JSON-RPC, and none of them needs a running server to test.
+//!
+//! Keeping them here rather than in `xtex-lsp` is what makes the phase's exit
+//! criterion provable instead of argued. "The language server and the CLI
+//! report the same thing for the same input" is true by construction when both
+//! call this module, and merely testable by comparison when they do not. See
+//! `docs/decisions/0005`.
+
+use crate::document::{Document, Node};
+use crate::scanner::EntryToken;
+use crate::source::{SourceId, Sources, Span};
+use crate::symbols::{EntityClass, SymbolTable};
+use std::fmt::Write as _;
+
+/// A one-based line and byte column, which is what editors speak.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Position {
+    /// One-based line.
+    pub line: u32,
+    /// One-based byte column.
+    pub column: u32,
+}
+
+/// A construct found under a cursor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Located {
+    /// Which construct it is.
+    pub kind: EntryToken,
+    /// The whole construct, which is what an editor highlights.
+    pub span: Span,
+    /// The identifier or key it carries.
+    pub name: String,
+}
+
+/// What to show when the cursor rests on a construct.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Hover {
+    /// The construct being described.
+    pub span: Span,
+    /// Plain text, one fact per line.
+    pub text: String,
+}
+
+/// Something an editor may offer inside a construct's parentheses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Completion {
+    /// The text to insert.
+    pub label: String,
+    /// What it names, so an editor can group or icon it.
+    pub class: EntityClass,
+    /// Where it is declared, for a one-line preview.
+    pub detail: Option<String>,
+}
+
+/// Byte offset of a one-based line and column.
+///
+/// Returns `None` past the end of the file, which is what an editor sends
+/// while a keystroke is in flight.
+#[must_use]
+pub fn offset_at(bytes: &[u8], position: Position) -> Option<usize> {
+    if position.line == 0 || position.column == 0 {
+        return None;
+    }
+    let mut at = 0usize;
+    for _ in 1..position.line {
+        at += bytes[at..].iter().position(|byte| *byte == b'\n')? + 1;
+    }
+    let end = bytes[at..]
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .map_or(bytes.len(), |line| at + line);
+    let offset = at + (position.column as usize - 1);
+    (offset <= end).then_some(offset)
+}
+
+/// The construct covering `offset`, innermost first.
+///
+/// Innermost, because a `@cite` inside a `\figure` caption is what the cursor
+/// is on; the block around it is context, not the answer.
+#[must_use]
+pub fn construct_at(sources: &Sources, document: &Document, offset: usize) -> Option<Located> {
+    let mut best: Option<Located> = None;
+    // `walk` descends into a block's fields, which is where a citation inside
+    // a caption lives. Iterating the top level only would answer "the table"
+    // for a cursor sitting on the `@cite` inside it.
+    document.walk(|node| {
+        let Node::Construct { kind, span, .. } = node else {
+            return;
+        };
+        if offset < span.start() || offset >= span.end() {
+            return;
+        }
+        let narrower = best
+            .as_ref()
+            .is_none_or(|found| span.end() - span.start() < found.span.end() - found.span.start());
+        if narrower {
+            best = Some(Located {
+                kind: *kind,
+                span: *span,
+                name: payload_text(sources, node.source(), *span).unwrap_or_default(),
+            });
+        }
+    });
+    best
+}
+
+/// What to show for the construct at `offset`.
+///
+/// Every line is a fact the compiler already holds. Nothing here is computed
+/// for the editor's benefit, which is why it cannot drift from what `check`
+/// reports.
+#[must_use]
+pub fn hover(
+    sources: &Sources,
+    document: &Document,
+    table: &SymbolTable,
+    offset: usize,
+) -> Option<Hover> {
+    let located = construct_at(sources, document, offset)?;
+    let mut text = String::new();
+
+    match located.kind {
+        EntryToken::Ref => {
+            let _ = writeln!(text, "@ref({})", located.name);
+            let demanded = table.demand_of(&located.name);
+            if demanded != EntityClass::UnknownOpen {
+                let _ = writeln!(text, "requires: {}", demanded.name());
+            }
+            match table.declaration(&located.name) {
+                Some(declaration) => {
+                    let _ = write!(text, "declared as: {}", declaration.class.name());
+                }
+                // An editor showing nothing here is the common case while the
+                // author is still typing the name, and saying so beats an
+                // empty popup that looks like a broken server.
+                None => text.push_str("not declared in this document root"),
+            }
+        }
+        EntryToken::Cite => {
+            let _ = write!(text, "@cite({})\ncitation key", located.name);
+        }
+        EntryToken::Id | EntryToken::Figure | EntryToken::Table => {
+            let class = table
+                .declaration(&located.name)
+                .map_or(EntityClass::UnknownOpen, |declaration| declaration.class);
+            let _ = write!(text, "{}\ndeclares: {}", located.name, class.name());
+        }
+        EntryToken::Import => {
+            let _ = write!(text, "@import({})\nimported into this root", located.name);
+        }
+        _ => return None,
+    }
+
+    Some(Hover {
+        span: located.span,
+        text,
+    })
+}
+
+/// What may be written at `offset`.
+///
+/// Empty unless the cursor is inside a construct that names something, because
+/// offering every identifier in a document while the author writes prose is
+/// worse than offering nothing.
+#[must_use]
+pub fn completions(
+    sources: &Sources,
+    document: &Document,
+    table: &SymbolTable,
+    offset: usize,
+) -> Vec<Completion> {
+    let Some(located) = construct_at(sources, document, offset) else {
+        return Vec::new();
+    };
+    if located.kind != EntryToken::Ref {
+        return Vec::new();
+    }
+
+    // The prefix already typed is the demand, so a reference that says `fig:`
+    // is offered figures and nothing else. That is the type system paying for
+    // itself in the editor rather than only in the exit code.
+    let demanded = table.demand_of(&located.name);
+    table
+        .declared()
+        .filter_map(|name| {
+            let declaration = table.declaration(name)?;
+            // The same relation the checker uses, not a second copy of it.
+            let compatible = declaration.class.is_consistent_with(demanded);
+            compatible.then(|| Completion {
+                label: name.to_owned(),
+                class: declaration.class,
+                detail: Some(declaration.class.name().to_owned()),
+            })
+        })
+        .collect()
+}
+
+/// Where the name at `offset` is declared.
+#[must_use]
+pub fn definition(
+    sources: &Sources,
+    document: &Document,
+    table: &SymbolTable,
+    offset: usize,
+) -> Option<Span> {
+    let located = construct_at(sources, document, offset)?;
+    Some(table.declaration(&located.name)?.construct)
+}
+
+/// The text between a construct's parentheses.
+fn payload_text(sources: &Sources, source: SourceId, span: Span) -> Option<String> {
+    let bytes = sources.get(source)?.slice(span)?;
+    let open = bytes.iter().position(|byte| *byte == b'(')? + 1;
+    let close = bytes.iter().rposition(|byte| *byte == b')')?;
+    if open > close {
+        return None;
+    }
+    std::str::from_utf8(&bytes[open..close])
+        .ok()
+        .map(|text| text.trim().to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+
+    const DOC: &str = "\\section{Intro} @id(sec:intro)\n\
+                       \\figure(fig:plot) { src = \"p.pdf\" caption = {C} }\n\
+                       See @ref(fig:plot) and @ref(tab:none) and @cite(knuth1984).\n";
+
+    fn document() -> (Sources, Document, SymbolTable) {
+        let mut sources = Sources::new();
+        let id = sources.add("paper.xtex", DOC.as_bytes().to_vec());
+        let document = parse(&sources, id);
+        let mut table = SymbolTable::new();
+        table.merge(&sources, &document);
+        (sources, document, table)
+    }
+
+    fn at(text: &str) -> usize {
+        DOC.find(text).expect("the fixture contains it") + 1
+    }
+
+    #[test]
+    fn a_position_maps_to_the_byte_the_editor_meant() {
+        let bytes = DOC.as_bytes();
+        assert_eq!(offset_at(bytes, Position { line: 1, column: 1 }), Some(0));
+        // Column one of line two is the byte after the first line ending.
+        let second = DOC.find('\n').expect("two lines") + 1;
+        assert_eq!(
+            offset_at(bytes, Position { line: 2, column: 1 }),
+            Some(second)
+        );
+    }
+
+    #[test]
+    fn a_position_past_the_end_is_none_rather_than_clamped() {
+        // An editor sends these while a keystroke is in flight. Clamping would
+        // answer a question about a position that does not exist.
+        let bytes = DOC.as_bytes();
+        assert_eq!(
+            offset_at(
+                bytes,
+                Position {
+                    line: 99,
+                    column: 1
+                }
+            ),
+            None
+        );
+        assert_eq!(
+            offset_at(
+                bytes,
+                Position {
+                    line: 1,
+                    column: 999
+                }
+            ),
+            None
+        );
+        assert_eq!(offset_at(bytes, Position { line: 0, column: 1 }), None);
+    }
+
+    #[test]
+    fn the_construct_under_the_cursor_is_the_innermost_one() {
+        // The cursor is on the caption's own bytes, inside the figure block.
+        // The block is context; the answer is what the cursor is actually on.
+        let mut sources = Sources::new();
+        let text = "\\table(tab:x) { caption = {See @cite(knuth1984)} }";
+        let id = sources.add("a.xtex", text.as_bytes().to_vec());
+        let document = parse(&sources, id);
+        let offset = text.find("@cite").expect("present") + 2;
+        let found = construct_at(&sources, &document, offset).expect("a construct");
+        assert_eq!(found.kind, EntryToken::Cite);
+        assert_eq!(found.name, "knuth1984");
+    }
+
+    #[test]
+    fn hover_on_a_resolved_reference_names_both_sides() {
+        let (sources, document, table) = document();
+        let hover = hover(&sources, &document, &table, at("@ref(fig:plot)")).expect("hover");
+        assert!(hover.text.contains("requires: figure"), "{}", hover.text);
+        assert!(hover.text.contains("declared as: figure"), "{}", hover.text);
+    }
+
+    #[test]
+    fn hover_on_an_unresolved_reference_says_so_rather_than_showing_nothing() {
+        let (sources, document, table) = document();
+        let hover = hover(&sources, &document, &table, at("@ref(tab:none)")).expect("hover");
+        assert!(hover.text.contains("not declared"), "{}", hover.text);
+    }
+
+    #[test]
+    fn hover_outside_a_construct_is_none() {
+        let (sources, document, table) = document();
+        assert!(hover(&sources, &document, &table, at("See ")).is_none());
+    }
+
+    #[test]
+    fn completion_offers_only_what_the_prefix_demands() {
+        // `@ref(tab:` demands a table, and the document declares a figure and a
+        // section. Offering them would be offering an error.
+        let (sources, document, table) = document();
+        let offered: Vec<_> = completions(&sources, &document, &table, at("@ref(tab:none)"))
+            .into_iter()
+            .map(|item| item.label)
+            .collect();
+        assert!(offered.is_empty(), "{offered:?}");
+    }
+
+    #[test]
+    fn completion_offers_the_matching_class() {
+        let (sources, document, table) = document();
+        let offered: Vec<_> = completions(&sources, &document, &table, at("@ref(fig:plot)"))
+            .into_iter()
+            .map(|item| item.label)
+            .collect();
+        assert_eq!(offered, ["fig:plot"]);
+    }
+
+    #[test]
+    fn completion_in_prose_offers_nothing() {
+        // Offering every identifier in the document while someone writes a
+        // sentence is worse than offering nothing.
+        let (sources, document, table) = document();
+        assert!(completions(&sources, &document, &table, at("See ")).is_empty());
+    }
+
+    #[test]
+    fn definition_points_at_the_declaring_construct() {
+        let (sources, document, table) = document();
+        let span = definition(&sources, &document, &table, at("@ref(fig:plot)")).expect("found");
+        let declared = DOC.find("\\figure(fig:plot)").expect("present");
+        assert_eq!(span.start(), declared);
+    }
+}

--- a/crates/xtex-core/src/lib.rs
+++ b/crates/xtex-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod blocks;
 pub mod check;
 pub mod diagnostics;
 pub mod document;
+pub mod editor;
 pub mod io;
 pub mod review;
 pub mod scanner;

--- a/crates/xtex-lsp/Cargo.toml
+++ b/crates/xtex-lsp/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "xtex-lsp"
+description = "The ExactTeX language server: JSON-RPC framing and dispatch, no protocol library."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "xtex-lsp"
+path = "src/main.rs"
+
+[dependencies]
+xtex-core = { path = "../xtex-core" }
+
+[lints]
+workspace = true

--- a/crates/xtex-lsp/src/json.rs
+++ b/crates/xtex-lsp/src/json.rs
@@ -1,0 +1,215 @@
+//! Just enough JSON to speak LSP.
+//!
+//! Not a JSON library and not on its way to becoming one. It reads the handful
+//! of shapes the protocol sends us and writes the handful we send back, and a
+//! message using something outside that is refused rather than guessed at.
+//!
+//! Written by hand for the reason in `docs/decisions/0005`: the compiler core
+//! has no dependencies and the server is small enough to keep it that way.
+
+use std::fmt::Write as _;
+
+/// A parsed JSON value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    /// `null`.
+    Null,
+    /// `true` or `false`.
+    Bool(bool),
+    /// Any number, held as written so an integer survives a round trip.
+    Number(f64),
+    /// A string with its escapes resolved.
+    Text(String),
+    /// An array.
+    List(Vec<Value>),
+    /// An object, in the order its keys arrived.
+    Map(Vec<(String, Value)>),
+}
+
+impl Value {
+    /// The value at `key`, if this is an object that has one.
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<&Self> {
+        match self {
+            Self::Map(entries) => entries
+                .iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value),
+            _ => None,
+        }
+    }
+
+    /// This value as text.
+    #[must_use]
+    pub fn text(&self) -> Option<&str> {
+        match self {
+            Self::Text(text) => Some(text),
+            _ => None,
+        }
+    }
+
+    /// This value as an integer, when it is one.
+    #[must_use]
+    pub fn integer(&self) -> Option<i64> {
+        match self {
+            #[allow(clippy::cast_possible_truncation)]
+            Self::Number(number) if number.fract() == 0.0 => Some(*number as i64),
+            _ => None,
+        }
+    }
+}
+
+/// Parses one JSON value, or `None` if the bytes are not one.
+#[must_use]
+pub fn parse(bytes: &[u8]) -> Option<Value> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    let mut chars: Vec<char> = text.chars().collect();
+    chars.push('\0');
+    let mut at = 0usize;
+    let value = value(&chars, &mut at)?;
+    skip_space(&chars, &mut at);
+    (chars[at] == '\0').then_some(value)
+}
+
+fn skip_space(chars: &[char], at: &mut usize) {
+    while chars[*at].is_ascii_whitespace() {
+        *at += 1;
+    }
+}
+
+fn value(chars: &[char], at: &mut usize) -> Option<Value> {
+    skip_space(chars, at);
+    match chars[*at] {
+        '"' => text(chars, at).map(Value::Text),
+        '{' => map(chars, at),
+        '[' => list(chars, at),
+        't' => literal(chars, at, "true").then_some(Value::Bool(true)),
+        'f' => literal(chars, at, "false").then_some(Value::Bool(false)),
+        'n' => literal(chars, at, "null").then_some(Value::Null),
+        _ => number(chars, at),
+    }
+}
+
+fn literal(chars: &[char], at: &mut usize, word: &str) -> bool {
+    if chars[*at..].starts_with(&word.chars().collect::<Vec<_>>()[..]) {
+        *at += word.len();
+        return true;
+    }
+    false
+}
+
+fn number(chars: &[char], at: &mut usize) -> Option<Value> {
+    let start = *at;
+    while matches!(chars[*at], '0'..='9' | '-' | '+' | '.' | 'e' | 'E') {
+        *at += 1;
+    }
+    (start < *at)
+        .then(|| chars[start..*at].iter().collect::<String>())
+        .and_then(|text| text.parse().ok())
+        .map(Value::Number)
+}
+
+fn text(chars: &[char], at: &mut usize) -> Option<String> {
+    if chars[*at] != '"' {
+        return None;
+    }
+    *at += 1;
+    let mut out = String::new();
+    loop {
+        match chars[*at] {
+            '\0' => return None,
+            '"' => {
+                *at += 1;
+                return Some(out);
+            }
+            '\\' => {
+                *at += 1;
+                let resolved = match chars[*at] {
+                    'n' => '\n',
+                    't' => '\t',
+                    'r' => '\r',
+                    'b' => '\u{8}',
+                    'f' => '\u{c}',
+                    'u' => {
+                        let hex: String = chars.get(*at + 1..*at + 5)?.iter().collect();
+                        let code = u32::from_str_radix(&hex, 16).ok()?;
+                        *at += 4;
+                        char::from_u32(code)?
+                    }
+                    other => other,
+                };
+                out.push(resolved);
+                *at += 1;
+            }
+            other => {
+                out.push(other);
+                *at += 1;
+            }
+        }
+    }
+}
+
+fn list(chars: &[char], at: &mut usize) -> Option<Value> {
+    *at += 1;
+    let mut items = Vec::new();
+    loop {
+        skip_space(chars, at);
+        if chars[*at] == ']' {
+            *at += 1;
+            return Some(Value::List(items));
+        }
+        items.push(value(chars, at)?);
+        skip_space(chars, at);
+        match chars[*at] {
+            ',' => *at += 1,
+            ']' => {}
+            _ => return None,
+        }
+    }
+}
+
+fn map(chars: &[char], at: &mut usize) -> Option<Value> {
+    *at += 1;
+    let mut entries = Vec::new();
+    loop {
+        skip_space(chars, at);
+        if chars[*at] == '}' {
+            *at += 1;
+            return Some(Value::Map(entries));
+        }
+        let key = text(chars, at)?;
+        skip_space(chars, at);
+        if chars[*at] != ':' {
+            return None;
+        }
+        *at += 1;
+        entries.push((key, value(chars, at)?));
+        skip_space(chars, at);
+        match chars[*at] {
+            ',' => *at += 1,
+            '}' => {}
+            _ => return None,
+        }
+    }
+}
+
+/// Appends `text` to `out` as a quoted JSON string.
+pub fn write_text(text: &str, out: &mut String) {
+    out.push('"');
+    for character in text.chars() {
+        match character {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            // The protocol is UTF-8, so only what JSON itself forbids is
+            // escaped. Escaping more would be correct and unreadable.
+            control if (control as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", control as u32);
+            }
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+}

--- a/crates/xtex-lsp/src/main.rs
+++ b/crates/xtex-lsp/src/main.rs
@@ -1,0 +1,237 @@
+//! The ExactTeX language server.
+//!
+//! # How to add a message
+//!
+//! One table maps a method to a handler, in [`handle`]. Add a case there and a
+//! function beside it. There is no trait to implement and no registration
+//! order that matters, and that is on purpose: `docs/decisions/0005` records
+//! that this server is written by hand and has to stay something an agent can
+//! change safely.
+//!
+//! Handlers hold no logic. Every question an editor asks is answered by
+//! `xtex_core::editor`, which is testable without a protocol — so "the server
+//! and the CLI report the same thing" is true by construction rather than by
+//! comparison.
+//!
+//! A message not in the table is not answered, and the editor's own fallback
+//! is the correct behaviour.
+
+mod json;
+mod rpc;
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::io::{BufReader, Write};
+
+use json::{Value, write_text};
+use xtex_core::bibliography::{Bibliography, Unavailable};
+use xtex_core::check::check;
+use xtex_core::document::Document;
+use xtex_core::editor::{Position, completions, definition, hover, offset_at};
+use xtex_core::parse;
+use xtex_core::source::Sources;
+use xtex_core::symbols::SymbolTable;
+
+/// Documents the editor has opened, by URI.
+type Open = BTreeMap<String, String>;
+
+fn main() -> std::io::Result<()> {
+    let stdin = std::io::stdin();
+    let mut input = BufReader::new(stdin.lock());
+    let mut output = std::io::stdout();
+    let mut open = Open::new();
+
+    while let Some(message) = rpc::read(&mut input)? {
+        if message.method == "shutdown" {
+            if let Some(id) = message.id {
+                rpc::write(&mut output, &rpc::reply(id, "null"))?;
+            }
+            continue;
+        }
+        if message.method == "exit" {
+            return Ok(());
+        }
+        for frame in handle(&message, &mut open) {
+            rpc::write(&mut output, &frame)?;
+        }
+        output.flush()?;
+    }
+    Ok(())
+}
+
+/// The table. One line per message this server answers.
+fn handle(message: &rpc::Message, open: &mut Open) -> Vec<String> {
+    match message.method.as_str() {
+        "initialize" => message.id.map(initialize).into_iter().collect(),
+        "textDocument/didOpen" | "textDocument/didChange" => {
+            did_change(&message.params, open).into_iter().collect()
+        }
+        "textDocument/hover" => reply_with(message, open, on_hover),
+        "textDocument/completion" => reply_with(message, open, on_completion),
+        "textDocument/definition" => reply_with(message, open, on_definition),
+        _ => Vec::new(),
+    }
+}
+
+/// Answers a positional request, or replies `null` when there is nothing there.
+fn reply_with(
+    message: &rpc::Message,
+    open: &Open,
+    answer: impl Fn(&str, Position) -> Option<String>,
+) -> Vec<String> {
+    let Some(id) = message.id else {
+        return Vec::new();
+    };
+    let Some((uri, position)) = locate(&message.params) else {
+        return vec![rpc::reply(id, "null")];
+    };
+    let Some(text) = open.get(&uri) else {
+        return vec![rpc::reply(id, "null")];
+    };
+    let body = answer(text, position).unwrap_or_else(|| "null".to_owned());
+    vec![rpc::reply(id, &body)]
+}
+
+fn initialize(id: i64) -> String {
+    rpc::reply(
+        id,
+        r#"{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"definitionProvider":true,"completionProvider":{"triggerCharacters":["(",":"]}},"serverInfo":{"name":"xtex-lsp"}}"#,
+    )
+}
+
+/// Records the document and publishes its diagnostics.
+///
+/// The editor is told on every change, because a diagnostic that arrives only
+/// on save is a diagnostic the author has already worked past.
+fn did_change(params: &Value, open: &mut Open) -> Option<String> {
+    let document = params.get("textDocument")?;
+    let uri = document.get("uri")?.text()?.to_owned();
+    let text = document
+        .get("text")
+        .and_then(Value::text)
+        .map(str::to_owned)
+        .or_else(|| {
+            // A full-sync change carries one item holding the whole document.
+            match params.get("contentChanges")? {
+                Value::List(items) => items.last()?.get("text")?.text().map(str::to_owned),
+                _ => None,
+            }
+        })?;
+
+    let diagnostics = diagnose(&uri, &text);
+    open.insert(uri.clone(), text);
+    Some(diagnostics)
+}
+
+/// The same diagnostics `xtex check` reports, rendered for an editor.
+fn diagnose(uri: &str, text: &str) -> String {
+    let mut sources = Sources::new();
+    let id = sources.add(uri, text.as_bytes().to_vec());
+    let document = parse(&sources, id);
+    let mut table = SymbolTable::new();
+    table.merge(&sources, &document);
+    // No bibliography is read here: the server has no project root, and
+    // `Unavailable` is exactly the state that keeps every citation silent
+    // rather than reported as missing.
+    let bibliography = Bibliography::Unavailable(Unavailable::NoneDeclared);
+
+    let mut items = String::new();
+    for diagnostic in check(&table, &bibliography) {
+        let (line, column) = line_column(text.as_bytes(), diagnostic.span.start());
+        let (end_line, end_column) = line_column(text.as_bytes(), diagnostic.span.end());
+        if !items.is_empty() {
+            items.push(',');
+        }
+        let _ = write!(
+            items,
+            r#"{{"range":{{"start":{{"line":{},"character":{}}},"end":{{"line":{},"character":{}}}}},"severity":1,"code":"{}","source":"xtex","message":"#,
+            line, column, end_line, end_column, diagnostic.code
+        );
+        write_text(&diagnostic.message, &mut items);
+        items.push('}');
+    }
+
+    let mut params = String::from(r#"{"uri":"#);
+    write_text(uri, &mut params);
+    let _ = write!(params, r#","diagnostics":[{items}]}}"#);
+    rpc::notify("textDocument/publishDiagnostics", &params)
+}
+
+fn on_hover(text: &str, position: Position) -> Option<String> {
+    let (sources, document, table) = analyse(text);
+    let offset = offset_at(text.as_bytes(), position)?;
+    let found = hover(&sources, &document, &table, offset)?;
+    let mut body = String::from(r#"{"contents":{"kind":"plaintext","value":"#);
+    write_text(&found.text, &mut body);
+    body.push_str("}}");
+    Some(body)
+}
+
+fn on_completion(text: &str, position: Position) -> Option<String> {
+    let (sources, document, table) = analyse(text);
+    let offset = offset_at(text.as_bytes(), position)?;
+    let items = completions(&sources, &document, &table, offset);
+    let mut body = String::from("[");
+    for (index, item) in items.iter().enumerate() {
+        if index > 0 {
+            body.push(',');
+        }
+        body.push_str(r#"{"label":"#);
+        write_text(&item.label, &mut body);
+        body.push_str(r#","detail":"#);
+        write_text(
+            item.detail.as_deref().unwrap_or(item.class.name()),
+            &mut body,
+        );
+        body.push('}');
+    }
+    body.push(']');
+    Some(body)
+}
+
+fn on_definition(text: &str, position: Position) -> Option<String> {
+    let (sources, document, table) = analyse(text);
+    let offset = offset_at(text.as_bytes(), position)?;
+    let span = definition(&sources, &document, &table, offset)?;
+    let (line, column) = line_column(text.as_bytes(), span.start());
+    let (end_line, end_column) = line_column(text.as_bytes(), span.end());
+    Some(format!(
+        r#"{{"uri":"","range":{{"start":{{"line":{line},"character":{column}}},"end":{{"line":{end_line},"character":{end_column}}}}}}}"#
+    ))
+}
+
+/// Parses the document and builds its table, which is what every positional
+/// handler needs and none of them should assemble itself.
+fn analyse(text: &str) -> (Sources, Document, SymbolTable) {
+    let mut sources = Sources::new();
+    let id = sources.add("document.xtex", text.as_bytes().to_vec());
+    let document = parse(&sources, id);
+    let mut table = SymbolTable::new();
+    table.merge(&sources, &document);
+    (sources, document, table)
+}
+
+/// The URI and position a positional request names.
+fn locate(params: &Value) -> Option<(String, Position)> {
+    let uri = params.get("textDocument")?.get("uri")?.text()?.to_owned();
+    let position = params.get("position")?;
+    // LSP counts from zero and this compiler counts from one.
+    let line = u32::try_from(position.get("line")?.integer()?).ok()? + 1;
+    let column = u32::try_from(position.get("character")?.integer()?).ok()? + 1;
+    Some((uri, Position { line, column }))
+}
+
+/// Zero-based line and column of a byte offset, which is what LSP wants.
+// Clippy suggests the `bytecount` crate here. `docs/decisions/0005` is why we
+// do not take it: this server carries no dependencies, and the counting is
+// over one line's worth of bytes per diagnostic.
+#[allow(clippy::naive_bytecount)]
+fn line_column(bytes: &[u8], offset: usize) -> (usize, usize) {
+    let before = &bytes[..offset.min(bytes.len())];
+    let line = before.iter().filter(|byte| **byte == b'\n').count();
+    let start = before
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |at| at + 1);
+    (line, offset.saturating_sub(start))
+}

--- a/crates/xtex-lsp/src/rpc.rs
+++ b/crates/xtex-lsp/src/rpc.rs
@@ -1,0 +1,92 @@
+//! JSON-RPC over stdio: framing in, framing out.
+//!
+//! The whole transport is here and it is deliberately dull. It reads a
+//! `Content-Length` header, reads that many bytes, and hands them on; it writes
+//! the same shape back. Nothing in this file knows what a document is.
+
+use std::io::{BufRead, Write};
+
+/// One message read from the stream.
+pub struct Message {
+    /// `id`, absent for a notification. A notification is never answered.
+    pub id: Option<i64>,
+    /// The method the client named.
+    pub method: String,
+    /// `params`, unexamined.
+    pub params: crate::json::Value,
+}
+
+/// Reads one message, or `None` at end of stream.
+///
+/// # Errors
+///
+/// Fails when the stream cannot be read. A malformed frame is reported as
+/// invalid data rather than skipped, because a client that framed one message
+/// wrongly will frame the next one wrongly too, and continuing would turn a
+/// protocol bug into a silent hang.
+pub fn read(input: &mut impl BufRead) -> std::io::Result<Option<Message>> {
+    let mut length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        if input.read_line(&mut line)? == 0 {
+            return Ok(None);
+        }
+        let line = line.trim_end();
+        if line.is_empty() {
+            break;
+        }
+        if let Some(value) = line.strip_prefix("Content-Length:") {
+            length = value.trim().parse().ok();
+        }
+    }
+    let Some(length) = length else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "a frame arrived with no Content-Length",
+        ));
+    };
+    let mut body = vec![0u8; length];
+    input.read_exact(&mut body)?;
+
+    let Some(value) = crate::json::parse(&body) else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "a frame body was not JSON",
+        ));
+    };
+    let method = value
+        .get("method")
+        .and_then(crate::json::Value::text)
+        .unwrap_or_default()
+        .to_owned();
+    Ok(Some(Message {
+        id: value.get("id").and_then(crate::json::Value::integer),
+        method,
+        params: value
+            .get("params")
+            .cloned()
+            .unwrap_or(crate::json::Value::Null),
+    }))
+}
+
+/// Writes a framed response body.
+///
+/// # Errors
+///
+/// Fails when the stream cannot be written.
+pub fn write(output: &mut impl Write, body: &str) -> std::io::Result<()> {
+    write!(output, "Content-Length: {}\r\n\r\n{body}", body.len())?;
+    output.flush()
+}
+
+/// A successful reply to `id`, carrying `result` verbatim.
+#[must_use]
+pub fn reply(id: i64, result: &str) -> String {
+    format!(r#"{{"jsonrpc":"2.0","id":{id},"result":{result}}}"#)
+}
+
+/// A notification carrying `params` verbatim.
+#[must_use]
+pub fn notify(method: &str, params: &str) -> String {
+    format!(r#"{{"jsonrpc":"2.0","method":"{method}","params":{params}}}"#)
+}

--- a/crates/xtex-lsp/tests/protocol.rs
+++ b/crates/xtex-lsp/tests/protocol.rs
@@ -1,0 +1,186 @@
+//! One test per message the server answers, feeding bytes and reading bytes.
+//!
+//! `docs/decisions/0005` requires this: an agent adding a method copies one of
+//! these, and a framing mistake fails as a wrong byte rather than as an editor
+//! that quietly does nothing.
+//!
+//! The server is driven as a subprocess over stdio, which is how an editor
+//! drives it. Calling the handlers directly would test everything except the
+//! part most likely to be wrong.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+const DOCUMENT: &str = "\\section{Intro} @id(sec:intro)\n\
+                        \\figure(fig:plot) { src = \"p.pdf\" caption = {C} }\n\
+                        See @ref(fig:plot) and @ref(tab:none).\n";
+
+/// Sends `bodies` as framed messages and returns the framed replies.
+fn talk(bodies: &[String]) -> Vec<String> {
+    let mut payload = Vec::new();
+    for body in bodies {
+        write!(payload, "Content-Length: {}\r\n\r\n{body}", body.len()).expect("write");
+    }
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_xtex-lsp"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("the server starts");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(&payload)
+        .expect("write to the server");
+    let out = child.wait_with_output().expect("the server exits");
+
+    let mut frames = Vec::new();
+    let bytes = out.stdout;
+    let mut at = 0usize;
+    while at < bytes.len() {
+        let head = bytes[at..]
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .expect("a frame header")
+            + at;
+        let header = String::from_utf8_lossy(&bytes[at..head]).to_string();
+        let length: usize = header
+            .split("Content-Length:")
+            .nth(1)
+            .expect("a length")
+            .trim()
+            .parse()
+            .expect("a number");
+        let start = head + 4;
+        frames.push(String::from_utf8_lossy(&bytes[start..start + length]).to_string());
+        at = start + length;
+    }
+    frames
+}
+
+fn open(uri: &str) -> String {
+    let mut text = String::new();
+    xtex_lsp_escape(DOCUMENT, &mut text);
+    format!(
+        r#"{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{uri}","text":{text}}}}}}}"#
+    )
+}
+
+fn xtex_lsp_escape(text: &str, out: &mut String) {
+    out.push('"');
+    for character in text.chars() {
+        match character {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+}
+
+fn positional(id: u32, method: &str, line: u32, character: u32) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","id":{id},"method":"textDocument/{method}","params":{{"textDocument":{{"uri":"file:///p.xtex"}},"position":{{"line":{line},"character":{character}}}}}}}"#
+    )
+}
+
+const EXIT: &str = r#"{"jsonrpc":"2.0","method":"exit","params":{}}"#;
+
+#[test]
+fn initialize_declares_what_the_server_answers() {
+    let frames = talk(&[
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#.to_owned(),
+        EXIT.to_owned(),
+    ]);
+    assert_eq!(frames.len(), 1, "{frames:?}");
+    for capability in [
+        "hoverProvider",
+        "definitionProvider",
+        "completionProvider",
+        "textDocumentSync",
+    ] {
+        assert!(frames[0].contains(capability), "{}", frames[0]);
+    }
+}
+
+#[test]
+fn opening_a_document_publishes_the_same_diagnostics_the_cli_reports() {
+    // The exit criterion of this phase, checked rather than argued: the code
+    // and the message are the checker's, because the server calls the checker.
+    let frames = talk(&[open("file:///p.xtex"), EXIT.to_owned()]);
+    assert_eq!(frames.len(), 1, "{frames:?}");
+    assert!(frames[0].contains("publishDiagnostics"), "{}", frames[0]);
+    assert!(frames[0].contains("XT1003"), "{}", frames[0]);
+    assert!(
+        frames[0].contains("identifier `tab:none` is not declared"),
+        "{}",
+        frames[0]
+    );
+    // And nothing about the reference that resolves.
+    assert!(!frames[0].contains("fig:plot"), "{}", frames[0]);
+}
+
+#[test]
+fn hover_names_what_is_required_and_what_is_declared() {
+    let frames = talk(&[
+        open("file:///p.xtex"),
+        positional(2, "hover", 2, 9),
+        EXIT.to_owned(),
+    ]);
+    let hover = frames.last().expect("a reply");
+    assert!(hover.contains("requires: figure"), "{hover}");
+    assert!(hover.contains("declared as: figure"), "{hover}");
+}
+
+#[test]
+fn completion_offers_only_what_the_prefix_demands() {
+    let frames = talk(&[
+        open("file:///p.xtex"),
+        positional(3, "completion", 2, 9),
+        EXIT.to_owned(),
+    ]);
+    let items = frames.last().expect("a reply");
+    assert!(items.contains("fig:plot"), "{items}");
+    // `sec:intro` is declared and is a section, so it is not offered to a
+    // reference whose prefix demands a figure.
+    assert!(!items.contains("sec:intro"), "{items}");
+}
+
+#[test]
+fn definition_points_at_the_declaring_construct() {
+    let frames = talk(&[
+        open("file:///p.xtex"),
+        positional(4, "definition", 2, 9),
+        EXIT.to_owned(),
+    ]);
+    let reply = frames.last().expect("a reply");
+    // The `\figure` block is the second line, zero-based line one.
+    assert!(reply.contains(r#""line":1"#), "{reply}");
+}
+
+#[test]
+fn a_position_in_prose_is_answered_with_null_rather_than_silence() {
+    // An editor waiting for a reply that never comes looks like a hung server.
+    let frames = talk(&[
+        open("file:///p.xtex"),
+        positional(5, "hover", 2, 1),
+        EXIT.to_owned(),
+    ]);
+    assert!(
+        frames.last().expect("a reply").contains(r#""result":null"#),
+        "{frames:?}"
+    );
+}
+
+#[test]
+fn an_unhandled_method_is_not_answered_and_does_not_stop_the_server() {
+    let frames = talk(&[
+        r#"{"jsonrpc":"2.0","id":9,"method":"textDocument/formatting","params":{}}"#.to_owned(),
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#.to_owned(),
+        EXIT.to_owned(),
+    ]);
+    assert_eq!(frames.len(), 1, "only initialize is answered: {frames:?}");
+    assert!(frames[0].contains(r#""id":1"#), "{}", frames[0]);
+}

--- a/docs/decisions/0005-the-language-server-is-written-by-hand.md
+++ b/docs/decisions/0005-the-language-server-is-written-by-hand.md
@@ -1,0 +1,51 @@
+# 0005 · The language server is written by hand
+
+**Status:** accepted, 2026-08-29. Decided by the director.
+**Issue:** [#16](https://github.com/camilochs/exacttex/issues/16)
+
+---
+
+## The decision
+
+`xtex-lsp` implements JSON-RPC, the LSP lifecycle and every message it answers **without a dependency**.
+`tower-lsp` and `lsp-types` were both available and both permissively licensed; neither is used.
+
+The reason is control over the long run rather than cost today. A language server is where an editor meets
+the compiler, and the shape of that meeting is something this project will keep changing — the diagnostics
+are ours, the entity classes are ours, and the hover text is a rendering of a record `checking.md` §10
+already defines. A dependency that models the protocol also models an opinion about that meeting.
+
+The director set one condition with it: **it has to stay simple enough for an agent to maintain.** That is
+not a wish, it is the design constraint, and the four rules below exist to satisfy it.
+
+## What keeps it maintainable
+
+**1. Transcribe only what is answered.** There is no attempt to model the protocol. A message the server does
+not answer has no type, no constant and no branch. Adding one is adding a case, not extending a model.
+
+**2. One table maps a method to a handler.** A reader looking for "what happens on hover" finds one line
+naming a function. There is no trait to implement, no builder, no registration order that matters.
+
+**3. The protocol layer holds no logic.** It frames bytes, reads a method name, calls a function, writes
+bytes back. Everything an editor asks about — what is at this position, what may complete here, what does
+this name refer to — is answered by `xtex-core`, in functions that take bytes and offsets and return data.
+
+That split is what makes the phase's exit criterion provable rather than argued: *the LSP and the CLI report
+the same diagnostics for the same input* is true by construction when both call the same function, and only
+testable by comparison when they do not.
+
+**4. Every handled message has a test that feeds bytes and asserts bytes.** An agent adding a method copies
+one, and a protocol mistake fails as a wrong byte rather than as an editor that quietly does nothing.
+
+## What this is not
+
+It is not a general LSP implementation and must not grow into one. If a message is not in
+`docs/lsp.md`'s table, this server does not answer it, and the editor's own fallback is the correct
+behaviour.
+
+## What would reverse it
+
+An editor feature that needs a part of the protocol large enough that transcribing it stops being cheaper
+than depending on it — a full workspace-edit refactoring protocol, or streaming partial results. Reversal
+means adding `lsp-types` to `xtex-lsp` alone; `xtex-core` keeps its zero dependencies either way, because
+nothing in the split above depends on this choice.

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -1,0 +1,100 @@
+# The language server
+
+`xtex-lsp` speaks LSP over stdin and stdout. It answers seven messages and no others.
+
+---
+
+## What it answers
+
+| Message | What it does |
+|---|---|
+| `initialize` | Declares the capabilities below. |
+| `textDocument/didOpen` | Records the document, publishes its diagnostics. |
+| `textDocument/didChange` | The same, on every keystroke the editor sends. |
+| `textDocument/hover` | What the construct under the cursor is, and whether it resolves. |
+| `textDocument/completion` | Identifiers that may go where the cursor is. |
+| `textDocument/definition` | Where the name under the cursor is declared. |
+| `shutdown` / `exit` | Replies `null`, then leaves. |
+
+**Anything else is not answered, and that is correct behaviour.** The editor's own fallback — its word-based
+completion, its "no definition found" — is better than a wrong answer from a server that does not model the
+question. A message that is not in this table has no code behind it.
+
+Capabilities declared: `textDocumentSync: 1` (full text on every change), `hoverProvider`,
+`definitionProvider`, and `completionProvider` triggered on `(` and `:`.
+
+---
+
+## Diagnostics are the checker's, not the server's
+
+The server calls `check`. It does not have diagnostics of its own, does not filter them, and does not
+reword them. `xtex check` and the editor show the same code, the same message and the same span for the same
+input, and that is true because there is one implementation rather than because two are kept in step.
+
+That is the exit criterion of this phase, and `opening_a_document_publishes_the_same_diagnostics_the_cli_reports`
+is where it is checked.
+
+One difference is deliberate: **the server reads no bibliography.** It is handed a document, not a project
+root, so the bibliography is `Unavailable` — which is exactly the state that keeps every `@cite` silent
+rather than reported as missing. An editor that flagged every citation in a file it could not resolve would
+be worse than one that flagged none.
+
+---
+
+## Hover
+
+```
+@ref(fig:plot)
+requires: figure
+declared as: figure
+```
+
+Every line is a fact the compiler already holds. `requires:` is the class the prefix demands
+([`decisions/0003`](decisions/0003-the-prefix-is-the-demand.md)); `declared as:` is what the target actually
+is. When they disagree you are looking at `XT1004` before the compiler has run.
+
+An unresolved reference says `not declared in this document root` rather than showing an empty popup, which
+is what an author sees for most of the time they are typing a name.
+
+---
+
+## Completion
+
+Inside `@ref(`, the prefix already typed **is** the filter. `@ref(tab:` is offered tables and nothing else,
+because offering a figure there is offering an error.
+
+This is the type system paying for itself in the editor rather than only in the exit code. An identifier
+whose class is `?O` is always offered, because `?O` is consistent with everything and the compiler has no
+grounds to exclude it.
+
+Outside a construct, nothing is offered. Suggesting every identifier in a document while someone writes a
+sentence is worse than suggesting none.
+
+---
+
+## Running it
+
+```sh
+cargo build --release -p xtex-lsp
+```
+
+The binary is `xtex-lsp` and it takes no arguments. Point your editor at it for the `xtex` language and
+`.xtex` files; the setup is whatever your editor calls "a custom language server command", and nothing here
+is editor-specific.
+
+There is no configuration. A project's `xtex.toml` is read by the compiler, not by the server.
+
+---
+
+## Why it is written by hand
+
+`tower-lsp` and `lsp-types` were both available and both permissively licensed. Neither is used, and
+[`decisions/0005`](decisions/0005-the-language-server-is-written-by-hand.md) records why and — more usefully
+— the four rules that keep a hand-written server maintainable.
+
+The one that matters for anyone changing it: **the protocol layer holds no logic.** It frames bytes, reads a
+method name, calls a function, writes bytes back. Every question is answered by `xtex_core::editor`, in
+functions that take bytes and offsets and return data, testable with no server running.
+
+To add a message: add a case to the table in `handle`, add a function beside it, and add a test to
+`crates/xtex-lsp/tests/protocol.rs` that feeds bytes and asserts bytes.


### PR DESCRIPTION
Closes #16. First of Phase 3.

## Working, driven as an editor drives it

```
initialize        -> ['textDocumentSync', 'hoverProvider', 'definitionProvider', 'completionProvider']
publishDiagnostics-> [('XT1003', 'identifier `tab:none` is not declared')]
hover             -> '@ref(fig:plot)\nrequires: figure\ndeclared as: figure'
completion        -> [{'label': 'fig:plot', 'detail': 'figure'}]
definition        -> {'start': {'line': 1, 'character': 0}, ...}
```

## Written by hand, and the condition that came with it

You chose no `tower-lsp` and no `lsp-types`, for control over the long run, and set the condition: **it has to stay simple enough for an agent to maintain.** That shaped the design more than the protocol did. `decisions/0005` records the four rules; the load-bearing one:

> **The protocol layer holds no logic.** It frames bytes, reads a method name, calls a function, writes bytes back.

Every question is answered by `xtex_core::editor`, in functions taking bytes and offsets and returning data — testable with no server running.

That split is what makes the phase's exit criterion **provable rather than argued**:

> *the LSP and the CLI report the same diagnostics for the same input*

True by construction when both call `check`. Only testable by comparison when they do not.

## Hover shows both sides of the type system

```
@ref(fig:plot)
requires: figure       ← what the prefix demands
declared as: figure    ← what the target is
```

Two lines that disagree are `XT1004` before the compiler has run. An unresolved reference **says so** rather than showing an empty popup — which is what an author sees for most of the time they are typing a name.

## Completion filters by the prefix

`@ref(tab:` is offered tables and nothing else. Offering a figure there is offering an error. The type system paying for itself in the editor rather than only in the exit code.

Outside a construct: nothing. Suggesting every identifier in a document while someone writes a sentence is worse than suggesting none.

## One deliberate difference from the CLI

**The server reads no bibliography.** It is handed a document, not a project root, so the bibliography is `Unavailable` — the state that keeps every `@cite` silent rather than reported as missing. An editor flagging every citation in a file it cannot resolve would be worse than one flagging none.

Written down in `docs/lsp.md` rather than left as a surprise.

## Seven protocol tests, over real frames

They drive the built binary as a subprocess over stdio, because calling the handlers directly would test everything except the part most likely to be wrong.

**Two are about what does *not* happen:**

- a position in prose is answered with `null` rather than silence — an editor waiting for a reply that never comes looks like a hung server;
- an unhandled method is not answered **and does not stop the server**.

## One lint refused in place

Clippy proposed the `bytecount` crate for counting line endings. Refused with the reason and a pointer to the decision, in the code, rather than silently allowed.

## Checks

141 tests pass, clippy clean at `-D warnings`, `cargo fmt --check` clean. `xtex-core` still has zero dependencies, and so does `xtex-lsp`. The invariant: **224 of 224**.