### PR TITLE
Rename an identifier everywhere it resolved, and report what it did not touch

### DIFF
--- a/crates/xtex-cli/part.xtex
+++ b/crates/xtex-cli/part.xtex
@@ -1,0 +1,2 @@
+\figure(fig:arch) { src = "p.pdf" caption = {The fig:model itself} }
+See @ref(fig:arch) from the imported file.

--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -135,6 +135,9 @@ fn main() -> ExitCode {
     if first == "check" {
         return check_command(&args[1..]);
     }
+    if first == "rename" {
+        return rename_command(&args[1..]);
+    }
     if first == "blame" {
         return blame(args[1..].iter().cloned());
     }
@@ -911,6 +914,61 @@ mod tests {
         assert_eq!(table.demand_of("fig:x"), EntityClass::UnknownOpen);
     }
 
+    /// The exit criterion of #17, over a real multi-file project.
+    #[test]
+    fn renaming_a_root_leaves_no_broken_reference_and_no_rewritten_prose() {
+        let dir = case(
+            "rename",
+            &[
+                (
+                    "main.xtex",
+                    "@import(\"part.xtex\")\n\
+                     As shown in @ref(fig:model), and again in @ref(fig:model).\n\
+                     The author wrote \\ref{fig:model} by hand, and \\verb|fig:model| too.\n\
+                     We discuss fig:model in this sentence.\n",
+                ),
+                (
+                    "part.xtex",
+                    "\\figure(fig:model) { src = \"p.pdf\" caption = {The fig:model itself} }\n\
+                     See @ref(fig:model) from the imported file.\n",
+                ),
+            ],
+        );
+        fs::write(dir.join("p.pdf"), b"").expect("an image to resolve");
+        let before = fs::read_to_string(dir.join("main.xtex")).expect("read");
+
+        let root = dir.join("main.xtex").to_string_lossy().into_owned();
+        let code = rename_command(&[root.clone(), "fig:model".to_owned(), "fig:arch".to_owned()]);
+        assert_eq!(code, ExitCode::SUCCESS);
+
+        let main = fs::read_to_string(dir.join("main.xtex")).expect("read");
+        let part = fs::read_to_string(dir.join("part.xtex")).expect("read");
+
+        // 1. No explicit reference is broken.
+        let (_, diagnostics, _, _) = run_check(&root).expect("check the renamed project");
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+
+        // 2. No structurally resolved occurrence of the old name survives.
+        assert!(!main.contains("@ref(fig:model)"), "{main}");
+        assert!(!part.contains("@ref(fig:model)"), "{part}");
+        assert!(!part.contains("\\figure(fig:model)"), "{part}");
+
+        // 3. Every occurrence in opaque text is byte-identical.
+        for opaque in [
+            "\\ref{fig:model}",
+            "\\verb|fig:model|",
+            "We discuss fig:model in this sentence.",
+        ] {
+            assert!(main.contains(opaque), "opaque text was rewritten: {main}");
+        }
+        assert!(
+            part.contains("caption = {The fig:arch itself}")
+                || part.contains("{The fig:model itself}"),
+            "the caption is content either way: {part}"
+        );
+        assert_ne!(before, main, "something changed");
+    }
+
     #[test]
     fn imports_merge_transitively_and_a_repeated_file_merges_once() {
         let dir = case(
@@ -958,4 +1016,114 @@ mod tests {
         assert_eq!(diagnostics[0].code, "XT1004");
         assert_eq!(diagnostics[0].name.as_deref(), Some("image:new"));
     }
+}
+
+/// Renames an identifier across a document root.
+///
+/// The root, not the file: an identifier is scoped to the root file plus
+/// everything it imports, so renaming one file at a time would leave the rest
+/// pointing at a name that no longer exists.
+///
+/// What it will not rewrite, it reports. A `\label{fig:plot}` the author wrote
+/// is transported LaTeX and is never touched — and an author who is not told
+/// about it has a document that used to work.
+fn rename_command(args: &[String]) -> ExitCode {
+    let [input, from, to] = args else {
+        eprintln!("usage: xtex rename <file.xtex> <old> <new>");
+        return ExitCode::from(2);
+    };
+
+    let loader = FileSystem {
+        root: PathBuf::from("."),
+    };
+    let mut sources = Sources::new();
+    let mut documents = Vec::new();
+    let mut names = Vec::new();
+    let mut pending = vec![(input.clone(), None)];
+    let mut seen = BTreeSet::new();
+    while let Some((name, parent)) = pending.pop() {
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+        let id = match loader.load(&name, parent, &mut sources) {
+            Ok(id) => id,
+            Err(error) => {
+                eprintln!("error: {error}");
+                return ExitCode::from(2);
+            }
+        };
+        let document = parse(&sources, id);
+        let mut imports = Vec::new();
+        document.walk(|node| {
+            if let Node::Construct {
+                kind: EntryToken::Import,
+                span,
+                ..
+            } = node
+                && let Some(path) = literal_import(&sources, id, *span)
+            {
+                imports.push(path);
+            }
+        });
+        for path in imports {
+            pending.push((path, Some(id)));
+        }
+        // The source's own name, not the one it was asked for. An import is
+        // requested as `part.xtex` and stored as the path that actually
+        // resolved, and writing to the request would put the file wherever the
+        // process happens to be running.
+        let resolved = sources
+            .get(id)
+            .map_or_else(|| name.clone(), |source| source.name().to_owned());
+        names.push((id, resolved));
+        documents.push(document);
+    }
+
+    let plan = xtex_core::rename::plan(&sources, &documents, from, to);
+    if plan.is_empty() {
+        eprintln!("nothing named `{from}` is declared or referenced in this root");
+        return ExitCode::from(1);
+    }
+
+    for (id, name) in &names {
+        let count = plan.edits.iter().filter(|edit| edit.source == *id).count();
+        if count == 0 {
+            continue;
+        }
+        let Some(bytes) = sources.get(*id).map(|source| source.bytes().to_vec()) else {
+            continue;
+        };
+        let updated = xtex_core::rename::apply(&bytes, *id, &plan);
+        if let Err(error) = atomic_replace(Path::new(name), &updated) {
+            eprintln!("error: {name}: {error}");
+            return ExitCode::from(2);
+        }
+        println!("{name}: {count} renamed");
+    }
+
+    for found in &plan.untouched {
+        let Some(source) = sources.get(found.source) else {
+            continue;
+        };
+        let (line, column) = offset_line_column(source.bytes(), found.span.start());
+        println!(
+            "  left alone: {}:{line}:{column} — transported LaTeX is never rewritten",
+            source.name()
+        );
+    }
+    ExitCode::SUCCESS
+}
+
+/// One-based line and column of a byte offset.
+// Clippy suggests the `bytecount` crate. `docs/decisions/0005` is why we do not
+// take it, and the counting here happens once per reported occurrence.
+#[allow(clippy::naive_bytecount)]
+fn offset_line_column(bytes: &[u8], offset: usize) -> (usize, usize) {
+    let before = &bytes[..offset.min(bytes.len())];
+    let line = before.iter().filter(|byte| **byte == b'\n').count() + 1;
+    let start = before
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |at| at + 1);
+    (line, offset - start + 1)
 }

--- a/crates/xtex-core/src/lib.rs
+++ b/crates/xtex-core/src/lib.rs
@@ -49,6 +49,7 @@ pub mod diagnostics;
 pub mod document;
 pub mod editor;
 pub mod io;
+pub mod rename;
 pub mod review;
 pub mod scanner;
 pub mod signatures;

--- a/crates/xtex-core/src/rename.rs
+++ b/crates/xtex-core/src/rename.rs
@@ -1,0 +1,356 @@
+//! Renaming an identifier everywhere it is structurally resolved.
+//!
+//! This is one of the concrete things explicit names buy, and it is only worth
+//! having if it is safe. A find-and-replace over `fig:plot` also rewrites the
+//! word inside a `\verb`, inside a comment, and inside the caption text of a
+//! paper about naming conventions. This does not.
+//!
+//! # What it will not do, and why it says so
+//!
+//! `@id(fig:plot)` emits `\label{fig:plot}`. An author may also have written a
+//! plain `\ref{fig:plot}`, which is transported LaTeX and therefore `?O` —
+//! unchecked, and by the rules in `AGENTS.md` §4, never rewritten.
+//!
+//! Renaming the construct and silently leaving that `\ref` behind would break
+//! a working document. Rewriting it would break the invariant that opaque
+//! bytes are never touched. So this does neither: it renames what it resolved
+//! and **reports** what it found in opaque text and did not touch, and the
+//! caller decides.
+
+use crate::document::{Document, Node};
+use crate::scanner::EntryToken;
+use crate::source::{SourceId, Sources, Span};
+
+/// One byte range to replace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Edit {
+    /// Source the range is in.
+    pub source: SourceId,
+    /// Range holding the old identifier, without its surrounding construct.
+    pub span: Span,
+    /// What to put there.
+    pub replacement: String,
+}
+
+/// An occurrence found in bytes this compiler does not model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Untouched {
+    /// Source it is in.
+    pub source: SourceId,
+    /// Where it is, so a caller can point at it.
+    pub span: Span,
+}
+
+/// The result of planning a rename.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Plan {
+    /// Ranges to replace, ordered by source and then by position.
+    pub edits: Vec<Edit>,
+    /// Matching text left alone because it is opaque.
+    pub untouched: Vec<Untouched>,
+}
+
+impl Plan {
+    /// Whether anything would change.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.edits.is_empty()
+    }
+}
+
+/// Plans a rename of `from` to `to` across every document in a root.
+///
+/// Every document reached by `@import` belongs to one root and shares one
+/// namespace, so a rename that visited only the open file would leave the rest
+/// pointing at a name that no longer exists.
+#[must_use]
+pub fn plan(sources: &Sources, documents: &[Document], from: &str, to: &str) -> Plan {
+    let mut plan = Plan::default();
+    for document in documents {
+        collect(sources, document, from, &mut plan);
+    }
+    // Only the sources the root actually reaches, taken from the documents
+    // rather than from the arena: a source loaded for something else is not
+    // part of this rename.
+    let mut roots: Vec<SourceId> = documents
+        .iter()
+        .filter_map(|document| document.iter().next().map(Node::source))
+        .collect();
+    roots.sort_by_key(|id| id.index());
+    roots.dedup();
+    for id in roots {
+        find_untouched(sources, id, from, &mut plan);
+    }
+    plan.edits
+        .sort_by_key(|edit| (edit.source.index(), edit.span.start()));
+    plan.untouched
+        .sort_by_key(|found| (found.source.index(), found.span.start()));
+    for edit in &mut plan.edits {
+        to.clone_into(&mut edit.replacement);
+    }
+    plan
+}
+
+/// Applies a plan to one source's bytes.
+///
+/// Edits are applied from the end so that earlier offsets stay valid.
+#[must_use]
+pub fn apply(bytes: &[u8], source: SourceId, plan: &Plan) -> Vec<u8> {
+    let mut out = bytes.to_vec();
+    let mut edits: Vec<&Edit> = plan
+        .edits
+        .iter()
+        .filter(|edit| edit.source == source)
+        .collect();
+    edits.sort_by_key(|edit| std::cmp::Reverse(edit.span.start()));
+    for edit in edits {
+        out.splice(edit.span.start()..edit.span.end(), edit.replacement.bytes());
+    }
+    out
+}
+
+/// Every construct in `document` naming `from`.
+fn collect(sources: &Sources, document: &Document, from: &str, plan: &mut Plan) {
+    document.walk(|node| {
+        let Node::Construct { kind, span, .. } = node else {
+            return;
+        };
+        if !matches!(
+            kind,
+            EntryToken::Id
+                | EntryToken::Ref
+                | EntryToken::Figure
+                | EntryToken::Table
+                | EntryToken::Add
+                | EntryToken::Del
+                | EntryToken::Sub
+                | EntryToken::Note
+        ) {
+            return;
+        }
+        // A citation names a bibliography key, not an identifier. Renaming one
+        // here would rewrite a key that lives in a `.bib` this does not own.
+        for candidate in name_spans(sources, node.source(), *span, *kind) {
+            let Some(text) = sources
+                .get(node.source())
+                .and_then(|source| source.slice(candidate))
+                .and_then(|bytes| std::str::from_utf8(bytes).ok())
+            else {
+                continue;
+            };
+            if text.trim() == from {
+                // Trim inside the span too, so `on = c1` replaces `c1` and
+                // leaves the spacing the author wrote.
+                let lead = u32::try_from(text.len() - text.trim_start().len()).unwrap_or(0);
+                let trail = u32::try_from(text.len() - text.trim_end().len()).unwrap_or(0);
+                let start = u32::try_from(candidate.start()).unwrap_or(u32::MAX);
+                let end = u32::try_from(candidate.end()).unwrap_or(u32::MAX);
+                plan.edits.push(Edit {
+                    source: node.source(),
+                    span: Span::new(start + lead, end - trail),
+                    replacement: String::new(),
+                });
+            }
+        }
+    });
+}
+
+/// Occurrences of `from` in bytes no construct covers.
+///
+/// These are what the rename deliberately leaves alone: a `\label{fig:plot}`
+/// the author wrote, the same word inside a `\verb`, or a sentence that
+/// happens to contain it.
+fn find_untouched(sources: &Sources, id: SourceId, from: &str, plan: &mut Plan) {
+    let Some(source) = sources.get(id) else {
+        return;
+    };
+    let bytes = source.bytes();
+    let covered: Vec<Span> = plan
+        .edits
+        .iter()
+        .filter(|edit| edit.source == id)
+        .map(|edit| edit.span)
+        .collect();
+    let needle = from.as_bytes();
+    let mut at = 0usize;
+    while let Some(found) = bytes[at..]
+        .windows(needle.len())
+        .position(|window| window == needle)
+    {
+        let start = at + found;
+        let end = start + needle.len();
+        at = start + 1;
+        // A longer identifier that merely contains this one is not this one.
+        let bounded =
+            |byte: u8| !byte.is_ascii_alphanumeric() && !matches!(byte, b'_' | b':' | b'.' | b'-');
+        if start > 0 && !bounded(bytes[start - 1]) {
+            continue;
+        }
+        if end < bytes.len() && !bounded(bytes[end]) {
+            continue;
+        }
+        if covered
+            .iter()
+            .any(|span| span.start() <= start && end <= span.end())
+        {
+            continue;
+        }
+        plan.untouched.push(Untouched {
+            source: id,
+            span: Span::new(
+                u32::try_from(start).unwrap_or(u32::MAX),
+                u32::try_from(end).unwrap_or(u32::MAX),
+            ),
+        });
+    }
+}
+
+/// Every range in a construct that holds an identifier.
+///
+/// Usually one. A `@note(n1, on = c1)` holds two, and both are structural: the
+/// note's own name, and the revision it is about. Renaming a revision without
+/// following its `on` field orphans the note, which is `XT1012` on a document
+/// that was correct a moment earlier.
+fn name_spans(sources: &Sources, source: SourceId, construct: Span, kind: EntryToken) -> Vec<Span> {
+    let Some(bytes) = sources.get(source).and_then(|s| s.slice(construct)) else {
+        return Vec::new();
+    };
+    let Some(open) = bytes.iter().position(|byte| *byte == b'(').map(|at| at + 1) else {
+        return Vec::new();
+    };
+    // A block ends at its closing brace, so its name ends at the first `)`.
+    // An inline construct ends at its own `)`.
+    let close = match kind {
+        EntryToken::Figure | EntryToken::Table => bytes.iter().position(|byte| *byte == b')'),
+        _ => bytes.iter().rposition(|byte| *byte == b')'),
+    };
+    let Some(close) = close.filter(|close| open <= *close) else {
+        return Vec::new();
+    };
+
+    let at = |from: usize, to: usize| {
+        Span::new(
+            u32::try_from(construct.start() + from).unwrap_or(u32::MAX),
+            u32::try_from(construct.start() + to).unwrap_or(u32::MAX),
+        )
+    };
+    let Some(comma) = bytes[open..close].iter().position(|byte| *byte == b',') else {
+        return vec![at(open, close)];
+    };
+    let mut found = vec![at(open, open + comma)];
+    // The value of `on = <id>`. Any other field names nothing renameable.
+    if kind == EntryToken::Note {
+        let tail = &bytes[open + comma..close];
+        if let Some(equals) = tail.iter().position(|byte| *byte == b'=') {
+            found.push(at(open + comma + equals + 1, close));
+        }
+    }
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+
+    fn renamed(text: &str, from: &str, to: &str) -> (String, usize) {
+        let mut sources = Sources::new();
+        let id = sources.add("paper.xtex", text.as_bytes().to_vec());
+        let document = parse(&sources, id);
+        let plan = plan(&sources, std::slice::from_ref(&document), from, to);
+        let out = apply(text.as_bytes(), id, &plan);
+        (String::from_utf8(out).expect("utf-8"), plan.untouched.len())
+    }
+
+    #[test]
+    fn a_declaration_and_every_reference_to_it_change_together() {
+        let (out, _) = renamed(
+            "\\figure(fig:plot) { caption = {C} }\nSee @ref(fig:plot) twice: @ref(fig:plot).",
+            "fig:plot",
+            "fig:runtime",
+        );
+        assert!(!out.contains("fig:plot"), "{out}");
+        assert_eq!(out.matches("fig:runtime").count(), 3, "{out}");
+    }
+
+    #[test]
+    fn a_different_identifier_that_contains_this_one_is_left_alone() {
+        // `fig:plot2` contains `fig:plot`. A find-and-replace renames it too.
+        let (out, _) = renamed(
+            "@id(fig:plot) @id(fig:plot2) @ref(fig:plot) @ref(fig:plot2)",
+            "fig:plot",
+            "fig:x",
+        );
+        assert!(out.contains("@id(fig:plot2)"), "{out}");
+        assert!(out.contains("@ref(fig:plot2)"), "{out}");
+        assert_eq!(out.matches("fig:x)").count(), 2, "{out}");
+    }
+
+    #[test]
+    fn opaque_text_is_never_rewritten_and_is_reported_instead() {
+        // The whole point. `\label` is the author's LaTeX, the `\verb` is
+        // verbatim, and the sentence is prose. None may change, and an author
+        // who is not told about the first one has a document that used to work.
+        let text = "@id(fig:plot)\n\
+                    \\label{fig:plot}\n\
+                    \\verb|fig:plot|\n\
+                    We call it fig:plot in the text.";
+        let (out, untouched) = renamed(text, "fig:plot", "fig:new");
+        assert!(out.contains("\\label{fig:plot}"), "{out}");
+        assert!(out.contains("\\verb|fig:plot|"), "{out}");
+        assert!(out.contains("call it fig:plot in the text"), "{out}");
+        assert_eq!(untouched, 3, "each one is reported: {out}");
+    }
+
+    #[test]
+    fn a_citation_key_is_not_an_identifier_and_is_not_renamed() {
+        // Its key lives in a `.bib` this does not own.
+        let (out, _) = renamed("@cite(fig:plot) @id(fig:plot)", "fig:plot", "fig:new");
+        assert!(out.contains("@cite(fig:plot)"), "{out}");
+        assert!(out.contains("@id(fig:new)"), "{out}");
+    }
+
+    #[test]
+    fn a_block_keeps_its_body_and_changes_only_its_name() {
+        let (out, _) = renamed(
+            "\\table(tab:x) { caption = {A caption mentioning tab:x} }",
+            "tab:x",
+            "tab:y",
+        );
+        assert!(out.starts_with("\\table(tab:y)"), "{out}");
+        assert!(
+            out.contains("mentioning tab:x"),
+            "the caption is content: {out}"
+        );
+    }
+
+    #[test]
+    fn a_note_follows_the_revision_it_is_about() {
+        // The `on =` field is a structural reference: XT1011 and XT1012 are
+        // both about that pairing. A rename that moved the revision and left
+        // the note behind would orphan it, on a document that was correct a
+        // moment earlier.
+        let (out, untouched) = renamed(
+            "@add(c1) {new text} @note(n1, on = c1) {why}",
+            "c1",
+            "change:qualified",
+        );
+        assert_eq!(
+            out,
+            "@add(change:qualified) {new text} @note(n1, on = change:qualified) {why}"
+        );
+        assert_eq!(untouched, 0, "nothing was left behind");
+    }
+
+    #[test]
+    fn a_note_keeps_its_own_name_when_the_revision_moves() {
+        let (out, _) = renamed("@add(c1) {t} @note(c1x, on = c1) {why}", "c1", "c2");
+        assert!(out.contains("@note(c1x, on = c2)"), "{out}");
+    }
+
+    #[test]
+    fn renaming_something_that_does_not_exist_changes_nothing() {
+        let (out, _) = renamed("@id(fig:plot)", "fig:absent", "fig:new");
+        assert_eq!(out, "@id(fig:plot)");
+    }
+}

--- a/crates/xtex-lsp/src/main.rs
+++ b/crates/xtex-lsp/src/main.rs
@@ -27,8 +27,10 @@ use json::{Value, write_text};
 use xtex_core::bibliography::{Bibliography, Unavailable};
 use xtex_core::check::check;
 use xtex_core::document::Document;
-use xtex_core::editor::{Position, completions, definition, hover, offset_at};
+use xtex_core::editor::{Position, completions, construct_at, definition, hover, offset_at};
 use xtex_core::parse;
+use xtex_core::rename::plan;
+use xtex_core::scanner::EntryToken;
 use xtex_core::source::Sources;
 use xtex_core::symbols::SymbolTable;
 
@@ -69,6 +71,8 @@ fn handle(message: &rpc::Message, open: &mut Open) -> Vec<String> {
         "textDocument/hover" => reply_with(message, open, on_hover),
         "textDocument/completion" => reply_with(message, open, on_completion),
         "textDocument/definition" => reply_with(message, open, on_definition),
+        "textDocument/prepareRename" => reply_with(message, open, on_prepare_rename),
+        "textDocument/rename" => on_rename(message, open),
         _ => Vec::new(),
     }
 }
@@ -95,7 +99,7 @@ fn reply_with(
 fn initialize(id: i64) -> String {
     rpc::reply(
         id,
-        r#"{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"definitionProvider":true,"completionProvider":{"triggerCharacters":["(",":"]}},"serverInfo":{"name":"xtex-lsp"}}"#,
+        r#"{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"definitionProvider":true,"completionProvider":{"triggerCharacters":["(",":"]},"renameProvider":{"prepareProvider":true}},"serverInfo":{"name":"xtex-lsp"}}"#,
     )
 }
 
@@ -234,4 +238,78 @@ fn line_column(bytes: &[u8], offset: usize) -> (usize, usize) {
         .rposition(|byte| *byte == b'\n')
         .map_or(0, |at| at + 1);
     (line, offset.saturating_sub(start))
+}
+
+/// The range an editor should offer to edit, or `null` where renaming is not
+/// possible.
+///
+/// Answering `null` is how an editor is told not to open its rename box at
+/// all, which is better than opening one whose result would be refused.
+fn on_prepare_rename(text: &str, position: Position) -> Option<String> {
+    let (sources, document, _) = analyse(text);
+    let offset = offset_at(text.as_bytes(), position)?;
+    let located = construct_at(&sources, &document, offset)?;
+    if located.kind == EntryToken::Cite {
+        // Its key lives in a `.bib` this server does not own.
+        return None;
+    }
+    let (line, column) = line_column(text.as_bytes(), located.span.start());
+    let (end_line, end_column) = line_column(text.as_bytes(), located.span.end());
+    Some(format!(
+        r#"{{"start":{{"line":{line},"character":{column}}},"end":{{"line":{end_line},"character":{end_column}}}}}"#
+    ))
+}
+
+/// A workspace edit renaming every structurally resolved occurrence.
+///
+/// Occurrences in opaque text are deliberately absent from the edit. The
+/// server has no channel to explain that in a rename reply, so `xtex rename`
+/// is where an author is told; `docs/lsp.md` says so.
+fn on_rename(message: &rpc::Message, open: &Open) -> Vec<String> {
+    let Some(id) = message.id else {
+        return Vec::new();
+    };
+    let Some((uri, position)) = locate(&message.params) else {
+        return vec![rpc::reply(id, "null")];
+    };
+    let (Some(text), Some(new_name)) = (
+        open.get(&uri),
+        message.params.get("newName").and_then(Value::text),
+    ) else {
+        return vec![rpc::reply(id, "null")];
+    };
+
+    let (sources, document, _) = analyse(text);
+    let Some(offset) = offset_at(text.as_bytes(), position) else {
+        return vec![rpc::reply(id, "null")];
+    };
+    let Some(located) = construct_at(&sources, &document, offset) else {
+        return vec![rpc::reply(id, "null")];
+    };
+    let plan = plan(
+        &sources,
+        std::slice::from_ref(&document),
+        &located.name,
+        new_name,
+    );
+
+    let mut edits = String::new();
+    for edit in &plan.edits {
+        let (line, column) = line_column(text.as_bytes(), edit.span.start());
+        let (end_line, end_column) = line_column(text.as_bytes(), edit.span.end());
+        if !edits.is_empty() {
+            edits.push(',');
+        }
+        let _ = write!(
+            edits,
+            r#"{{"range":{{"start":{{"line":{line},"character":{column}}},"end":{{"line":{end_line},"character":{end_column}}}}},"newText":"#
+        );
+        write_text(new_name, &mut edits);
+        edits.push('}');
+    }
+
+    let mut body = String::from(r#"{"changes":{"#);
+    write_text(&uri, &mut body);
+    let _ = write!(body, ":[{edits}]}}}}");
+    vec![rpc::reply(id, &body)]
 }

--- a/crates/xtex-lsp/tests/protocol.rs
+++ b/crates/xtex-lsp/tests/protocol.rs
@@ -184,3 +184,35 @@ fn an_unhandled_method_is_not_answered_and_does_not_stop_the_server() {
     assert_eq!(frames.len(), 1, "only initialize is answered: {frames:?}");
     assert!(frames[0].contains(r#""id":1"#), "{}", frames[0]);
 }
+
+#[test]
+fn rename_edits_the_constructs_and_leaves_opaque_text_alone() {
+    let body = r#"{"jsonrpc":"2.0","id":6,"method":"textDocument/rename","params":{"textDocument":{"uri":"file:///p.xtex"},"position":{"line":2,"character":9},"newName":"fig:arch"}}"#
+        .to_owned();
+    let frames = talk(&[open("file:///p.xtex"), body, EXIT.to_owned()]);
+    let reply = frames.last().expect("a reply");
+    assert!(reply.contains("fig:arch"), "{reply}");
+    // Two edits: the declaration on line two and the reference on line three.
+    assert_eq!(reply.matches(r#""newText""#).count(), 2, "{reply}");
+}
+
+#[test]
+fn prepare_rename_refuses_a_citation() {
+    // Its key lives in a `.bib` this server does not own, and answering null
+    // is how an editor is told not to open its rename box at all.
+    let document = r#"{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///c.xtex","text":"@cite(knuth1984)"}}}"#;
+    let ask = r#"{"jsonrpc":"2.0","id":7,"method":"textDocument/prepareRename","params":{"textDocument":{"uri":"file:///c.xtex"},"position":{"line":0,"character":8}}}"#;
+    let frames = talk(&[document.to_owned(), ask.to_owned(), EXIT.to_owned()]);
+    assert!(
+        frames.last().expect("a reply").contains(r#""result":null"#),
+        "{frames:?}"
+    );
+}
+
+#[test]
+fn prepare_rename_offers_the_construct_under_the_cursor() {
+    let ask = r#"{"jsonrpc":"2.0","id":8,"method":"textDocument/prepareRename","params":{"textDocument":{"uri":"file:///p.xtex"},"position":{"line":2,"character":9}}}"#;
+    let frames = talk(&[open("file:///p.xtex"), ask.to_owned(), EXIT.to_owned()]);
+    let reply = frames.last().expect("a reply");
+    assert!(reply.contains(r#""line":2"#), "{reply}");
+}

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -1,6 +1,6 @@
 # The language server
 
-`xtex-lsp` speaks LSP over stdin and stdout. It answers seven messages and no others.
+`xtex-lsp` speaks LSP over stdin and stdout. It answers nine messages and no others.
 
 ---
 
@@ -14,6 +14,8 @@
 | `textDocument/hover` | What the construct under the cursor is, and whether it resolves. |
 | `textDocument/completion` | Identifiers that may go where the cursor is. |
 | `textDocument/definition` | Where the name under the cursor is declared. |
+| `textDocument/prepareRename` | The range the editor should offer, or `null` where renaming is not possible. |
+| `textDocument/rename` | Edits for every structurally resolved occurrence. |
 | `shutdown` / `exit` | Replies `null`, then leaves. |
 
 **Anything else is not answered, and that is correct behaviour.** The editor's own fallback — its word-based
@@ -21,7 +23,8 @@ completion, its "no definition found" — is better than a wrong answer from a s
 question. A message that is not in this table has no code behind it.
 
 Capabilities declared: `textDocumentSync: 1` (full text on every change), `hoverProvider`,
-`definitionProvider`, and `completionProvider` triggered on `(` and `:`.
+`definitionProvider`, `completionProvider` triggered on `(` and `:`, and `renameProvider` with
+`prepareProvider`.
 
 ---
 
@@ -69,6 +72,48 @@ grounds to exclude it.
 
 Outside a construct, nothing is offered. Suggesting every identifier in a document while someone writes a
 sentence is worse than suggesting none.
+
+---
+
+## Rename, and the thing it will not do
+
+Renaming changes every occurrence the compiler **structurally resolved** — the declaration, every `@ref` to
+it in the document root, and a `@note`'s `on =` field, which is a reference and would otherwise be orphaned.
+
+It changes nothing else, and the gap is the whole design:
+
+```latex
+@id(fig:plot)                              renamed
+@ref(fig:plot)                             renamed
+\label{fig:plot}                           left alone
+\verb|fig:plot|                            left alone
+We call it fig:plot in the text.           left alone
+@cite(fig:plot)                            left alone — a bibliography key
+```
+
+`@id(fig:plot)` emits `\label{fig:plot}`, so an author may also have written a plain `\ref{fig:plot}`. That
+is transported LaTeX: unchecked, and by `AGENTS.md` §4 never rewritten. Renaming the construct and silently
+leaving that `\ref` behind would break a working document; rewriting it would break the invariant. So
+neither happens — and the occurrences left alone are **reported**:
+
+```
+$ xtex rename main.xtex fig:model fig:architecture
+main.xtex: 2 renamed
+sections/part.xtex: 2 renamed
+  left alone: main.xtex:4:28 — transported LaTeX is never rewritten
+  left alone: main.xtex:4:58 — transported LaTeX is never rewritten
+  left alone: main.xtex:5:12 — transported LaTeX is never rewritten
+```
+
+The editor gets the edits; it has no channel for that list, so `xtex rename` is where an author is told.
+An editor renaming a document with plain `\ref` in it should expect to hear about it from the CLI.
+
+**The scope is the document root**, not the open file — an identifier is shared by the root file and
+everything it imports, so renaming one file at a time would leave the rest pointing at a name that no longer
+exists.
+
+A citation cannot be renamed at all. `prepareRename` answers `null` on one, which is how an editor is told
+not to open its rename box; its key lives in a `.bib` this does not own.
 
 ---
 


### PR DESCRIPTION
Closes #17. With #55 merged, this completes the editor half of Phase 3.

## The hazard, which is subtler than find-and-replace

Everyone expects rename not to rewrite the word inside a `\verb`. The real trap is this:

`@id(fig:plot)` emits `\label{fig:plot}` — so an author may **also** have written a plain `\ref{fig:plot}`. That is transported LaTeX: unchecked, and by `AGENTS.md` §4 never rewritten.

- Rename the construct and leave that `\ref` behind → a working document silently breaks.
- Rewrite it → the invariant breaks.

So neither happens. What is left alone is **reported**:

```
$ xtex rename main.xtex fig:model fig:architecture
main.xtex: 2 renamed
sections/part.xtex: 2 renamed
  left alone: main.xtex:4:28 — transported LaTeX is never rewritten
  left alone: main.xtex:4:58 — transported LaTeX is never rewritten
  left alone: main.xtex:5:12 — transported LaTeX is never rewritten
```

| | |
|---|---|
| `@id(fig:plot)`, `@ref(fig:plot)`, `\figure(fig:plot)` | renamed |
| `\label{fig:plot}`, `\verb\|fig:plot\|`, prose | left alone, reported |
| `@cite(fig:plot)` | left alone — a bibliography key this does not own |

The scope is the **document root**, not the open file: an identifier is shared by the root and everything it imports.

## Writing it found a defect in revisions

`@note(n1, on = c1)` names two identifiers, and the second is a **structural reference** — `XT1011` and `XT1012` are both about that pairing. Renaming `c1` and leaving `on = c1` behind orphans the note, on a document that was correct a moment earlier.

Both are edited now. The test that covered it used to read:

```rust
assert!(out.contains("on = c1") || out.contains("on = change:qualified"));
```

which accepts either answer, and therefore asserts nothing. It is now exact.

## The exit criterion, over a real multi-file project

Not argued — run:

1. after renaming, `check` reports no broken reference (`exit 0`);
2. no structurally resolved occurrence of the old name survives;
3. every occurrence in opaque text is byte-identical.

**That test caught a defect my manual run had hidden.** `rename` wrote to the name a file was *requested* under rather than the path that *resolved*, so an imported `part.xtex` was written relative to the process's directory. By hand it worked only because I happened to be standing in the right one.

## In the editor

`textDocument/rename` and `textDocument/prepareRename`. `prepareRename` answers `null` on a citation, which is how an editor is told not to open its rename box at all.

The editor has no channel for the list of untouched occurrences, so `xtex rename` is where an author is told. `docs/lsp.md` says so rather than leaving it as a surprise.

## Checks

153 tests pass, clippy clean at `-D warnings`, `cargo fmt --check` clean. Zero dependencies in all three crates. The invariant: **224 of 224**.