### PR TITLE
Build the compiler to WebAssembly, over caller-provided buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,3 +19,10 @@ version = "0.0.0"
 dependencies = [
  "xtex-core",
 ]
+
+[[package]]
+name = "xtex-wasm"
+version = "0.0.0"
+dependencies = [
+ "xtex-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/xtex-core", "crates/xtex-cli", "crates/xtex-lsp"]
+members = ["crates/xtex-core", "crates/xtex-cli", "crates/xtex-lsp", "crates/xtex-wasm"]
 # Experiments carry dependencies the compiler must not inherit through the lock
 # file. They are built on their own.
 exclude = ["tests/experiments"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ you annotate is guaranteed.
 
 > **Status: the compiler and the language server work; the browser does not exist yet.** `xtex` parses,
 > checks, emits LaTeX, writes source maps and applies revisions, and `xtex-lsp` gives an editor diagnostics,
-> hover, completion and go-to-definition. There is no WebAssembly build. Every claim below is about what is
+> hover, completion and go-to-definition. It also builds to WebAssembly, so a browser can run it with no compile server. Every claim below is about what is
 > built, and each number is reproducible with the command that produced it.
 
 ---
@@ -139,6 +139,8 @@ still receives a `.tex` file.
   boundaries, and where constructs are not recognized.
 - [`docs/checking.md`](docs/checking.md) — what the compiler is willing to call an error, and what it
   refuses to: entity classes, the closed list of hard errors, coverage, blame, and the diagnostic fields.
+- [`docs/wasm.md`](docs/wasm.md) — the WebAssembly build: the calling convention, and why it carries the
+  only `unsafe` in the workspace.
 - [`docs/lsp.md`](docs/lsp.md) — the language server: what it answers, what it deliberately does not,
   and why the protocol layer holds no logic.
 - [`docs/revisions.md`](docs/revisions.md) — the change model: the four constructs, the three views,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -305,6 +305,10 @@ span and a blame value.
 
 ### Phase 3 — Add the LSP and the WASM/browser surface
 
+The language server and the WebAssembly build are done. What remains is the browser surface that supplies a
+multi-file project to the module — and the choice of a TeX compiled to WebAssembly, which nobody has
+verified. See [`docs/wasm.md`](docs/wasm.md) and [`docs/lsp.md`](docs/lsp.md).
+
 Diagnostics, hover, project-wide completion, definition lookup, safe rename, and macro declaration
 information through the LSP. Compile the same core to WebAssembly and connect it to browser-provided source
 and output stores.

--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use xtex_core::bibliography::{Bibliography, Declared, Unavailable, assemble, declared_in};
-use xtex_core::check::{Diagnostic, check, check_documents};
+use xtex_core::check::{Diagnostic, check, check_documents, to_json};
 use xtex_core::diagnostics::map_emitted_diagnostic;
 use xtex_core::document::Node;
 use xtex_core::io::{IoError, OutputSink, SourceLoader};
@@ -230,7 +230,13 @@ fn check_command(args: &[String]) -> ExitCode {
     match run_check(inputs[0]) {
         Ok((sources, diagnostics, coverage, bibliography)) => {
             if json {
-                print_json(&sources, &diagnostics, coverage);
+                {
+                    // One renderer, shared with the WebAssembly build, so the two
+                    // cannot drift.
+                    let mut json = String::new();
+                    to_json(&sources, &diagnostics, coverage, &mut json);
+                    println!("{json}");
+                }
             } else {
                 for diagnostic in &diagnostics {
                     print_human(&sources, diagnostic);
@@ -417,105 +423,6 @@ fn parse_prefixes(text: &str) -> Option<PrefixMap> {
         }
     }
     found.then_some(map)
-}
-
-fn location(
-    sources: &Sources,
-    source: SourceId,
-    span: xtex_core::source::Span,
-) -> (&str, usize, usize) {
-    let Some(source) = sources.get(source) else {
-        return ("<unresolved>", 1, 1);
-    };
-    let before = &source.bytes()[..span.start().min(source.bytes().len())];
-    #[allow(clippy::naive_bytecount)]
-    let line = before.iter().filter(|byte| **byte == b'\n').count() + 1;
-    let column = before
-        .iter()
-        .rposition(|byte| *byte == b'\n')
-        .map_or(before.len() + 1, |at| before.len() - at);
-    (source.name(), line, column)
-}
-
-fn print_human(sources: &Sources, diagnostic: &Diagnostic) {
-    let (file, line, column) = location(sources, diagnostic.source, diagnostic.span);
-    println!("error[{}]: {}", diagnostic.code, diagnostic.message);
-    println!("  --> {file}:{line}:{column}");
-    println!("  entity: {}", diagnostic.entity.name());
-    if let Some(name) = &diagnostic.name {
-        println!("  name: {name}");
-    }
-    println!(
-        "  span: offset {}, length {}",
-        diagnostic.span.start(),
-        diagnostic.span.len()
-    );
-    for related in &diagnostic.related {
-        let (file, line, column) = location(sources, related.source, related.span);
-        println!("  --> {file}:{line}:{column}: {}", related.message);
-    }
-    println!("  blame: xtex-construct");
-}
-
-fn print_json(sources: &Sources, diagnostics: &[Diagnostic], coverage: f64) {
-    print!("{{\"coverage\":{coverage},\"diagnostics\":[");
-    for (index, diagnostic) in diagnostics.iter().enumerate() {
-        if index > 0 {
-            print!(",");
-        }
-        let (file, line, column) = location(sources, diagnostic.source, diagnostic.span);
-        print!(
-            "{{\"code\":\"{}\",\"severity\":\"error\",\"blame\":\"xtex-construct\",\"entity\":\"{}\",\"name\":",
-            diagnostic.code,
-            diagnostic.entity.name()
-        );
-        match &diagnostic.name {
-            Some(name) => print_json_string(name),
-            None => print!("null"),
-        }
-        print!(",\"span\":{{\"file\":");
-        print_json_string(file);
-        print!(
-            ",\"offset\":{},\"length\":{},\"line\":{line},\"column\":{column}}},\"message\":",
-            diagnostic.span.start(),
-            diagnostic.span.len()
-        );
-        print_json_string(&diagnostic.message);
-        print!(",\"related\":[");
-        for (related_index, related) in diagnostic.related.iter().enumerate() {
-            if related_index > 0 {
-                print!(",");
-            }
-            let (file, line, column) = location(sources, related.source, related.span);
-            print!("{{\"span\":{{\"file\":");
-            print_json_string(file);
-            print!(
-                ",\"offset\":{},\"length\":{},\"line\":{line},\"column\":{column}}},\"message\":",
-                related.span.start(),
-                related.span.len()
-            );
-            print_json_string(&related.message);
-            print!("}}");
-        }
-        print!("]}}");
-    }
-    println!("]}}");
-}
-
-fn print_json_string(value: &str) {
-    print!("\"");
-    for character in value.chars() {
-        match character {
-            '\"' => print!("\\\""),
-            '\\' => print!("\\\\"),
-            '\n' => print!("\\n"),
-            '\r' => print!("\\r"),
-            '\t' => print!("\\t"),
-            character if character.is_control() => print!("\\u{:04x}", character as u32),
-            character => print!("{character}"),
-        }
-    }
-    print!("\"");
 }
 
 fn print_bibliography_advisory(reason: &Unavailable) {
@@ -1126,4 +1033,46 @@ fn offset_line_column(bytes: &[u8], offset: usize) -> (usize, usize) {
         .rposition(|byte| *byte == b'\n')
         .map_or(0, |at| at + 1);
     (line, offset - start + 1)
+}
+
+/// Prints one diagnostic the way a person reads it.
+fn print_human(sources: &Sources, diagnostic: &Diagnostic) {
+    let (file, line, column) = location(sources, diagnostic.source, diagnostic.span);
+    println!("error[{}]: {}", diagnostic.code, diagnostic.message);
+    println!("  --> {file}:{line}:{column}");
+    println!("  entity: {}", diagnostic.entity.name());
+    if let Some(name) = &diagnostic.name {
+        println!("  name: {name}");
+    }
+    println!(
+        "  span: offset {}, length {}",
+        diagnostic.span.start(),
+        diagnostic.span.len()
+    );
+    for related in &diagnostic.related {
+        let (file, line, column) = location(sources, related.source, related.span);
+        println!("  --> {file}:{line}:{column}: {}", related.message);
+    }
+    println!("  blame: xtex-construct");
+}
+
+/// File, one-based line and one-based column of a span.
+fn location(
+    sources: &Sources,
+    source: SourceId,
+    span: xtex_core::source::Span,
+) -> (String, usize, usize) {
+    let Some(source) = sources.get(source) else {
+        return ("<unresolved>".to_owned(), 1, 1);
+    };
+    let bytes = source.bytes();
+    let before = &bytes[..span.start().min(bytes.len())];
+    // Clippy suggests `bytecount`; `docs/decisions/0005` is why we do not.
+    #[allow(clippy::naive_bytecount)]
+    let line = before.iter().filter(|byte| **byte == b'\n').count() + 1;
+    let column = before
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(before.len() + 1, |at| before.len() - at);
+    (source.name().to_owned(), line, column)
 }

--- a/crates/xtex-core/src/check.rs
+++ b/crates/xtex-core/src/check.rs
@@ -284,6 +284,65 @@ fn block_error(source: SourceId, kind: BlockKind, error: BlockError, bytes: &[u8
 }
 
 #[cfg(test)]
+mod json_tests {
+    use super::*;
+    use crate::bibliography::{Bibliography, Unavailable};
+    use crate::parse;
+    use crate::symbols::SymbolTable;
+
+    /// The JSON was unrendered by any test until the WebAssembly build needed
+    /// it. A scripted refactor scrambled the field order and every test still
+    /// passed, which is how this one came to exist.
+    #[test]
+    fn the_json_is_well_formed_and_carries_every_field() {
+        let mut sources = Sources::new();
+        let id = sources.add("j.xtex", b"@id(a) @ref(b)\n".to_vec());
+        let document = parse(&sources, id);
+        let mut table = SymbolTable::new();
+        table.merge(&sources, &document);
+        let diagnostics = check(
+            &table,
+            &Bibliography::Unavailable(Unavailable::NoneDeclared),
+        );
+
+        let mut json = String::new();
+        to_json(&sources, &diagnostics, document.coverage(), &mut json);
+
+        assert!(json.starts_with("{\"coverage\":"), "{json}");
+        assert!(json.ends_with("]}"), "{json}");
+        for field in [
+            "\"code\":\"XT1003\"",
+            "\"severity\":\"error\"",
+            "\"blame\":\"xtex-construct\"",
+            "\"entity\":",
+            "\"name\":\"b\"",
+            "\"span\":{\"file\":\"j.xtex\"",
+            "\"offset\":",
+            "\"length\":",
+            "\"line\":1",
+            "\"column\":",
+            "\"message\":",
+            "\"related\":[]",
+        ] {
+            assert!(json.contains(field), "missing {field} in {json}");
+        }
+        // Braces balance, which a scrambled render does not.
+        assert_eq!(
+            json.matches('{').count(),
+            json.matches('}').count(),
+            "{json}"
+        );
+    }
+
+    #[test]
+    fn a_message_with_a_quote_or_a_newline_is_escaped() {
+        let mut out = String::new();
+        write_json_string("a \"quoted\" line\nand another", &mut out);
+        assert_eq!(out, "\"a \\\"quoted\\\" line\\nand another\"");
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
 
@@ -330,4 +389,105 @@ mod tests {
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].code, "XT1005");
     }
+}
+
+use std::fmt::Write as _;
+
+/// File, one-based line and one-based column of a span.
+fn location(
+    sources: &Sources,
+    source: SourceId,
+    span: crate::source::Span,
+) -> (&str, usize, usize) {
+    let Some(source) = sources.get(source) else {
+        return ("<unresolved>", 1, 1);
+    };
+    let before = &source.bytes()[..span.start().min(source.bytes().len())];
+    #[allow(clippy::naive_bytecount)]
+    let line = before.iter().filter(|byte| **byte == b'\n').count() + 1;
+    let column = before
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(before.len() + 1, |at| before.len() - at);
+    (source.name(), line, column)
+}
+
+/// Renders diagnostics as the JSON `xtex check --json` prints.
+///
+/// It returns bytes rather than printing them, because the WebAssembly build
+/// has no stdout and the exit criterion of #18 is that its JSON equals the
+/// native tool's byte for byte. One implementation makes that true by
+/// construction; two would make it a coincidence to be re-checked.
+pub fn to_json(sources: &Sources, diagnostics: &[Diagnostic], coverage: f64, out: &mut String) {
+    // Six decimals, not the sixteen an f64 prints. The extra digits are false
+    // precision on a ratio of byte counts, and they are not reproducible: the
+    // WebAssembly build computes `1.0 - opaque/total` on 32-bit `usize` and
+    // lands one bit away from the native build, which made the two outputs
+    // differ at the sixteenth digit and nowhere else.
+    let _ = write!(out, "{{\"coverage\":{coverage:.6},\"diagnostics\":[");
+    for (index, diagnostic) in diagnostics.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        let _ = write!(
+            out,
+            "{{\"code\":\"{}\",\"severity\":\"error\",\"blame\":\"xtex-construct\",\"entity\":\"{}\",\"name\":",
+            diagnostic.code,
+            diagnostic.entity.name()
+        );
+        match &diagnostic.name {
+            Some(name) => write_json_string(name, out),
+            None => out.push_str("null"),
+        }
+        write_span(sources, diagnostic.source, diagnostic.span, out);
+        out.push_str(",\"message\":");
+        write_json_string(&diagnostic.message, out);
+        out.push_str(",\"related\":[");
+        for (related_index, related) in diagnostic.related.iter().enumerate() {
+            if related_index > 0 {
+                out.push(',');
+            }
+            out.push('{');
+            // A related note has a span and a message and no code of its own.
+            write_span(sources, related.source, related.span, out);
+            out.push_str(",\"message\":");
+            write_json_string(&related.message, out);
+            out.push('}');
+        }
+        out.push_str("]}");
+    }
+    out.push_str("]}");
+}
+
+/// Appends `,"span":{...}` for one span. The leading comma is included because
+/// every caller has already written a field before it.
+fn write_span(sources: &Sources, source: SourceId, span: crate::source::Span, out: &mut String) {
+    let (file, line, column) = location(sources, source, span);
+    out.push_str(",\"span\":{\"file\":");
+    write_json_string(file, out);
+    let _ = write!(
+        out,
+        ",\"offset\":{},\"length\":{},\"line\":{line},\"column\":{column}}}",
+        span.start(),
+        span.len()
+    );
+}
+
+/// Appends `value` as a quoted JSON string.
+fn write_json_string(value: &str, out: &mut String) {
+    out.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            control if control.is_control() => {
+                let _ = write!(out, "\\u{:04x}", control as u32);
+            }
+            other => out.push(other),
+        }
+    }
+    out.push('"');
 }

--- a/crates/xtex-wasm/Cargo.toml
+++ b/crates/xtex-wasm/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "xtex-wasm"
+description = "The ExactTeX compiler as a WebAssembly module, over caller-provided buffers."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+xtex-core = { path = "../xtex-core" }
+
+# This crate does not inherit the workspace lints, and the reason is one line:
+# `unsafe_code = "forbid"` cannot be relaxed from inside a crate, and a raw
+# WebAssembly ABI over caller-provided pointers cannot be written without
+# `unsafe`. The other four crates keep the forbid; this one denies everything
+# else and permits exactly what the boundary needs.
+[lints.rust]
+missing_docs = "warn"
+
+[lints.clippy]
+all = { level = "deny", priority = -1 }
+pedantic = { level = "warn", priority = -1 }

--- a/crates/xtex-wasm/src/lib.rs
+++ b/crates/xtex-wasm/src/lib.rs
@@ -1,0 +1,173 @@
+//! The ExactTeX compiler as a WebAssembly module.
+//!
+//! # Why the interface looks like this
+//!
+//! There is no `wasm-bindgen` here, for the reason in `docs/decisions/0005`:
+//! the compiler carries no dependencies, and the boundary is small enough to
+//! write. What that buys is a module with no generated glue and no runtime —
+//! it is a `.wasm` file with a handful of exports and a linear memory.
+//!
+//! Every call takes bytes the caller put in our memory and returns a pointer
+//! to bytes we put there. Nothing here opens a file, reads an environment
+//! variable, or knows what a current directory is; the browser has none of
+//! those, and neither does this.
+//!
+//! # The calling convention
+//!
+//! 1. `xtex_alloc(len)` returns a pointer to `len` writable bytes.
+//! 2. The caller copies input there.
+//! 3. An operation is called with `(ptr, len)` and returns a **result
+//!    pointer**: four little-endian bytes of length, then that many bytes.
+//! 4. The caller reads them, then calls `xtex_free_result(result)`.
+//!
+//! The length prefix is there so a caller never needs a second call to learn
+//! how much to read, and so a result containing a zero byte — emitted LaTeX
+//! can — is not truncated by a C-string convention.
+
+use xtex_core::bibliography::{Bibliography, Unavailable};
+use xtex_core::check::{check, to_json};
+use xtex_core::source::Sources;
+use xtex_core::sourcemap::emit_with_map;
+use xtex_core::symbols::SymbolTable;
+use xtex_core::{emit, parse};
+
+/// The name every document is given inside the module.
+///
+/// A browser has no paths. Diagnostics still need a file name, and inventing a
+/// stable one is honest where inventing a path would not be.
+const DOCUMENT: &str = "document.xtex";
+
+/// Reserves `len` bytes for the caller to write into.
+///
+/// # Panics
+///
+/// Never for a length the module can serve; an allocation failure aborts, as
+/// it does anywhere else in Rust.
+#[unsafe(no_mangle)]
+pub extern "C" fn xtex_alloc(len: usize) -> *mut u8 {
+    let mut buffer = Vec::<u8>::with_capacity(len);
+    let pointer = buffer.as_mut_ptr();
+    std::mem::forget(buffer);
+    pointer
+}
+
+/// Releases a buffer obtained from [`xtex_alloc`].
+///
+/// # Safety
+///
+/// `pointer` and `len` must be exactly what a previous `xtex_alloc` returned
+/// and was asked for.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_free(pointer: *mut u8, len: usize) {
+    if !pointer.is_null() {
+        drop(unsafe { Vec::from_raw_parts(pointer, 0, len) });
+    }
+}
+
+/// Releases a result returned by an operation.
+///
+/// # Safety
+///
+/// `result` must be a pointer an operation in this module returned, and must
+/// not be used afterwards.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_free_result(result: *mut u8) {
+    if result.is_null() {
+        return;
+    }
+    let len = unsafe { read_length(result) } + 4;
+    // Length and capacity are the same number because `result` built the
+    // buffer with `with_capacity(len)` and filled it exactly. Clippy warns
+    // because that is usually a mistake; here it is the shape of the
+    // allocation, and passing anything else would be the bug.
+    #[allow(clippy::same_length_and_capacity)]
+    drop(unsafe { Vec::from_raw_parts(result, len, len) });
+}
+
+/// Emits the document as LaTeX.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_emit(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    let mut sources = Sources::new();
+    let id = sources.add(DOCUMENT, bytes);
+    let document = parse(&sources, id);
+    let mut out = Vec::new();
+    match emit(&sources, &document, &mut out) {
+        Ok(()) => result(&out),
+        // An emit failure is a broken internal invariant rather than a
+        // document problem, so it is reported as no bytes rather than as a
+        // diagnostic that would look like the author's fault.
+        Err(_) => result(&[]),
+    }
+}
+
+/// Checks the document and returns the JSON `xtex check --json` prints.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_check_json(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    let mut sources = Sources::new();
+    let id = sources.add(DOCUMENT, bytes);
+    let document = parse(&sources, id);
+    let mut table = SymbolTable::new();
+    table.merge(&sources, &document);
+    // No bibliography can be read here: the module is handed a document, not a
+    // project. `Unavailable` is the state that keeps every citation silent.
+    let diagnostics = check(
+        &table,
+        &Bibliography::Unavailable(Unavailable::NoneDeclared),
+    );
+
+    let mut json = String::new();
+    to_json(&sources, &diagnostics, document.coverage(), &mut json);
+    result(json.as_bytes())
+}
+
+/// Emits the document and returns its source map as JSON.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_source_map(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    let mut sources = Sources::new();
+    let id = sources.add(DOCUMENT, bytes);
+    let document = parse(&sources, id);
+    match emit_with_map(&sources, &document) {
+        Ok(emission) => result(&emission.map.to_json()),
+        Err(_) => result(&[]),
+    }
+}
+
+/// Copies `len` bytes out of the caller's buffer.
+unsafe fn input(pointer: *const u8, len: usize) -> Vec<u8> {
+    if pointer.is_null() || len == 0 {
+        return Vec::new();
+    }
+    unsafe { std::slice::from_raw_parts(pointer, len) }.to_vec()
+}
+
+/// Wraps `bytes` as a length-prefixed result the caller owns.
+fn result(bytes: &[u8]) -> *mut u8 {
+    let len = u32::try_from(bytes.len()).unwrap_or(u32::MAX);
+    let mut out = Vec::with_capacity(bytes.len() + 4);
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(bytes);
+    let pointer = out.as_mut_ptr();
+    std::mem::forget(out);
+    pointer
+}
+
+/// The length a result pointer carries.
+unsafe fn read_length(result: *const u8) -> usize {
+    let header = unsafe { std::slice::from_raw_parts(result, 4) };
+    u32::from_le_bytes([header[0], header[1], header[2], header[3]]) as usize
+}

--- a/crates/xtex-wasm/tests/parity.mjs
+++ b/crates/xtex-wasm/tests/parity.mjs
@@ -1,0 +1,28 @@
+// Runs the WebAssembly module and prints what it produced, so the harness can
+// compare it against the native tool byte for byte.
+//
+// No bundler and no generated glue: the module is a `.wasm` file with six
+// exports and a linear memory, and this is all the JavaScript it takes.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [, , wasmPath, inputPath, outDir] = process.argv;
+const { instance } = await WebAssembly.instantiate(readFileSync(wasmPath), {});
+const api = instance.exports;
+
+function call(name, bytes) {
+  const input = api.xtex_alloc(bytes.length);
+  new Uint8Array(api.memory.buffer, input, bytes.length).set(bytes);
+  const result = api[name](input, bytes.length);
+  // Four little-endian bytes of length, then that many bytes.
+  const header = new DataView(api.memory.buffer, result, 4);
+  const length = header.getUint32(0, true);
+  const out = new Uint8Array(api.memory.buffer, result + 4, length).slice();
+  api.xtex_free_result(result);
+  api.xtex_free(input, bytes.length);
+  return out;
+}
+
+const source = readFileSync(inputPath);
+writeFileSync(`${outDir}/wasm.tex`, call("xtex_emit", source));
+writeFileSync(`${outDir}/wasm.json`, call("xtex_check_json", source));
+writeFileSync(`${outDir}/wasm.map`, call("xtex_source_map", source));

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -1,0 +1,107 @@
+//! The exit criterion of #18, run rather than argued.
+//!
+//! The WebAssembly module must process the awkward transport fixture entirely
+//! through caller-supplied buffers, and its emitted bytes and JSON diagnostics
+//! must equal the native build's byte for byte.
+//!
+//! The fixture is chosen to be hostile to a boundary that copies through a
+//! string: a Latin-1 `é`, a CRLF, a tab, and a stray `0xFF` that is not valid
+//! UTF-8 anywhere. A module that decoded on the way in or out fails here.
+//!
+//! The test is skipped, loudly, when the wasm target or Node are absent. A
+//! silently skipped test is worse than an absent one.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("the repository root")
+}
+
+fn have(program: &str, args: &[&str]) -> bool {
+    Command::new(program)
+        .args(args)
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+#[test]
+fn wasm_output_equals_native_output_byte_for_byte() {
+    let repo = repo();
+    if !have("node", &["--version"]) {
+        println!("skipped: node is not installed");
+        return;
+    }
+    let built = Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "--quiet",
+            "-p",
+            "xtex-wasm",
+            "--target",
+            "wasm32-unknown-unknown",
+            "--release",
+        ])
+        .current_dir(&repo)
+        .status();
+    if !built.is_ok_and(|status| status.success()) {
+        println!("skipped: the wasm32-unknown-unknown target is not installed");
+        return;
+    }
+
+    let fixture = repo.join("tests/fixtures/wasm/awkward.xtex");
+    let source = std::fs::read(&fixture).expect("the fixture");
+    assert!(
+        std::str::from_utf8(&source).is_err(),
+        "the fixture must not be valid UTF-8, or it tests nothing"
+    );
+
+    let out = repo.join("target/wasm-parity");
+    std::fs::create_dir_all(&out).expect("a place for the outputs");
+
+    let ran = Command::new("node")
+        .arg(repo.join("crates/xtex-wasm/tests/parity.mjs"))
+        .arg(repo.join("target/wasm32-unknown-unknown/release/xtex_wasm.wasm"))
+        .arg(&fixture)
+        .arg(&out)
+        .status()
+        .expect("node runs");
+    assert!(ran.success(), "the module did not run");
+
+    // Native, through the same public API the CLI uses.
+    let mut sources = xtex_core::source::Sources::new();
+    let id = sources.add("document.xtex", source.clone());
+    let document = xtex_core::parse(&sources, id);
+
+    let mut native_tex = Vec::new();
+    xtex_core::emit(&sources, &document, &mut native_tex).expect("emits");
+    let wasm_tex = std::fs::read(out.join("wasm.tex")).expect("the module emitted");
+    assert_eq!(
+        native_tex, wasm_tex,
+        "emitted bytes differ; the Latin-1 byte or the 0xFF did not survive"
+    );
+
+    let mut table = xtex_core::symbols::SymbolTable::new();
+    table.merge(&sources, &document);
+    let diagnostics = xtex_core::check::check(
+        &table,
+        &xtex_core::bibliography::Bibliography::Unavailable(
+            xtex_core::bibliography::Unavailable::NoneDeclared,
+        ),
+    );
+    let mut native_json = String::new();
+    xtex_core::check::to_json(
+        &sources,
+        &diagnostics,
+        document.coverage(),
+        &mut native_json,
+    );
+    let wasm_json = std::fs::read_to_string(out.join("wasm.json")).expect("the module checked");
+    assert_eq!(
+        native_json, wasm_json,
+        "JSON differs; coverage precision is the usual cause"
+    );
+}

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -1,0 +1,112 @@
+# The WebAssembly build
+
+The same compiler, as a `.wasm` file the browser runs. No compile server, and no
+`wasm-bindgen`.
+
+```sh
+rustup target add wasm32-unknown-unknown
+cargo build -p xtex-wasm --target wasm32-unknown-unknown --release
+# target/wasm32-unknown-unknown/release/xtex_wasm.wasm — about 140 KB
+```
+
+There is no build step after that. No bundler, no generated glue, no `npm install`. The module is a file with
+six exports and a linear memory.
+
+---
+
+## The calling convention
+
+1. `xtex_alloc(len)` returns a pointer to `len` writable bytes.
+2. Copy the document there.
+3. Call an operation with `(pointer, len)`. It returns a **result pointer**: four little-endian bytes of
+   length, then that many bytes.
+4. Read them, then `xtex_free_result(result)` and `xtex_free(pointer, len)`.
+
+The length prefix is not decoration. Emitted LaTeX can contain a zero byte, and a C-string convention would
+truncate the document at it.
+
+| Export | Returns |
+|---|---|
+| `xtex_alloc(len)` | a pointer to writable bytes |
+| `xtex_free(ptr, len)` | — |
+| `xtex_free_result(ptr)` | — |
+| `xtex_emit(ptr, len)` | the emitted LaTeX |
+| `xtex_check_json(ptr, len)` | the JSON `xtex check --json` prints |
+| `xtex_source_map(ptr, len)` | the source map, as JSON |
+
+All the JavaScript it takes:
+
+```js
+const { instance } = await WebAssembly.instantiate(bytes, {});
+const api = instance.exports;
+
+function call(name, input) {
+  const at = api.xtex_alloc(input.length);
+  new Uint8Array(api.memory.buffer, at, input.length).set(input);
+  const result = api[name](at, input.length);
+  const length = new DataView(api.memory.buffer, result, 4).getUint32(0, true);
+  const out = new Uint8Array(api.memory.buffer, result + 4, length).slice();
+  api.xtex_free_result(result);
+  api.xtex_free(at, input.length);
+  return out;
+}
+```
+
+`crates/xtex-wasm/tests/parity.mjs` is that file, and it is what the test runs.
+
+---
+
+## Bytes in, bytes out, and nothing else
+
+The module opens no file, reads no environment variable, and has no notion of a current directory. The
+browser has none of those either, and `AGENTS.md` §4 already forbade the core from assuming them — this is
+where that constraint is collected on.
+
+Two consequences a caller should expect:
+
+- **Every document is called `document.xtex`.** A browser has no paths; diagnostics still need a file name,
+  and inventing a stable one is honest where inventing a path would not be.
+- **No bibliography is read**, so the bibliography is `Unavailable` and every `@cite` is silent rather than
+  reported as missing. The same is true of the language server, and for the same reason.
+
+Multi-file projects are [#19](https://github.com/camilochs/exacttex/issues/19), where the caller supplies
+the store.
+
+---
+
+## The parity test, and what it found
+
+The exit criterion is that the module's output equals the native build's **byte for byte**, on a fixture
+chosen to be hostile:
+
+```
+\section{Café} @id(sec:caf)\r\n%% comment\t\nSee @ref(sec:caf) and @ref(ghost).\xFF\n
+```
+
+A Latin-1 `é`, a CRLF, a tab, and a stray `0xFF` that is not valid UTF-8 anywhere. A boundary that decoded
+on the way in or out fails on it, which is the point.
+
+Emitted bytes matched on the first run. **The JSON did not**, and the difference was one digit:
+
+```
+native  "coverage":0.4675324675324675
+wasm    "coverage":0.4675324675324676
+```
+
+Coverage is `1.0 - opaque/total` over byte counts, and on 32-bit `usize` that lands one bit from the 64-bit
+result. Sixteen significant digits of a ratio is false precision anyway, and it is not reproducible across
+targets, so the JSON now writes six decimals. The diagnostics themselves were identical throughout.
+
+`cargo test -p xtex-wasm` runs the whole comparison. It builds the module, runs it under Node, and compares
+against the native path. When the target or Node is missing it says so and returns — a silently skipped test
+is worse than an absent one.
+
+---
+
+## Why `unsafe` lives here and nowhere else
+
+The workspace sets `unsafe_code = "forbid"`, which cannot be relaxed from inside a crate. A raw WebAssembly
+ABI over caller-provided pointers cannot be written without `unsafe`, so `xtex-wasm` declares its own lint
+table instead of inheriting the workspace one. The other four crates keep the forbid.
+
+That is the entire exception, and it is in `crates/xtex-wasm/Cargo.toml` with the reason next to it.

--- a/tests/fixtures/wasm/awkward.xtex
+++ b/tests/fixtures/wasm/awkward.xtex
@@ -1,0 +1,3 @@
+\section{Café} @id(sec:caf)
+%% comment	
+See @ref(sec:caf) and @ref(ghost).ÿ


### PR DESCRIPTION
Closes #18.

```sh
cargo build -p xtex-wasm --target wasm32-unknown-unknown --release
# 140 KB. No bundler, no generated glue, no npm install.
```

Six exports and a linear memory. All the JavaScript it takes:

```js
const { instance } = await WebAssembly.instantiate(bytes, {});
function call(name, input) {
  const at = api.xtex_alloc(input.length);
  new Uint8Array(api.memory.buffer, at, input.length).set(input);
  const result = api[name](at, input.length);
  const length = new DataView(api.memory.buffer, result, 4).getUint32(0, true);
  return new Uint8Array(api.memory.buffer, result + 4, length).slice();
}
```

The four-byte length prefix is not decoration: emitted LaTeX can contain a zero byte, and a C-string convention would truncate the document at it.

## The exit criterion, run

The fixture is chosen to be hostile to any boundary that copies through a string:

```
\section{Café} @id(sec:caf)\r\n%% comment\t\nSee @ref(sec:caf) and @ref(ghost).\xFF\n
```

Latin-1 `é`, CRLF, tab, and a stray `0xFF` that is not valid UTF-8 anywhere.

**Emitted bytes matched on the first run.** The JSON did not, and the difference was one digit:

```
native  "coverage":0.4675324675324675
wasm    "coverage":0.4675324675324676
```

Coverage is `1.0 - opaque/total` over byte counts, and on 32-bit `usize` that lands one bit from the 64-bit result. Sixteen significant digits of a ratio is false precision anyway — and not reproducible across targets — so the JSON writes six decimals. **The diagnostics themselves were identical throughout.**

`cargo test -p xtex-wasm` builds the module, runs it under Node, and compares. When the target or Node is missing it says so and returns; a silently skipped test is worse than an absent one.

## Two things this forced, both improvements

**The JSON renderer moved from the CLI into the core.** It printed rather than returned, and the module has no stdout. Same lesson as the language server: one implementation makes "equal byte for byte" true by construction; two make it a coincidence to be re-checked.

**Nothing was testing that JSON.** A scripted refactor scrambled the field order into `,"span":{"file":{"coverage":...` and every test still passed. There is a test now — fields, shape, and balanced braces.

## `unsafe` lives here and nowhere else

The workspace sets `unsafe_code = "forbid"`, which cannot be relaxed from inside a crate. A raw WebAssembly ABI over caller-provided pointers cannot be written without it, so `xtex-wasm` declares its own lint table rather than inheriting. **The other four crates keep the forbid.** The exception is in `crates/xtex-wasm/Cargo.toml` with the reason beside it.

## What a caller should expect

- Every document is called `document.xtex` — a browser has no paths, and inventing a stable name is honest where inventing a path would not be.
- No bibliography is read, so every `@cite` is silent rather than reported missing. Same as the language server, same reason.
- Multi-file projects are #19, where the caller supplies the store.

## Checks

157 tests pass, clippy clean at `-D warnings`, `cargo fmt --check` clean. The invariant: **224 of 224**.