### PR TITLE
Assemble the transport corpus, and record what it cannot yet show

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -322,6 +322,10 @@ Shallow LaTeX parsing, parser quarantine, opaque transport, selected macro decla
 multi-file preservation, and TeX-log attribution. Assemble licensed corpus files with declared provenance
 plus synthetic files for every parser hazard. Set quarantine thresholds before measuring the corpus.
 
+Done: `tests/corpus/` holds the thresholds, the tooling and ten hazard fixtures. Real documents are
+referenced by fingerprint rather than vendored, because their licences are not ours to grant. The baseline
+was taken and is recorded with the reason it does not yet mean what it appears to.
+
 **Done when** every corpus file transports byte-for-byte with no per-file special case, and quarantine stays
 rare enough that real documents still have room to annotate.
 

--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -135,6 +135,9 @@ fn main() -> ExitCode {
     if first == "check" {
         return check_command(&args[1..]);
     }
+    if first == "confidence" {
+        return confidence_command(&args[1..]);
+    }
     if first == "rename" {
         return rename_command(&args[1..]);
     }
@@ -1075,4 +1078,42 @@ fn location(
         .rposition(|byte| *byte == b'\n')
         .map_or(before.len() + 1, |at| before.len() - at);
     (source.name().to_owned(), line, column)
+}
+
+/// Reports how much of a file the parser recognises before giving up.
+///
+/// One line, meant for `tests/corpus/measure.py` rather than for a person:
+/// the fraction of the file available before `OpaqueToEof`, or `none` when
+/// recognition never stops.
+fn confidence_command(args: &[String]) -> ExitCode {
+    let Some(input) = args.first() else {
+        eprintln!("usage: xtex confidence <file.tex>");
+        return ExitCode::from(2);
+    };
+    let loader = FileSystem {
+        root: PathBuf::from("."),
+    };
+    let mut sources = Sources::new();
+    let Ok(id) = loader.load(input, None, &mut sources) else {
+        eprintln!("error: cannot read {input}");
+        return ExitCode::from(2);
+    };
+    let document = parse(&sources, id);
+    let Some(source) = sources.get(id) else {
+        return ExitCode::from(2);
+    };
+    let total = source.bytes().len();
+
+    match document.quarantine_position() {
+        // A file with no bytes is available in full rather than not at all.
+        Some(at) if total > 0 => {
+            #[allow(clippy::cast_precision_loss)]
+            let fraction = at as f64 / total as f64;
+            println!("quarantine: {fraction:.6}");
+        }
+        _ => println!("quarantine: none"),
+    }
+    println!("bytes: {total}");
+    println!("coverage: {:.6}", document.coverage());
+    ExitCode::SUCCESS
 }

--- a/crates/xtex-core/src/document.rs
+++ b/crates/xtex-core/src/document.rs
@@ -233,6 +233,22 @@ impl Document {
         }
     }
 
+    /// Byte offset where recognition stopped for good, if it did.
+    ///
+    /// The number `tests/corpus/measure.py` reports. A file that never
+    /// quarantines has none, and one that quarantines at its first byte has
+    /// zero — which is the difference between a document an author can annotate
+    /// and one they cannot.
+    #[must_use]
+    pub fn quarantine_position(&self) -> Option<usize> {
+        self.nodes.iter().find_map(|node| match node {
+            Node::Opaque {
+                span, confidence, ..
+            } if !confidence.recognition_continues() => Some(span.start()),
+            _ => None,
+        })
+    }
+
     /// Whether the parser gave up before the end of the source.
     #[must_use]
     pub fn reached_end_of_recognition(&self) -> bool {

--- a/tests/corpus/README.md
+++ b/tests/corpus/README.md
@@ -1,0 +1,105 @@
+# The transport corpus
+
+Real LaTeX, used to decide how the shallow parser behaves. Two halves with different rules.
+
+| | Where it lives | Why |
+|---|---|---|
+| **Real documents** | referenced, never copied here | licences we do not hold |
+| **Adversarial fixtures** | in this repository | ours, and written to break things |
+
+---
+
+## Real documents are referenced, not vendored
+
+`manifest.toml` records, per file: where it came from, under what licence, and a SHA-256 of the exact bytes
+measured. It does not contain the file.
+
+The reason is ordinary caution. A journal submission's copyright frequently sits with the publisher, and
+this repository is MIT. Recording a fingerprint claims nothing about the bytes except that they are the ones
+the number was computed from — which is the only claim a measurement needs.
+
+It is also better evidence. Anyone can point the tooling at their own corpus and get a comparable number,
+and the fingerprint makes a stale result detectable rather than silently reused. That is the measurement
+rule in [`AGENTS.md`](../../AGENTS.md) §7 applied to our own inputs.
+
+```sh
+python3 tests/corpus/measure.py ~/Workspace          # measure a corpus
+python3 tests/corpus/measure.py --verify manifest.toml   # check the fingerprints still match
+```
+
+---
+
+## The thresholds, recorded before the measurement
+
+The parser has three confidence levels, and the one that matters is `OpaqueToEof`: once a file enters it,
+nothing further in that file is recognised. A file quarantined early is a file an author cannot annotate.
+
+**The metric.** For each file, the byte position where `OpaqueToEof` begins, as a fraction of the file's
+length. A file that never quarantines scores `1.0`. A file quarantined at its first byte scores `0.0`.
+
+**What would count as failure**, fixed on 2026-08-29, before any corpus was measured:
+
+| | Threshold |
+|---|---|
+| Median file | **≥ 0.90** available before quarantine |
+| Files quarantined before half their bytes | **≤ 10%** |
+
+The first is the one that matters. ExactTeX's on-ramp is "rename a `.tex` and start annotating", and an
+author whose typical document goes dark at 60% cannot do that — the promise fails for the median case, not
+the worst one.
+
+The second catches a different shape: a small number of files that quarantine almost immediately would not
+move the median but would mean a whole class of documents is unusable, and that class needs naming rather
+than averaging away.
+
+**Why these numbers and not others.** They are a judgement, not a derivation, and stating them before
+measuring is what stops them from becoming whatever the first result happened to be. Missing them is not
+proof the parser is wrong; it is a signal to look at *which* files failed and why, and either fix the
+handling or record the class as unsupported with its reason.
+
+---
+
+## Adversarial fixtures
+
+Under `hazards/`, one directory per parser hazard in [`ROADMAP.md`](../../ROADMAP.md)'s table. These are
+written here rather than found, because a corpus contains what its authors happened to write and the
+dangerous cases are exactly the ones nobody writes on purpose.
+
+Each carries the observation that would show its handling is wrong — the roadmap's own falsifier — so a
+fixture that starts passing for the wrong reason is visible.
+
+---
+
+## Baseline, 2026-08-29 — and why it does not mean what it says
+
+```
+555 files
+  median available before quarantine   1.000   (threshold >= 0.900)
+  quarantined before half their bytes  0.0%     (threshold <= 10%)
+  never quarantined                    555
+thresholds: met
+```
+
+**Do not read this as the parser passing.** It is the measurement taken *before* the shallow LaTeX parser
+exists, and what it records is that almost nothing quarantines yet — because almost nothing is detected yet.
+
+The hazard fixtures say so directly. Three of them are specified to enter `OpaqueToEof`, and on this build
+none of them does:
+
+| Fixture | Specified | Today |
+|---|---|---|
+| `01-verb-without-a-terminator` | `OpaqueToEof` | none |
+| `03-catcode-at-top-level` | `OpaqueToEof` | none |
+| `04-makeatletter-unmatched` | `OpaqueToEof` | none |
+
+A number that reports success while measuring the absence of the thing it names is the failure mode
+[`AGENTS.md`](../../AGENTS.md) §7 exists to catch, so it is written down here rather than quoted as a
+result.
+
+**What the baseline is good for** is the comparison. When [#21](https://github.com/camilochs/exacttex/issues/21)
+lands, quarantine will start firing, and the same command on the same fingerprinted bytes says whether it
+fires where it should or everywhere. A threshold met before the parser existed and missed after it would be
+information; a threshold met in both cases would mean the parser changed nothing.
+
+Re-run it against this manifest rather than against a fresh sweep, or the comparison is between two
+different corpora.

--- a/tests/corpus/hazards/01-verb-without-a-terminator/expect.txt
+++ b/tests/corpus/hazards/01-verb-without-a-terminator/expect.txt
@@ -1,0 +1,3 @@
+confidence: OpaqueToEof from the \verb
+constructs: ref(seen) only
+falsifier: bytes inside the literal become constructs, or a terminator is invented

--- a/tests/corpus/hazards/01-verb-without-a-terminator/input.xtex
+++ b/tests/corpus/hazards/01-verb-without-a-terminator/input.xtex
@@ -1,0 +1,2 @@
+Before @ref(seen).
+\verb|never closed and @ref(hidden) with it

--- a/tests/corpus/hazards/02-verbatim-holding-every-marker/expect.txt
+++ b/tests/corpus/hazards/02-verbatim-holding-every-marker/expect.txt
@@ -1,0 +1,3 @@
+confidence: the environment is opaque, recognition resumes after it
+constructs: ref(after) only
+falsifier: a marker inside becomes a construct, or any contained byte changes

--- a/tests/corpus/hazards/02-verbatim-holding-every-marker/input.xtex
+++ b/tests/corpus/hazards/02-verbatim-holding-every-marker/input.xtex
@@ -1,0 +1,4 @@
+\begin{verbatim}
+@id(a) @ref(b) @cite(c) \figure(d) { } latex {e}
+\end{verbatim}
+After @ref(after).

--- a/tests/corpus/hazards/03-catcode-at-top-level/expect.txt
+++ b/tests/corpus/hazards/03-catcode-at-top-level/expect.txt
@@ -1,0 +1,3 @@
+confidence: OpaqueToEof from the \catcode
+constructs: ref(seen) only
+falsifier: parsing resumes past a boundary expansion can move

--- a/tests/corpus/hazards/03-catcode-at-top-level/input.xtex
+++ b/tests/corpus/hazards/03-catcode-at-top-level/input.xtex
@@ -1,0 +1,3 @@
+Before @ref(seen).
+\catcode`\@=11
+After @ref(hidden).

--- a/tests/corpus/hazards/04-makeatletter-unmatched/expect.txt
+++ b/tests/corpus/hazards/04-makeatletter-unmatched/expect.txt
@@ -1,0 +1,3 @@
+confidence: OpaqueToEof — the opener has no \makeatother
+constructs: none
+falsifier: the control sequence is split at @, or a construct is recognised after the opener

--- a/tests/corpus/hazards/04-makeatletter-unmatched/input.xtex
+++ b/tests/corpus/hazards/04-makeatletter-unmatched/input.xtex
@@ -1,0 +1,3 @@
+\makeatletter
+\@internal@name is one control sequence, not split at the @.
+@ref(hidden) after an opener that never closes.

--- a/tests/corpus/hazards/05-newcommand-body-with-a-marker/expect.txt
+++ b/tests/corpus/hazards/05-newcommand-body-with-a-marker/expect.txt
@@ -1,0 +1,3 @@
+confidence: the body is opaque; the name \mycmd and arity 2 are recorded
+constructs: ref(after) only
+falsifier: the body is expanded, normalised, or counted as checked content

--- a/tests/corpus/hazards/05-newcommand-body-with-a-marker/input.xtex
+++ b/tests/corpus/hazards/05-newcommand-body-with-a-marker/input.xtex
@@ -1,0 +1,2 @@
+\newcommand{\mycmd}[2]{sees @ref(inside) and #1 and #2}
+Then @ref(after).

--- a/tests/corpus/hazards/06-csname-generated-name/expect.txt
+++ b/tests/corpus/hazards/06-csname-generated-name/expect.txt
@@ -1,0 +1,3 @@
+confidence: OpaqueBalanced over the whole \csname group
+constructs: ref(after) only
+falsifier: the generated name enters the symbol table as a declaration

--- a/tests/corpus/hazards/06-csname-generated-name/input.xtex
+++ b/tests/corpus/hazards/06-csname-generated-name/input.xtex
@@ -1,0 +1,2 @@
+\csname sec@\romannumeral 3 \endcsname
+Then @ref(after).

--- a/tests/corpus/hazards/07-conditional-both-branches/expect.txt
+++ b/tests/corpus/hazards/07-conditional-both-branches/expect.txt
@@ -1,0 +1,3 @@
+confidence: every branch opaque; the condition is not evaluated
+constructs: ref(after) only
+falsifier: one branch is dropped, or a construct in either branch is a hard error

--- a/tests/corpus/hazards/07-conditional-both-branches/input.xtex
+++ b/tests/corpus/hazards/07-conditional-both-branches/input.xtex
@@ -1,0 +1,6 @@
+\ifdefined\pdfoutput
+  @ref(taken)
+\else
+  @ref(nottaken)
+\fi
+Then @ref(after).

--- a/tests/corpus/hazards/08-input-is-an-edge-not-a-splice/expect.txt
+++ b/tests/corpus/hazards/08-input-is-an-edge-not-a-splice/expect.txt
@@ -1,0 +1,3 @@
+confidence: an opaque project edge
+constructs: ref(after) only
+falsifier: normal output contains the imported bytes inlined

--- a/tests/corpus/hazards/08-input-is-an-edge-not-a-splice/input.xtex
+++ b/tests/corpus/hazards/08-input-is-an-edge-not-a-splice/input.xtex
@@ -1,0 +1,2 @@
+\input{sections/part}
+Then @ref(after).

--- a/tests/corpus/hazards/09-newenvironment-shell-only/expect.txt
+++ b/tests/corpus/hazards/09-newenvironment-shell-only/expect.txt
@@ -1,0 +1,3 @@
+confidence: the declaration shell is located; both bodies opaque
+constructs: ref(after) only
+falsifier: a marker in a definition body is treated as an active construct

--- a/tests/corpus/hazards/09-newenvironment-shell-only/input.xtex
+++ b/tests/corpus/hazards/09-newenvironment-shell-only/input.xtex
@@ -1,0 +1,2 @@
+\newenvironment{mine}[1]{begin @ref(inbegin) #1}{end @ref(inend)}
+Then @ref(after).

--- a/tests/corpus/hazards/10-verbatim-name-that-is-not-configured/expect.txt
+++ b/tests/corpus/hazards/10-verbatim-name-that-is-not-configured/expect.txt
@@ -1,0 +1,5 @@
+confidence: not a known verbatim environment, so its body is ordinary
+constructs: ref(exposed)
+falsifier: an unconfigured environment is guessed to be verbatim, which would
+  silently stop checking content the author expects checked. The remedy is
+  xtex.toml, not inference.

--- a/tests/corpus/hazards/10-verbatim-name-that-is-not-configured/input.xtex
+++ b/tests/corpus/hazards/10-verbatim-name-that-is-not-configured/input.xtex
@@ -1,0 +1,3 @@
+\begin{mycustomverb}
+@ref(exposed)
+\end{mycustomverb}

--- a/tests/corpus/hazards/README.md
+++ b/tests/corpus/hazards/README.md
@@ -1,0 +1,29 @@
+# Hazard fixtures
+
+One per row of the parser hazard table in [`ROADMAP.md`](../../../ROADMAP.md). Each carries the
+**falsifying observation** from that table — the thing that, if seen, means the handling is wrong.
+
+They are written here rather than found in a corpus, because a corpus contains what its authors happened to
+write, and these are the cases nobody writes on purpose.
+
+## Not handled yet
+
+The shallow LaTeX parser is [#21](https://github.com/camilochs/exacttex/issues/21) and does not exist. Every
+fixture below is specified and unsatisfied, which is the point of writing them first:
+
+| Fixture | Specified behaviour |
+|---|---|
+| `01-verb-without-a-terminator` | `OpaqueToEof`, no invented terminator |
+| `02-verbatim-holding-every-marker` | opaque body, recognition resumes after |
+| `03-catcode-at-top-level` | `OpaqueToEof` |
+| `04-makeatletter-unmatched` | `OpaqueToEof` |
+| `05-newcommand-body-with-a-marker` | opaque body; name and arity recorded |
+| `06-csname-generated-name` | `OpaqueBalanced`; no inferred name |
+| `07-conditional-both-branches` | both branches opaque, condition unevaluated |
+| `08-input-is-an-edge-not-a-splice` | an opaque project edge |
+| `09-newenvironment-shell-only` | shell located, bodies opaque |
+| `10-verbatim-name-that-is-not-configured` | ordinary — no guessing |
+
+The last one is the only one that asserts something must **not** happen. Guessing that an unknown
+environment is verbatim would silently stop checking content the author expects checked, and the remedy is
+`xtex.toml` rather than inference.

--- a/tests/corpus/measure.py
+++ b/tests/corpus/measure.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Measures a LaTeX corpus, and verifies a manifest against it.
+
+Two jobs, deliberately in one file so the numbers and the fingerprints they were
+computed from cannot drift apart.
+
+    python3 measure.py <root>                 measure, and write a manifest
+    python3 measure.py --verify <manifest>    check the bytes still match
+
+The measurement asks one question per file: at what byte position does the
+parser stop recognising anything? `tests/corpus/README.md` records the
+thresholds, and it records them from before any corpus was measured.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+
+def tex_files(root):
+    for base, dirs, names in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in {".git", "node_modules", "target", "build"}]
+        for name in names:
+            if name.endswith((".tex", ".xtex")):
+                yield os.path.join(base, name)
+
+
+def fingerprint(path):
+    with open(path, "rb") as handle:
+        return hashlib.sha256(handle.read()).hexdigest()
+
+
+def quarantine_position(binary, path):
+    """Fraction of the file available before `OpaqueToEof`, or 1.0 if never."""
+    result = subprocess.run(
+        [binary, "confidence", path], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        if line.startswith("quarantine:"):
+            value = line.split(":", 1)[1].strip()
+            return 1.0 if value == "none" else float(value)
+    return None
+
+
+def measure(root, binary):
+    rows = []
+    for path in sorted(tex_files(root)):
+        size = os.path.getsize(path)
+        if size == 0:
+            continue
+        position = quarantine_position(binary, path)
+        if position is None:
+            continue
+        rows.append(
+            {
+                "path": os.path.relpath(path, root),
+                "sha256": fingerprint(path),
+                "bytes": size,
+                "available": position,
+            }
+        )
+    return rows
+
+
+def report(rows):
+    if not rows:
+        print("no files measured")
+        return 1
+    available = sorted(row["available"] for row in rows)
+    median = available[len(available) // 2]
+    early = sum(1 for value in available if value < 0.5) / len(available)
+
+    print(f"{len(rows)} files")
+    print(f"  median available before quarantine   {median:.3f}   (threshold >= 0.900)")
+    print(f"  quarantined before half their bytes  {early:.1%}     (threshold <= 10%)")
+    print(f"  never quarantined                    {sum(1 for v in available if v >= 1.0)}")
+
+    failed = median < 0.90 or early > 0.10
+    print("\nthresholds: " + ("MISSED" if failed else "met"))
+    if failed:
+        print("  Which files, and why, before changing the numbers. The thresholds")
+        print("  were fixed before any corpus was measured; moving them now would")
+        print("  make them a description of the result rather than a test of it.")
+        for row in sorted(rows, key=lambda r: r["available"])[:10]:
+            print(f"    {row['available']:.3f}  {row['path']}")
+    return 1 if failed else 0
+
+
+def verify(manifest_path):
+    with open(manifest_path) as handle:
+        manifest = json.load(handle)
+    root = manifest["root"]
+    changed = []
+    missing = []
+    for row in manifest["files"]:
+        path = os.path.join(root, row["path"])
+        if not os.path.exists(path):
+            missing.append(row["path"])
+        elif fingerprint(path) != row["sha256"]:
+            changed.append(row["path"])
+
+    print(f"{len(manifest['files'])} files in the manifest")
+    print(f"  missing  {len(missing)}")
+    print(f"  changed  {len(changed)}")
+    for path in (missing + changed)[:10]:
+        print(f"    {path}")
+    if missing or changed:
+        print("\nThe recorded measurement was taken from bytes that are no longer")
+        print("there. Re-measure before reusing any number from it.")
+        return 1
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("target")
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--binary", default="target/debug/xtex")
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    if args.verify:
+        return verify(args.target)
+
+    rows = measure(args.target, args.binary)
+    if args.out:
+        with open(args.out, "w") as handle:
+            json.dump({"root": os.path.abspath(args.target), "files": rows}, handle, indent=2)
+        print(f"manifest written to {args.out}\n")
+    return report(rows)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #20. First of Phase 4.

## Two halves, different rules

| | Where | Why |
|---|---|---|
| Real documents | **referenced by SHA-256, never copied here** | a journal submission's copyright usually sits with the publisher; this repo is MIT |
| Adversarial fixtures | in the repo | ours, and a corpus only contains what its authors happened to write |

Referencing is also better evidence: anyone can point the tooling at their own corpus and get a comparable number, and the fingerprints make a stale result detectable rather than silently reused. `measure.py --verify` reports which files changed — checked by changing one:

```
555 files in the manifest
  missing  0
  changed  1
    01_Me/Books/IA-generativa-libros/fuentes-guIA/guia-hoja-de-ruta.tex

The recorded measurement was taken from bytes that are no longer there.
```

## The thresholds, fixed before any corpus was measured

| | Threshold |
|---|---|
| Median file available before quarantine | **≥ 0.90** |
| Files quarantined before half their bytes | **≤ 10%** |

The first is the one that matters: the on-ramp is *"rename a `.tex` and start annotating"*, and an author whose typical document goes dark at 60% cannot do that.

Writing them down first is what stops them becoming a description of whatever the first result happened to be.

## The baseline, and why it does not mean what it says

```
555 files
  median available before quarantine   1.000   (threshold >= 0.900)
  quarantined before half their bytes  0.0%     (threshold <= 10%)
thresholds: met
```

**This is not the parser passing.** The shallow LaTeX parser is #21 and does not exist. What the number measures is that almost nothing quarantines yet — because almost nothing is *detected* yet.

The hazard fixtures say so directly:

| Fixture | Specified | Today |
|---|---|---|
| `01-verb-without-a-terminator` | `OpaqueToEof` | none |
| `03-catcode-at-top-level` | `OpaqueToEof` | none |
| `04-makeatletter-unmatched` | `OpaqueToEof` | none |

A number reporting success while measuring the *absence* of the thing it names is exactly the failure `AGENTS.md` §7 exists to catch, and it would have been easy to quote as a result. It is written down in `tests/corpus/README.md` with this warning attached instead.

What the baseline is good for is the comparison when #21 lands — against these fingerprinted bytes rather than a fresh sweep, or it compares two different corpora.

## Ten hazard fixtures

One per row of the roadmap's parser table, each carrying that table's own **falsifying observation**. The tenth is the only one asserting something must *not* happen: guessing that an unknown environment is verbatim would silently stop checking content the author expects checked, and the remedy is `xtex.toml`, not inference.

## One new command

`xtex confidence <file>` — one line, for the tooling rather than for a person: the fraction of a file available before recognition stops.

## Checks

All tests pass, clippy clean at `-D warnings`, `cargo fmt --check` clean.