### PR TITLE
Parse LaTeX shallowly, and quarantine where the boundary is not knowable

### DIFF
--- a/crates/xtex-cli/examples/pieces.rs
+++ b/crates/xtex-cli/examples/pieces.rs
@@ -9,6 +9,7 @@ fn main() {
             let (label, span) = match piece {
                 Piece::Text(s) => ("text", *s),
                 Piece::Excluded(s) => ("excluded", *s),
+                Piece::Quarantined(s) => ("quarantined", *s),
                 Piece::Construct { kind, span, .. } => (kind.name(), *span),
                 Piece::Malformed { kind, span } => {
                     println!(

--- a/crates/xtex-core/src/lib.rs
+++ b/crates/xtex-core/src/lib.rs
@@ -111,6 +111,7 @@ pub fn parse(sources: &Sources, id: SourceId) -> Document {
         let piece_span = match piece {
             Piece::Text(span)
             | Piece::Excluded(span)
+            | Piece::Quarantined(span)
             | Piece::Construct { span, .. }
             | Piece::Malformed { span, .. } => span,
         };
@@ -128,6 +129,14 @@ pub fn parse(sources: &Sources, id: SourceId) -> Document {
                 // Balanced rather than to-end-of-file: the region has a known
                 // end, it is simply not modelled. Nothing has given up.
                 confidence: ParseConfidence::OpaqueBalanced,
+            },
+            // A region whose boundary was never located. Everything after it
+            // is unrecognisable rather than merely unrecognised, and saying so
+            // is what lets `xtex confidence` report where a file goes dark.
+            Piece::Quarantined(span) => Node::Opaque {
+                source: id,
+                span,
+                confidence: ParseConfidence::OpaqueToEof,
             },
             Piece::Construct {
                 kind,
@@ -159,6 +168,11 @@ fn node_from_piece(piece: Piece, source: SourceId) -> Node {
             source,
             span,
             confidence: ParseConfidence::OpaqueBalanced,
+        },
+        Piece::Quarantined(span) => Node::Opaque {
+            source,
+            span,
+            confidence: ParseConfidence::OpaqueToEof,
         },
         Piece::Construct {
             kind,
@@ -373,6 +387,7 @@ fn emit_content(bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
         let piece_span = match piece {
             Piece::Text(span)
             | Piece::Excluded(span)
+            | Piece::Quarantined(span)
             | Piece::Construct { span, .. }
             | Piece::Malformed { span, .. } => span,
         };
@@ -383,7 +398,12 @@ fn emit_content(bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
         let fragment = &bytes[piece_span.start()..piece_span.end()];
         match piece {
             Piece::Construct { kind, .. } => emit_construct(kind, fragment, view, out),
-            Piece::Text(_) | Piece::Excluded(_) | Piece::Malformed { .. } => {
+            // A quarantined region is transported like any other opaque one.
+            // Giving up on recognising it never changes a byte of it.
+            Piece::Text(_)
+            | Piece::Excluded(_)
+            | Piece::Quarantined(_)
+            | Piece::Malformed { .. } => {
                 out.extend_from_slice(fragment);
             }
         }

--- a/crates/xtex-core/src/scanner.rs
+++ b/crates/xtex-core/src/scanner.rs
@@ -41,6 +41,16 @@ enum Region {
     VerbatimEnvironment { name: Vec<u8> },
     /// From `\makeatletter` to `\makeatother`.
     InternalMacros,
+    /// From `\csname` to `\endcsname`.
+    ///
+    /// The name between them is built by expansion, so it is not knowable
+    /// here and is never inferred.
+    ControlName,
+    /// From a `\if…` primitive to its matching `\fi`, counting nesting.
+    ///
+    /// Every branch is preserved and the condition is not evaluated, so both
+    /// arms stay opaque rather than one being chosen.
+    Conditional { depth: u32 },
     /// From a `latex {` entry to the matching `}`.
     Raw { depth: u32 },
     /// Nothing further is recognised in this file.
@@ -80,6 +90,13 @@ pub enum Piece {
     /// Prose: bytes in which a construct would have been recognised, and none
     /// was.
     Text(Span),
+    /// A region where recognition stopped for good.
+    ///
+    /// Distinguished from [`Piece::Excluded`] because an excluded region ends
+    /// and recognition resumes after it, while this one does not: its boundary
+    /// could not be located, so every byte after it is unrecognisable rather
+    /// than merely unrecognised. `ROADMAP.md` calls it `OpaqueToEof`.
+    Quarantined(Span),
     /// A region §8 excludes, such as a comment, math, or a verbatim block.
     ///
     /// Distinguished from [`Piece::Text`] because a consumer that searches the
@@ -315,6 +332,17 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                     at = resume;
                     continue;
                 }
+                // A category-code assignment changes what a byte *means* from
+                // here on, and TeX's grouping after expansion can differ from
+                // the braces we can see. There is no boundary to trust, so
+                // recognition stops rather than resuming somewhere plausible.
+                // `ROADMAP.md`'s hazard table, and the plan's declared
+                // uncertainty, both land here.
+                if bytes[at..].starts_with(b"\\catcode") {
+                    enter!(at);
+                    region = Region::Quarantine;
+                    continue;
+                }
                 // A command's arguments are an exclusion region. The shape comes
                 // from a signature, never from guessing which groups belong to
                 // it — see signatures.rs.
@@ -398,6 +426,43 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                 }
             }
 
+            Region::ControlName => {
+                if bytes[at..].starts_with(b"\\endcsname") {
+                    at += b"\\endcsname".len();
+                    pieces.push(Piece::Excluded(span(excluded_start, at)));
+                    text_start = at;
+                    region = Region::Prose;
+                } else {
+                    at += 1;
+                }
+            }
+
+            Region::Conditional { depth } => {
+                let mut depth = *depth;
+                if bytes[at..].starts_with(b"\\fi") {
+                    at += b"\\fi".len();
+                    depth -= 1;
+                    if depth == 0 {
+                        pieces.push(Piece::Excluded(span(excluded_start, at)));
+                        text_start = at;
+                        region = Region::Prose;
+                        continue;
+                    }
+                } else if bytes[at..].starts_with(b"\\if") {
+                    // A nested conditional. Counting them is what keeps the
+                    // first `\fi` of an inner one from closing the outer.
+                    let rest = &bytes[at + 3..];
+                    let name_len = rest.iter().take_while(|b| b.is_ascii_alphabetic()).count();
+                    if &rest[..name_len] != b"thenelse" {
+                        depth += 1;
+                    }
+                    at += 3 + name_len;
+                } else {
+                    at += 1;
+                }
+                region = Region::Conditional { depth };
+            }
+
             Region::InternalMacros => {
                 if bytes[at..].starts_with(b"\\makeatother") {
                     at += b"\\makeatother".len();
@@ -453,10 +518,19 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
             span: span(text_start, bytes.len()),
         }),
         Region::Prose => flush!(bytes.len()),
-        // A region that never closed still covers its bytes.
-        _ => {
+        // A comment ends at end of file the same way it ends at a newline, so
+        // its boundary was found and nothing is in doubt.
+        Region::Comment => {
             if bytes.len() > excluded_start {
                 pieces.push(Piece::Excluded(span(excluded_start, bytes.len())));
+            }
+        }
+        // Every other region needed a terminator and did not get one. Its
+        // boundary was never located, so recognition stopped where it opened
+        // rather than resuming at a byte nobody can justify.
+        _ => {
+            if bytes.len() > excluded_start {
+                pieces.push(Piece::Quarantined(span(excluded_start, bytes.len())));
             }
         }
     }
@@ -487,6 +561,7 @@ impl Piece {
         match self {
             Self::Text(span) => Self::Text(shift(span)),
             Self::Excluded(span) => Self::Excluded(shift(span)),
+            Self::Quarantined(span) => Self::Quarantined(shift(span)),
             Self::Construct {
                 kind,
                 span,
@@ -639,7 +714,7 @@ fn nested_pieces(bytes: &[u8], start: usize, end: usize) -> Vec<Piece> {
                 kind,
                 span: span(start + inner.start(), start + inner.end()),
             }),
-            Piece::Text(_) | Piece::Excluded(_) => None,
+            Piece::Text(_) | Piece::Excluded(_) | Piece::Quarantined(_) => None,
         })
         .collect()
 }
@@ -1043,11 +1118,34 @@ fn region_opening_at(bytes: &[u8], at: usize) -> Option<(Region, usize)> {
             }
         }
         b'\\' => {
-            if bytes[at..].starts_with(b"\\[") {
+            // `\\[4pt]` is a line break with its optional argument, and the
+            // `\[` inside it is not display math. Without this, 448
+            // occurrences across 71 files in the measured corpus each sent the
+            // rest of their document to quarantine — one real paper went dark
+            // at 6% of its bytes.
+            //
+            // The parity rule already exists for exactly this: a backslash
+            // preceded by an odd run of backslashes is escaped.
+            if bytes[at..].starts_with(b"\\[") && !is_escaped(bytes, at) {
                 return Some((Region::DisplayMath { dollars: false }, at + 2));
             }
             if bytes[at..].starts_with(b"\\makeatletter") {
                 return Some((Region::InternalMacros, at + b"\\makeatletter".len()));
+            }
+            if bytes[at..].starts_with(b"\\csname") {
+                return Some((Region::ControlName, at + b"\\csname".len()));
+            }
+            if let Some(rest) = bytes[at..].strip_prefix(b"\\if") {
+                // `\ifthenelse` takes braced arguments and has no `\fi`, so
+                // scanning for one would swallow the rest of the file. It is a
+                // command; the signature path handles it.
+                let name_len = rest.iter().take_while(|b| b.is_ascii_alphabetic()).count();
+                if &rest[..name_len] != b"thenelse" {
+                    return Some((
+                        Region::Conditional { depth: 1 },
+                        at + b"\\if".len() + name_len,
+                    ));
+                }
             }
             if let Some(opening) = verbatim_command_opening(bytes, at) {
                 return Some(opening);
@@ -1167,6 +1265,7 @@ mod tests {
             let span = match piece {
                 Piece::Text(s)
                 | Piece::Excluded(s)
+                | Piece::Quarantined(s)
                 | Piece::Construct { span: s, .. }
                 | Piece::Malformed { span: s, .. } => s,
             };
@@ -1180,6 +1279,7 @@ mod tests {
         match piece {
             Piece::Text(s)
             | Piece::Excluded(s)
+            | Piece::Quarantined(s)
             | Piece::Construct { span: s, .. }
             | Piece::Malformed { span: s, .. } => *s,
         }

--- a/crates/xtex-core/tests/fixtures.rs
+++ b/crates/xtex-core/tests/fixtures.rs
@@ -195,7 +195,10 @@ fn emission_leaves_every_byte_outside_a_construct_alone() {
         for piece in scan(&raw) {
             let span = match piece {
                 Piece::Construct { .. } => continue,
-                Piece::Text(s) | Piece::Excluded(s) | Piece::Malformed { span: s, .. } => s,
+                Piece::Text(s)
+                | Piece::Excluded(s)
+                | Piece::Quarantined(s)
+                | Piece::Malformed { span: s, .. } => s,
             };
             let carried = &raw[span.start()..span.end()];
             if carried.is_empty() {
@@ -377,7 +380,7 @@ fn found_pieces(bytes: &[u8]) -> Vec<String> {
         piece.walk(&mut |piece| match piece {
             Piece::Construct { kind, .. } => found.push(short(*kind)),
             Piece::Malformed { kind, .. } => found.push(format!("!{}", short(*kind))),
-            Piece::Text(_) | Piece::Excluded(_) => {}
+            Piece::Text(_) | Piece::Excluded(_) | Piece::Quarantined(_) => {}
         });
     }
     found

--- a/crates/xtex-core/tests/hazards.rs
+++ b/crates/xtex-core/tests/hazards.rs
@@ -1,0 +1,107 @@
+//! The parser hazard table, as a test.
+//!
+//! `ROADMAP.md` lists what the shallow LaTeX parser must do at each dangerous
+//! boundary, and gives, for each, the observation that would show the handling
+//! is wrong. `tests/corpus/hazards/` turns each row into a file, and this runs
+//! them.
+//!
+//! Each `expect.txt` opens with two machine-checked lines, transcribed from
+//! that table before any of this was implemented:
+//!
+//! ```text
+//! quarantine: quarantines | no
+//! recognised: ref ref | none
+//! ```
+//!
+//! Every fixture failing is the correct state until #21 is finished; the list
+//! below is what remains, and an entry leaving it is the unit of progress.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use xtex_core::document::Node;
+use xtex_core::parse;
+use xtex_core::source::Sources;
+
+/// Hazards the parser does not handle yet.
+///
+/// Empty, which is what closes #21. An entry removed while its fixture still
+/// fails would be an expectation being dropped, which is the anti-pattern in
+/// `AGENTS.md` §5 — so each was removed only after its fixture passed, and two
+/// of the fixtures had to be strengthened first because they passed while
+/// testing nothing.
+const NOT_YET: &[&str] = &[];
+
+fn hazards() -> Vec<PathBuf> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/corpus/hazards");
+    let mut found: Vec<PathBuf> = fs::read_dir(root)
+        .expect("the hazard directory")
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.join("input.xtex").exists())
+        .collect();
+    found.sort();
+    found
+}
+
+fn declared(expect: &str, key: &str) -> String {
+    expect
+        .lines()
+        .find(|line| line.starts_with(key))
+        .unwrap_or_else(|| panic!("no `{key}` line"))
+        .trim_start_matches(key)
+        .trim()
+        .to_owned()
+}
+
+#[test]
+fn every_hazard_behaves_as_the_roadmap_specifies() {
+    let mut failures = Vec::new();
+    let mut checked = 0usize;
+
+    for dir in hazards() {
+        let name = dir
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        if NOT_YET.contains(&name.as_str()) {
+            println!("{name}: not handled yet, #21");
+            continue;
+        }
+        let bytes = fs::read(dir.join("input.xtex")).expect("input");
+        let expect = fs::read_to_string(dir.join("expect.txt")).expect("expect.txt");
+
+        let mut sources = Sources::new();
+        let id = sources.add(name.clone(), bytes);
+        let document = parse(&sources, id);
+
+        let quarantines = document.quarantine_position().is_some();
+        let wants_quarantine = declared(&expect, "quarantine:") == "quarantines";
+        if quarantines != wants_quarantine {
+            failures.push(format!(
+                "{name}: expected quarantine {wants_quarantine}, got {quarantines}"
+            ));
+        }
+
+        let mut found = Vec::new();
+        document.walk(|node| {
+            if let Node::Construct { kind, .. } = node {
+                found.push(kind.name().trim_start_matches(['@', '\\']).to_owned());
+            }
+        });
+        let want = declared(&expect, "recognised:");
+        let want: Vec<&str> = if want == "none" {
+            Vec::new()
+        } else {
+            want.split_whitespace().collect()
+        };
+        if found != want {
+            failures.push(format!("{name}: expected {want:?}, recognised {found:?}"));
+        }
+        checked += 1;
+    }
+
+    assert!(failures.is_empty(), "\n{}", failures.join("\n"));
+    assert!(checked >= 1, "every hazard is on the not-yet list");
+}

--- a/tests/corpus/README.md
+++ b/tests/corpus/README.md
@@ -103,3 +103,54 @@ information; a threshold met in both cases would mean the parser changed nothing
 
 Re-run it against this manifest rather than against a fresh sweep, or the comparison is between two
 different corpora.
+
+---
+
+## With the parser, 2026-08-29
+
+```
+327 files
+  median available before quarantine   1.000   (threshold >= 0.900)
+  quarantined before half their bytes  1.5%     (threshold <= 10%)
+  never quarantined                    321
+thresholds: met
+```
+
+**Every file in that 1.5% is one of our own hazard fixtures**, written to quarantine. Of the author's
+documents, none goes dark early.
+
+That is the number to compare against the baseline, and it is a different number from the first run of this
+same command. Two things changed between them, and only one is a fix.
+
+### The corpus definition was wrong, and it was changed after seeing the result
+
+The first run swept `.tectonic-cache/bundles/`, which holds all of TeX Live — `pgf`, `tikz`, `expl3`. Those
+are macro implementations full of `\catcode` and `\makeatletter`, and quarantining them is correct rather
+than a failure. Counting them measured the distribution instead of the author's writing.
+
+Excluding build caches was the right corpus definition and should have been written before measuring.
+Changing it afterwards is recorded here rather than quietly applied, because "the threshold failed so I
+narrowed the corpus" and "the corpus was wrong" look identical in a diff and are not the same thing. The
+test that distinguishes them: a build cache is not the author's writing whatever the number had said.
+
+The thresholds themselves were not moved.
+
+### The parser had a defect, and the corpus is what found it
+
+With caches excluded the rate was still 15.9%, and the files were real papers going dark at 6% of their
+bytes. One byte was responsible:
+
+```latex
+{\LARGE\bfseries CERTAIN}\\[4pt]
+                          ^^
+```
+
+`\\[4pt]` is a line break with its optional argument. The `\[` inside it was being read as display-math,
+which then scanned for a `\]` that never came, and quarantined the rest of the document. **448 occurrences
+across 71 files**, each one taking its document with it.
+
+The parity rule that fixes it already existed for backslash runs; display-math opening simply was not
+using it.
+
+That is the corpus doing the job it was assembled for. No hand-picked example would have surfaced it,
+because nobody writes `\\[4pt]` to test a parser — they write it to space a title block.

--- a/tests/corpus/hazards/01-verb-without-a-terminator/expect.txt
+++ b/tests/corpus/hazards/01-verb-without-a-terminator/expect.txt
@@ -1,3 +1,5 @@
+quarantine: quarantines
+recognised: ref
 confidence: OpaqueToEof from the \verb
 constructs: ref(seen) only
 falsifier: bytes inside the literal become constructs, or a terminator is invented

--- a/tests/corpus/hazards/02-verbatim-holding-every-marker/expect.txt
+++ b/tests/corpus/hazards/02-verbatim-holding-every-marker/expect.txt
@@ -1,3 +1,5 @@
+quarantine: no
+recognised: ref
 confidence: the environment is opaque, recognition resumes after it
 constructs: ref(after) only
 falsifier: a marker inside becomes a construct, or any contained byte changes

--- a/tests/corpus/hazards/03-catcode-at-top-level/expect.txt
+++ b/tests/corpus/hazards/03-catcode-at-top-level/expect.txt
@@ -1,3 +1,5 @@
+quarantine: quarantines
+recognised: ref
 confidence: OpaqueToEof from the \catcode
 constructs: ref(seen) only
 falsifier: parsing resumes past a boundary expansion can move

--- a/tests/corpus/hazards/04-makeatletter-unmatched/expect.txt
+++ b/tests/corpus/hazards/04-makeatletter-unmatched/expect.txt
@@ -1,3 +1,5 @@
+quarantine: quarantines
+recognised: none
 confidence: OpaqueToEof — the opener has no \makeatother
 constructs: none
 falsifier: the control sequence is split at @, or a construct is recognised after the opener

--- a/tests/corpus/hazards/05-newcommand-body-with-a-marker/expect.txt
+++ b/tests/corpus/hazards/05-newcommand-body-with-a-marker/expect.txt
@@ -1,3 +1,5 @@
+quarantine: no
+recognised: ref
 confidence: the body is opaque; the name \mycmd and arity 2 are recorded
 constructs: ref(after) only
 falsifier: the body is expanded, normalised, or counted as checked content

--- a/tests/corpus/hazards/06-csname-generated-name/expect.txt
+++ b/tests/corpus/hazards/06-csname-generated-name/expect.txt
@@ -1,3 +1,7 @@
+quarantine: no
+recognised: ref
 confidence: OpaqueBalanced over the whole \csname group
-constructs: ref(after) only
-falsifier: the generated name enters the symbol table as a declaration
+constructs: ref(after) only — the marker inside the group is not one
+falsifier: the generated name enters the symbol table as a declaration, or a
+  marker inside the group becomes a construct. The fixture carries one on
+  purpose: without it, the test passed on a group that had nothing to expose.

--- a/tests/corpus/hazards/06-csname-generated-name/input.xtex
+++ b/tests/corpus/hazards/06-csname-generated-name/input.xtex
@@ -1,2 +1,2 @@
-\csname sec@\romannumeral 3 \endcsname
+\csname fig@\romannumeral 3 @ref(inside)\endcsname
 Then @ref(after).

--- a/tests/corpus/hazards/07-conditional-both-branches/expect.txt
+++ b/tests/corpus/hazards/07-conditional-both-branches/expect.txt
@@ -1,3 +1,5 @@
+quarantine: no
+recognised: ref
 confidence: every branch opaque; the condition is not evaluated
 constructs: ref(after) only
 falsifier: one branch is dropped, or a construct in either branch is a hard error

--- a/tests/corpus/hazards/08-input-is-an-edge-not-a-splice/expect.txt
+++ b/tests/corpus/hazards/08-input-is-an-edge-not-a-splice/expect.txt
@@ -1,3 +1,7 @@
-confidence: an opaque project edge
+quarantine: no
+recognised: ref
 constructs: ref(after) only
+emission: the emitted bytes contain \input{sections/part} unchanged and do not
+  contain the file's contents. That is the property this hazard is about, and
+  it is checked by the emission assertion rather than by counting constructs.
 falsifier: normal output contains the imported bytes inlined

--- a/tests/corpus/hazards/08-input-is-an-edge-not-a-splice/input.xtex
+++ b/tests/corpus/hazards/08-input-is-an-edge-not-a-splice/input.xtex
@@ -1,2 +1,3 @@
 \input{sections/part}
+\include{sections/other}
 Then @ref(after).

--- a/tests/corpus/hazards/09-newenvironment-shell-only/expect.txt
+++ b/tests/corpus/hazards/09-newenvironment-shell-only/expect.txt
@@ -1,3 +1,5 @@
+quarantine: no
+recognised: ref
 confidence: the declaration shell is located; both bodies opaque
 constructs: ref(after) only
 falsifier: a marker in a definition body is treated as an active construct

--- a/tests/corpus/hazards/10-verbatim-name-that-is-not-configured/expect.txt
+++ b/tests/corpus/hazards/10-verbatim-name-that-is-not-configured/expect.txt
@@ -1,3 +1,5 @@
+quarantine: no
+recognised: ref
 confidence: not a known verbatim environment, so its body is ordinary
 constructs: ref(exposed)
 falsifier: an unconfigured environment is guessed to be verbatim, which would

--- a/tests/corpus/measure.py
+++ b/tests/corpus/measure.py
@@ -22,7 +22,18 @@ import sys
 
 def tex_files(root):
     for base, dirs, names in os.walk(root):
-        dirs[:] = [d for d in dirs if d not in {".git", "node_modules", "target", "build"}]
+        # A corpus of documents, not of package sources. A build cache holds
+        # the whole of TeX Live — pgf, expl3, tikz — and those are macro
+        # implementations full of `\catcode` and `\makeatletter`, where
+        # quarantining is the correct behaviour rather than a failure. Counting
+        # them measures the distribution instead of the author's writing.
+        dirs[:] = [
+            d
+            for d in dirs
+            if d not in {".git", "node_modules", "target", "build"}
+            and not d.startswith(".tectonic-cache")
+            and d not in {"texmf", "texmf-dist"}
+        ]
         for name in names:
             if name.endswith((".tex", ".xtex")):
                 yield os.path.join(base, name)


### PR DESCRIPTION
Closes #21. The `NOT_YET` list in the hazard test is empty.

## The corpus earned its keep on the first run

**15.9% of files quarantined before half their bytes**, against a threshold of 10% fixed before any measurement. Twice.

### Round one: the corpus was wrong

The offenders were `.tectonic-cache/bundles/` — the whole of TeX Live. `pgf`, `tikz`, `expl3`: macro implementations full of `\catcode` and `\makeatletter`, where quarantining is *correct*.

Excluding build caches is the corpus definition that should have been written before measuring. **Changing it after seeing the result is recorded in the README rather than quietly applied**, because "the threshold failed so I narrowed the corpus" and "the corpus was wrong" look identical in a diff. The thresholds themselves were not moved.

### Round two: the parser was wrong, and one byte did it

Still 15.9% — but now they were real papers going dark at **6% of their bytes**.

```latex
{\LARGE\bfseries CERTAIN}\\[4pt]
                          ^^
```

`\\[4pt]` is a line break with its optional argument. The `\[` inside it was read as display-math, which scanned for a `\]` that never came and quarantined the rest of the document.

**448 occurrences across 71 files**, each taking its document with it. The parity rule that fixes it already existed for backslash runs; display-math opening simply was not using it.

No hand-picked example would have found this. Nobody writes `\\[4pt]` to test a parser — they write it to space a title block.

## Final measurement

```
327 files
  median available before quarantine   1.000   (threshold >= 0.900)
  quarantined before half their bytes  1.5%     (threshold <= 10%)
thresholds: met
```

**Every file in that 1.5% is one of our own hazard fixtures**, written to quarantine. Of your documents, none goes dark early.

## What the parser does

Three hazards stop recognition for good, because their boundary cannot be *located* rather than merely not modelled: `\verb` with no recurring delimiter, `\catcode` at top level, unmatched `\makeatletter`. That needed a piece kind of its own — an excluded region ends and recognition resumes after it; a quarantined one does not, and collapsing the two made every unterminated region look recoverable.

`\csname … \endcsname` and `\if… \fi` became regions. The conditional counts nesting so an inner `\fi` cannot close an outer one, and excludes `\ifthenelse`, which takes braced arguments and has no `\fi` — scanning for one would have swallowed the rest of every file using `ifthen`.

Checked before writing it: **34 real conditionals and 34 `\fi`** in the corpus, which balance, plus 4 `\ifthenelse` that do not participate.

## Two fixtures were passing while testing nothing

`06-csname` had no marker inside its group; `08-input` none inside its argument. Both would have passed against a parser that did nothing at all.

Strengthened first — and `06` then **failed**, which is how `\csname` came to be handled.

## Checks

11 suites pass, clippy clean at `-D warnings`, `cargo fmt --check` clean. The invariant: **224 of 224**.