### PR TITLE
Say a typesetting failure about the author's entity, when the evidence allows

### DIFF
--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -13,6 +13,7 @@ use xtex_core::bibliography::{Bibliography, Declared, Unavailable, assemble, dec
 use xtex_core::check::{Diagnostic, check, check_documents, to_json};
 use xtex_core::diagnostics::map_emitted_diagnostic;
 use xtex_core::document::Node;
+use xtex_core::editor::entity_at;
 use xtex_core::io::{IoError, OutputSink, SourceLoader};
 use xtex_core::review::{
     Resolution, parse_sidecar, prune_sidecar, resolve, resolve_sidecar, validate,
@@ -1141,6 +1142,8 @@ fn compile_command(args: &[String]) -> ExitCode {
         return ExitCode::from(2);
     };
     let document = parse(&sources, id);
+    let mut table = SymbolTable::new();
+    table.merge(&sources, &document);
     let Ok(emission) = emit_with_map(&sources, &document) else {
         eprintln!("error: {input} could not be emitted");
         return ExitCode::from(2);
@@ -1173,46 +1176,41 @@ fn compile_command(args: &[String]) -> ExitCode {
     };
 
     let output = String::from_utf8_lossy(&run.stderr);
-    let records = xtex_core::texlog::parse(&output);
-    let mut reported = 0usize;
+    let mut records = xtex_core::texlog::parse(&output);
 
-    for record in &records {
-        match record {
-            xtex_core::texlog::Record::Located {
-                severity,
-                line,
-                message,
-                ..
-            } => {
-                let mapped = map_emitted_diagnostic(
-                    message.clone(),
-                    &emission.bytes,
-                    *line,
-                    1,
-                    &emission.map,
-                );
-                let label = match severity {
-                    xtex_core::texlog::Severity::Error => "error[TEX]",
-                    xtex_core::texlog::Severity::Warning => "warning[TEX]",
-                };
-                println!("{label}: {}", mapped.message);
-                println!("  emitted at {}:{line}", emitted.display());
-                match &mapped.span {
-                    Some(span) => {
-                        println!(
-                            "  corresponds to {}:{}:{}",
-                            span.file, span.line, span.column
-                        );
-                    }
-                    None => println!("  corresponds to an unmapped position"),
-                }
-                println!("  blame: {}", mapped.blame.as_str());
-                reported += 1;
+    // The raw log carries records stderr never shows — `Float too large for
+    // page` is one, checked against a live run. Reading stderr alone would
+    // silently miss a whole class of failure.
+    let mut log = emitted.clone();
+    log.set_extension("log");
+    if let Ok(text) = fs::read_to_string(&log) {
+        let name = emitted
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned();
+        for record in xtex_core::texlog::parse_log(&text, &name) {
+            // A typesetting failure supersedes the plainer stderr line for the
+            // same message, so the restated form is the one an author reads.
+            let xtex_core::texlog::Record::Typeset { message, .. } = &record else {
+                continue;
+            };
+            records.retain(|existing| {
+                !matches!(
+                    existing,
+                    xtex_core::texlog::Record::Located { message: other, .. } if other == message
+                )
+            });
+            if !records.contains(&record) {
+                records.push(record);
             }
-            // Kept and printed unchanged. An engine's output is evidence, and
-            // a line we cannot place is still a line it said.
-            xtex_core::texlog::Record::Unrecognised(line) => println!("{line}"),
         }
+    }
+    let mut reported = 0usize;
+    for record in &records {
+        reported += usize::from(report_record(
+            record, &emission, &emitted, &sources, &document, &table,
+        ));
     }
 
     if reported == 0 && run.status.success() {
@@ -1240,4 +1238,78 @@ fn tex_engine() -> String {
             || "tectonic".to_owned(),
             |value| value.trim().trim_matches('"').to_owned(),
         )
+}
+
+/// Prints one engine record, and says whether it had a location to print.
+///
+/// Split out of `compile_command` because that function was doing three jobs;
+/// this is the one an author actually reads.
+fn report_record(
+    record: &xtex_core::texlog::Record,
+    emission: &xtex_core::sourcemap::MappedEmission,
+    emitted: &Path,
+    sources: &Sources,
+    document: &xtex_core::document::Document,
+    table: &SymbolTable,
+) -> bool {
+    use xtex_core::texlog::{Record, Severity};
+
+    let (label, line, message, visual) = match record {
+        Record::Located {
+            severity,
+            line,
+            message,
+            ..
+        } => (
+            match severity {
+                Severity::Error => "error[TEX]",
+                Severity::Warning => "warning[TEX]",
+            },
+            *line,
+            message,
+            None,
+        ),
+        Record::Typeset {
+            visual,
+            line,
+            message,
+            ..
+        } => ("warning[TEX]", *line, message, Some(*visual)),
+        // Kept and printed unchanged. An engine's output is evidence, and a
+        // line we cannot place is still a line it said.
+        Record::Unrecognised(line) => {
+            println!("{line}");
+            return false;
+        }
+    };
+
+    let mapped = map_emitted_diagnostic(message.clone(), &emission.bytes, line, 1, &emission.map);
+
+    // A typesetting failure is restated in the author's terms only when a map
+    // segment and a declared entity both supply the evidence. Where either is
+    // missing the engine's own sentence stands, because "something overflows"
+    // is worse than a message that at least locates a box.
+    let named = visual.and_then(|visual| {
+        let span = mapped.span.as_ref()?;
+        let (name, class) = entity_at(sources, document, table, span.offset as usize)?;
+        Some((visual, name, class))
+    });
+
+    match named {
+        Some((visual, name, class)) => {
+            println!("{label}: {} `{name}` {}", class.name(), visual.name());
+            println!("  TeX said: {message}");
+        }
+        None => println!("{label}: {}", mapped.message),
+    }
+    println!("  emitted at {}:{line}", emitted.display());
+    match &mapped.span {
+        Some(span) => println!(
+            "  corresponds to {}:{}:{}",
+            span.file, span.line, span.column
+        ),
+        None => println!("  corresponds to an unmapped position"),
+    }
+    println!("  blame: {}", mapped.blame.as_str());
+    true
 }

--- a/crates/xtex-core/src/editor.rs
+++ b/crates/xtex-core/src/editor.rs
@@ -199,6 +199,47 @@ pub fn completions(
         .collect()
 }
 
+/// The declared entity whose construct encloses `offset`, innermost first.
+///
+/// What turns "an overfull box at line 12" into "the caption of figure
+/// `fig:runtime` overflows its line". Returns `None` where no declared entity
+/// encloses the position, and the caller must then leave the engine's message
+/// alone rather than name something it cannot support.
+#[must_use]
+pub fn entity_at(
+    sources: &Sources,
+    document: &Document,
+    table: &SymbolTable,
+    offset: usize,
+) -> Option<(String, EntityClass)> {
+    let mut best: Option<(String, EntityClass, usize)> = None;
+    document.walk(|node| {
+        let Node::Construct { kind, span, .. } = node else {
+            return;
+        };
+        if !matches!(
+            kind,
+            EntryToken::Id | EntryToken::Figure | EntryToken::Table
+        ) {
+            return;
+        }
+        if offset < span.start() || offset >= span.end() {
+            return;
+        }
+        let Some(name) = payload_text(sources, node.source(), *span) else {
+            return;
+        };
+        let class = table
+            .declaration(&name)
+            .map_or(EntityClass::UnknownOpen, |declaration| declaration.class);
+        let width = span.end() - span.start();
+        if best.as_ref().is_none_or(|(_, _, best)| width < *best) {
+            best = Some((name, class, width));
+        }
+    });
+    best.map(|(name, class, _)| (name, class))
+}
+
 /// Where the name at `offset` is declared.
 #[must_use]
 pub fn definition(
@@ -349,6 +390,29 @@ mod tests {
         // sentence is worse than offering nothing.
         let (sources, document, table) = document();
         assert!(completions(&sources, &document, &table, at("See ")).is_empty());
+    }
+
+    #[test]
+    fn an_entity_is_found_only_where_one_encloses_the_position() {
+        let text = "\\table(tab:x) { caption = {C} }\nOutside any entity.\n";
+        let mut sources = Sources::new();
+        let id = sources.add("a.xtex", text.as_bytes().to_vec());
+        let document = parse(&sources, id);
+        let mut table = SymbolTable::new();
+        table.merge(&sources, &document);
+
+        let inside = text.find("caption").expect("present");
+        let (name, class) =
+            entity_at(&sources, &document, &table, inside).expect("inside the block");
+        assert_eq!(name, "tab:x");
+        assert_eq!(class, EntityClass::Table);
+
+        // The negative case carries the weight: a position outside every
+        // declared entity must yield nothing, so a typesetting failure there
+        // keeps TeX's own sentence instead of naming something it cannot
+        // support.
+        let outside = text.find("Outside").expect("present");
+        assert!(entity_at(&sources, &document, &table, outside).is_none());
     }
 
     #[test]

--- a/crates/xtex-core/src/texlog.rs
+++ b/crates/xtex-core/src/texlog.rs
@@ -23,6 +23,37 @@ pub enum Severity {
     Warning,
 }
 
+/// A typesetting failure the compiler can restate.
+///
+/// Five shapes, every one transcribed from a live `tectonic` run rather than
+/// recalled. The engine's own sentence is kept beside them; these only say
+/// which kind it was and how much, so a diagnostic can name the author's
+/// entity without discarding the evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Visual {
+    /// `Overfull \hbox (113.94pt too wide) …` — content wider than its line.
+    OverfullHbox,
+    /// `Overfull \vbox (38.48pt too high) …` — content taller than its box.
+    OverfullVbox,
+    /// `Missing character: There is no 日 ("65E5) in font ec-lmr10!`
+    MissingGlyph,
+    /// `LaTeX Warning: Float too large for page by 327.53pt on input line 9.`
+    FloatTooLarge,
+}
+
+impl Visual {
+    /// How the compiler names this failure to an author.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::OverfullHbox => "overflows its line",
+            Self::OverfullVbox => "overflows its box",
+            Self::MissingGlyph => "uses a character the font does not have",
+            Self::FloatTooLarge => "is too large for the page",
+        }
+    }
+}
+
 /// One line of engine output.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Record {
@@ -37,12 +68,100 @@ pub enum Record {
         /// The engine's own words, unchanged.
         message: String,
     },
+    /// A typesetting failure, recognised and located.
+    ///
+    /// Separate from [`Record::Located`] because only these can be restated
+    /// in terms of an entity, and only when a map segment and a declared
+    /// entity both supply the evidence.
+    Typeset {
+        /// Which failure.
+        visual: Visual,
+        /// File the engine named, which is an emitted file.
+        file: String,
+        /// One-based line in that file.
+        line: u32,
+        /// The engine's own words, unchanged.
+        message: String,
+    },
     /// A line that matched no known form.
     ///
     /// Kept rather than dropped: an engine's output is evidence, and silently
     /// discarding part of it makes the compiler look like it saw less than it
     /// did.
     Unrecognised(String),
+}
+
+/// Recognises a typesetting failure in an engine's own sentence.
+///
+/// Returns `None` for anything not in the transcribed set, which is what keeps
+/// an unfamiliar message from being restated as something it is not.
+#[must_use]
+pub fn classify(message: &str) -> Option<Visual> {
+    if message.starts_with("Overfull \\hbox") {
+        return Some(Visual::OverfullHbox);
+    }
+    if message.starts_with("Overfull \\vbox") {
+        return Some(Visual::OverfullVbox);
+    }
+    if message.starts_with("Missing character:") {
+        return Some(Visual::MissingGlyph);
+    }
+    if message.starts_with("LaTeX Warning: Float too large for page") {
+        return Some(Visual::FloatTooLarge);
+    }
+    None
+}
+
+/// The line a `.log` record names, when it names one in its own text.
+///
+/// `LaTeX Warning: … on input line 9.` carries its line inside the sentence
+/// rather than in a `file:line:` prefix, which is why the raw log needs its own
+/// reader: that record never reaches stderr at all.
+#[must_use]
+pub fn line_in_message(message: &str) -> Option<u32> {
+    let at = message.find("on input line ")? + "on input line ".len();
+    let digits: String = message[at..]
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect();
+    digits.parse().ok()
+}
+
+/// Reads a raw `.log`, which carries records stderr never shows.
+///
+/// Checked against a live run: `Float too large for page` appears only here.
+/// A reader that took stderr alone would silently miss a whole class.
+#[must_use]
+pub fn parse_log(log: &str, file: &str) -> Vec<Record> {
+    let mut records = Vec::new();
+    for line in log.lines() {
+        let line = line.trim_end();
+        let Some(visual) = classify(line) else {
+            continue;
+        };
+        let Some(number) = line_in_message(line).or_else(|| line_after(line)) else {
+            continue;
+        };
+        let record = Record::Typeset {
+            visual,
+            file: file.to_owned(),
+            line: number,
+            message: line.to_owned(),
+        };
+        if !records.contains(&record) {
+            records.push(record);
+        }
+    }
+    records
+}
+
+/// The line an `Overfull` record names in its trailing `at line N` or
+/// `at lines N--M`.
+fn line_after(message: &str) -> Option<u32> {
+    let at = message.rfind("at line")? + "at line".len();
+    let rest = message[at..].trim_start_matches('s').trim_start();
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
 }
 
 /// Parses one line of engine output.
@@ -113,6 +232,102 @@ pub fn parse(output: &str) -> Vec<Record> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The five shapes, transcribed from live tectonic runs on 2026-08-29.
+    const OBSERVED: &[(&str, Option<Visual>)] = &[
+        (
+            "Overfull \\hbox (113.94pt too wide) in paragraph at lines 5--5",
+            Some(Visual::OverfullHbox),
+        ),
+        (
+            "Overfull \\hbox (215.64pt too wide) detected at line 14",
+            Some(Visual::OverfullHbox),
+        ),
+        (
+            "Overfull \\vbox (38.48pt too high) detected at line 16",
+            Some(Visual::OverfullVbox),
+        ),
+        (
+            "Missing character: There is no X (\"65E5) in font ec-lmr10!",
+            Some(Visual::MissingGlyph),
+        ),
+        (
+            "LaTeX Warning: Float too large for page by 327.5271pt on input line 9.",
+            Some(Visual::FloatTooLarge),
+        ),
+        // Real lines from the same runs that must not be classified.
+        (
+            "Underfull \\hbox (badness 10000) in paragraph at lines 3--4",
+            None,
+        ),
+        ("LaTeX Warning: There were undefined references.", None),
+        (
+            "Package hyperref Warning: Token not allowed in a PDF string.",
+            None,
+        ),
+    ];
+
+    #[test]
+    fn only_the_transcribed_shapes_are_classified() {
+        for (line, expected) in OBSERVED {
+            assert_eq!(classify(line), *expected, "{line}");
+        }
+    }
+
+    #[test]
+    fn a_shape_that_was_never_transcribed_is_not_guessed_at() {
+        // The failure this guards: restating an unfamiliar message as
+        // something it is not. An underfull box is a real warning and a real
+        // typesetting problem, and it is not in the supported set, so it stays
+        // TeX's own sentence rather than becoming a claim about an entity.
+        assert_eq!(
+            classify("Underfull \\vbox (badness 10000) has occurred"),
+            None
+        );
+        assert_eq!(classify("Overfull nothing at all"), None);
+    }
+
+    #[test]
+    fn a_record_carrying_its_line_inside_the_sentence_is_read() {
+        // `Float too large` never reaches stderr, and its line is in the prose
+        // rather than in a `file:line:` prefix. A reader taking stderr alone
+        // would miss the whole class.
+        let log = "LaTeX Warning: Float too large for page by 327.5271pt on input line 9.\n";
+        let records = parse_log(log, "paper.tex");
+        assert_eq!(records.len(), 1);
+        let Record::Typeset { visual, line, .. } = &records[0] else {
+            panic!("expected a typeset record")
+        };
+        assert_eq!(*visual, Visual::FloatTooLarge);
+        assert_eq!(*line, 9);
+    }
+
+    #[test]
+    fn an_overfull_range_is_read_from_its_first_line() {
+        let log = "Overfull \\hbox (113.94pt too wide) in paragraph at lines 5--5\n";
+        let Record::Typeset { line, .. } = &parse_log(log, "p.tex")[0] else {
+            panic!("expected a typeset record")
+        };
+        assert_eq!(*line, 5);
+    }
+
+    #[test]
+    fn a_log_line_that_is_not_a_supported_failure_yields_no_record() {
+        let log = "This is the LaTeX engine, version whatever\nUnderfull \\hbox somewhere\n";
+        assert!(parse_log(log, "p.tex").is_empty());
+    }
+
+    #[test]
+    fn the_engines_own_words_survive_classification() {
+        let log = "Overfull \\hbox (215.64pt too wide) detected at line 14\n";
+        let Record::Typeset { message, .. } = &parse_log(log, "p.tex")[0] else {
+            panic!("expected a typeset record")
+        };
+        assert_eq!(
+            message,
+            "Overfull \\hbox (215.64pt too wide) detected at line 14"
+        );
+    }
 
     #[test]
     fn an_error_carries_its_file_and_line() {

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -70,9 +70,47 @@ and which something is yours to pin.
 
 ---
 
-## What this does not do yet
+## Typesetting failures, said about your entity
 
-Translating a supported visual failure — an overfull box, a float that drifted, a missing glyph — into a
-sentence about *your* entity rather than TeX's box is
-[#23](https://github.com/camilochs/exacttex/issues/23). Today an overfull box arrives mapped to your line,
-with TeX's own words.
+When a supported failure lands inside something you declared, the compiler names it:
+
+```
+warning[TEX]: table `tab:wide` overflows its line
+  TeX said: Overfull \hbox (215.64pt too wide) detected at line 7
+  emitted at build/v.tex:7
+  corresponds to v.xtex:4:1
+  blame: xtex-generated
+```
+
+When it does not, the engine's own sentence stands:
+
+```
+warning[TEX]: Overfull \hbox (192.54001pt too wide) detected at line 11
+  emitted at build/v.tex:11
+  corresponds to v.xtex:9:1
+  blame: author-latex
+```
+
+**Both halves are the feature.** Restating requires a map segment *and* a declared entity enclosing the
+position. Where either is missing, nothing is named — "something overflows" is worse than a message that at
+least locates a box.
+
+### The five supported shapes
+
+Every one transcribed from a live engine run:
+
+| Shape | Said as |
+|---|---|
+| `Overfull \hbox (…pt too wide) …` | overflows its line |
+| `Overfull \vbox (…pt too high) …` | overflows its box |
+| `Missing character: There is no X ("65E5) in font …!` | uses a character the font does not have |
+| `LaTeX Warning: Float too large for page by …pt on input line 9.` | is too large for the page |
+
+Anything else keeps TeX's words and gains no entity. An *underfull* box is a real warning about a real
+typesetting problem, and it is not in this set, so it is not restated as a claim about your figure.
+
+### The raw log is read, not just stderr
+
+`Float too large for page` **never reaches stderr** — checked against a live run. A reader taking stderr
+alone would silently miss the whole class, so `xtex compile` reads the `.log` beside the emitted file and
+prefers the richer record where both exist.


### PR DESCRIPTION
Closes #23, and with it **Phase 4**.

## Both halves are the feature

Inside something you declared:

```
warning[TEX]: table `tab:wide` overflows its line
  TeX said: Overfull \hbox (215.64pt too wide) detected at line 7
  emitted at build/v.tex:7
  corresponds to v.xtex:4:1
  blame: xtex-generated
```

Outside every declared entity, three lines later in the same run:

```
warning[TEX]: Overfull \hbox (192.54001pt too wide) detected at line 11
  corresponds to v.xtex:9:1
  blame: author-latex
```

**Restating requires a map segment *and* a declared entity enclosing the position.** Where either is missing, nothing is named — *"something overflows"* is worse than a message that at least locates a box.

## Five shapes, transcribed from runs written to provoke them

| Shape | Said as |
|---|---|
| `Overfull \hbox (…pt too wide) …` | overflows its line |
| `Overfull \vbox (…pt too high) …` | overflows its box |
| `Missing character: There is no X ("65E5) in font …!` | uses a character the font does not have |
| `LaTeX Warning: Float too large for page by …pt on input line 9.` | is too large for the page |

Anything else keeps TeX's words and gains no entity. An **underfull** box is a real warning about a real typesetting problem, deliberately not in the set, and is never restated as a claim about your figure.

## Provoking them changed the design

**`Float too large for page` never reaches stderr.** It exists only in the raw `.log`, and its line number sits *inside the sentence* rather than in a `file:line:` prefix.

A reader taking stderr alone would have silently missed the whole class. `xtex compile` now reads the log beside the emitted file and prefers the richer record where both exist.

## The tests that carry the weight are negative

- a shape never transcribed is **not guessed at** — including `Underfull \hbox`, which is real and adjacent;
- a log line that is not a supported failure yields **no record**;
- a position outside every declared entity yields **no entity**.

Two fixtures here were recently found passing while testing nothing, so each of these was checked to fail when the behaviour it names is removed.

## Also

`compile_command` grew past what one function should hold, and the reporting — the part an author actually reads — is split out.

## Checks

11 suites pass, clippy clean at `-D warnings`, `cargo fmt --check` clean. The invariant: **224 of 224**.