### PR TITLE
Verify that annotating changes nothing, and fix what verifying it found

### DIFF
--- a/crates/xtex-cli/examples/pieces.rs
+++ b/crates/xtex-cli/examples/pieces.rs
@@ -9,6 +9,7 @@ fn main() {
             let (label, span) = match piece {
                 Piece::Text(s) => ("text", *s),
                 Piece::Excluded(s) => ("excluded", *s),
+                Piece::Arguments(s) => ("arguments", *s),
                 Piece::Quarantined(s) => ("quarantined", *s),
                 Piece::Construct { kind, span, .. } => (kind.name(), *span),
                 Piece::Malformed { kind, span } => {

--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -4,13 +4,13 @@
 //! and process exit codes. `xtex-core` has none of them, which is what lets
 //! the same core compile to WebAssembly.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
 use xtex_core::bibliography::{Bibliography, Declared, Unavailable, assemble, declared_in};
-use xtex_core::check::{Diagnostic, check, check_documents, to_json};
+use xtex_core::check::{Diagnostic, check_documents, check_with_labels, to_json};
 use xtex_core::diagnostics::map_emitted_diagnostic;
 use xtex_core::document::Node;
 use xtex_core::editor::entity_at;
@@ -281,6 +281,11 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
     let mut merged = BTreeSet::new();
     let mut import_diagnostics = Vec::new();
     let mut declared = Declared::default();
+    // One inventory for the whole root, merged like the symbol table: a
+    // `\label` in an imported file declares its name for the root, exactly as
+    // an `@id` there does.
+    let mut labels: BTreeMap<String, xtex_core::source::Span> = BTreeMap::new();
+    let mut labels_available = true;
 
     while let Some(id) = pending.pop() {
         let name = sources
@@ -293,6 +298,13 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
         }
         let document = parse(&sources, id);
         table.merge(&sources, &document);
+        match xtex_core::labels::inventory(&sources, &document, id) {
+            xtex_core::labels::Inventory::Complete(found) => labels.extend(found),
+            // One file that went dark makes the root's inventory a subset, and
+            // a subset that looks complete turns every name it missed into a
+            // false "not declared".
+            xtex_core::labels::Inventory::Unavailable(_) => labels_available = false,
+        }
         merge_declared(&mut declared, declared_in(&sources, id));
         let mut imports = Vec::new();
         document.walk(|node| {
@@ -328,7 +340,11 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
 
     let base = Path::new(root).parent().unwrap_or_else(|| Path::new("."));
     let bibliography = assemble(&declared, |name| fs::read(base.join(name)).ok());
-    let mut diagnostics = check(&table, &bibliography);
+    // The author's own `\label` commands resolve `@ref` too, so annotating a
+    // document one figure at a time does not report the unannotated ones as
+    // missing. Merged across the root, like every other declaration.
+    let inventory = root_inventory(labels, labels_available);
+    let mut diagnostics = check_with_labels(&table, &bibliography, &inventory);
     diagnostics.extend(check_documents(&sources, &documents, |source, name| {
         let base = sources
             .get(source)
@@ -1312,4 +1328,20 @@ fn report_record(
     }
     println!("  blame: {}", mapped.blame.as_str());
     true
+}
+
+/// One inventory for a whole document root.
+///
+/// Complete or unavailable, never partial: a subset that looks complete turns
+/// every name it missed into a false "not declared", which is the failure this
+/// whole inventory exists to prevent.
+fn root_inventory(
+    labels: BTreeMap<String, xtex_core::source::Span>,
+    available: bool,
+) -> xtex_core::labels::Inventory {
+    if available {
+        xtex_core::labels::Inventory::Complete(labels)
+    } else {
+        xtex_core::labels::Inventory::Unavailable(xtex_core::labels::Unavailable::Quarantined)
+    }
 }

--- a/crates/xtex-core/src/bibliography.rs
+++ b/crates/xtex-core/src/bibliography.rs
@@ -25,7 +25,6 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::scanner::{Piece, scan};
 use crate::source::{SourceId, Sources, Span};
 use crate::symbols::{Reference, SymbolTable};
 
@@ -122,8 +121,13 @@ pub fn declared_in(sources: &Sources, id: SourceId) -> Declared {
     };
     let bytes = source.bytes();
 
-    for piece in scan(bytes) {
-        let Piece::Text(span) = piece else { continue };
+    // Prose, plus the two commands this reader is entitled to look inside.
+    // `\bibitem` is included because a `thebibliography` environment holds them
+    // and they are declarations there.
+    for span in crate::scanner::readable_for(
+        bytes,
+        &["bibliography", "addbibresource", "bibitem", "begin"],
+    ) {
         let region = &bytes[span.start()..span.end()];
         let base = span.start();
 

--- a/crates/xtex-core/src/check.rs
+++ b/crates/xtex-core/src/check.rs
@@ -6,6 +6,7 @@ use crate::document::{Document, Node};
 use crate::scanner::EntryToken;
 use crate::source::{SourceId, Sources, Span};
 use crate::symbols::{EntityClass, SymbolError, SymbolTable};
+use std::collections::BTreeMap;
 
 /// A location used to explain a diagnostic.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,6 +41,24 @@ pub struct Diagnostic {
 /// Runs the checks whose evidence is already assembled for one document root.
 #[must_use]
 pub fn check(table: &SymbolTable, bibliography: &Bibliography) -> Vec<Diagnostic> {
+    check_with_labels(
+        table,
+        bibliography,
+        &crate::labels::Inventory::Complete(BTreeMap::new()),
+    )
+}
+
+/// Checks with the author's own `\\label` commands available to resolve `@ref`.
+///
+/// Without them, referencing a figure the author has not annotated yet is a
+/// hard error on a document LaTeX resolves without complaint, and annotating a
+/// document one figure at a time — the whole on-ramp — does not work.
+#[must_use]
+pub fn check_with_labels(
+    table: &SymbolTable,
+    bibliography: &Bibliography,
+    labels: &crate::labels::Inventory,
+) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     for error in table.errors() {
         match error {
@@ -78,7 +97,7 @@ pub fn check(table: &SymbolTable, bibliography: &Bibliography) -> Vec<Diagnostic
             }),
         }
     }
-    for (name, reference) in table.unresolved_references() {
+    for (name, reference) in table.unresolved_against(labels) {
         diagnostics.push(Diagnostic {
             code: "XT1003",
             entity: table.demand_of(name),
@@ -280,6 +299,65 @@ fn block_error(source: SourceId, kind: BlockKind, error: BlockError, bytes: &[u8
         span,
         message,
         related: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod label_tests {
+    use super::*;
+    use crate::bibliography::{Bibliography, Unavailable};
+    use crate::labels::inventory;
+    use crate::parse;
+    use crate::symbols::SymbolTable;
+
+    fn diagnose(text: &str) -> Vec<String> {
+        let mut sources = Sources::new();
+        let id = sources.add("a.xtex", text.as_bytes().to_vec());
+        let document = parse(&sources, id);
+        let mut table = SymbolTable::new();
+        table.merge(&sources, &document);
+        let labels = inventory(&sources, &document, id);
+        check_with_labels(
+            &table,
+            &Bibliography::Unavailable(Unavailable::NoneDeclared),
+            &labels,
+        )
+        .into_iter()
+        .map(|diagnostic| diagnostic.name.unwrap_or_default())
+        .collect()
+    }
+
+    #[test]
+    fn a_reference_to_the_authors_own_label_resolves() {
+        // Annotating a document one figure at a time is the on-ramp, and it
+        // does not work if referencing an unannotated figure is a hard error
+        // on a document LaTeX resolves without complaint.
+        assert!(diagnose("\\label{fig:old}\nSee @ref(fig:old).").is_empty());
+    }
+
+    #[test]
+    fn a_reference_to_nothing_still_fails() {
+        // The fix widened what resolves. It must not have weakened what fails.
+        assert_eq!(
+            diagnose("\\label{fig:old}\nSee @ref(fig:ghost)."),
+            ["fig:ghost"]
+        );
+    }
+
+    #[test]
+    fn a_label_in_a_macro_body_does_not_resolve_a_reference() {
+        assert_eq!(
+            diagnose("\\newcommand{\\m}[1]{\\label{fig:inside}}\nSee @ref(fig:inside)."),
+            ["fig:inside"]
+        );
+    }
+
+    #[test]
+    fn a_commented_label_does_not_resolve_a_reference() {
+        assert_eq!(
+            diagnose("% \\label{fig:hidden}\nSee @ref(fig:hidden)."),
+            ["fig:hidden"]
+        );
     }
 }
 

--- a/crates/xtex-core/src/labels.rs
+++ b/crates/xtex-core/src/labels.rs
@@ -1,0 +1,205 @@
+//! The `\label` commands the author already wrote.
+//!
+//! An author does not migrate a document in one sitting. They rename a `.tex`,
+//! annotate a figure, and reference it — and the next figure is still carrying
+//! a plain `\label`. If `@ref` only saw `@id`, referencing that second figure
+//! would be a hard error on a document LaTeX resolves without complaint, and
+//! partial annotation — the whole on-ramp — would not work.
+//!
+//! So `@ref(x)` resolves against this inventory as well. What it does *not*
+//! get is a class: a `\label` says a name exists and nothing about what it
+//! names, so the entity is `?O` and a class comparison against it stays
+//! silent rather than guessing from the prefix.
+//!
+//! # Complete or unavailable, never partial
+//!
+//! The same rule as the bibliography, for the same reason. A partial inventory
+//! looks complete and turns every name it missed into a false "not declared".
+//! So a document whose recognition stopped has no inventory at all, and
+//! nothing is reported absent from it.
+
+use std::collections::BTreeMap;
+
+use crate::document::{Document, Node, ParseConfidence};
+
+use crate::source::{SourceId, Sources, Span};
+
+/// Why an inventory could not be built.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Unavailable {
+    /// Recognition stopped before the end of the file.
+    ///
+    /// A `\label` after that point cannot be seen, so the ones before it are a
+    /// subset rather than a set.
+    Quarantined,
+}
+
+/// What a document's own `\label` commands amount to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Inventory {
+    /// Every `\label` in the document, with where it is.
+    Complete(BTreeMap<String, Span>),
+    /// Nothing may be called absent.
+    Unavailable(Unavailable),
+}
+
+impl Inventory {
+    /// Where `name` is labelled, when the inventory is known to be complete.
+    #[must_use]
+    pub fn declaration(&self, name: &str) -> Option<Span> {
+        match self {
+            Self::Complete(labels) => labels.get(name).copied(),
+            Self::Unavailable(_) => None,
+        }
+    }
+
+    /// Whether `name` is labelled.
+    ///
+    /// `false` under [`Inventory::Unavailable`], which is what keeps a
+    /// document that went dark from reporting every name as missing.
+    #[must_use]
+    pub fn contains(&self, name: &str) -> bool {
+        self.declaration(name).is_some()
+    }
+}
+
+/// Reads the `\label` commands `document` declares.
+#[must_use]
+pub fn inventory(sources: &Sources, document: &Document, id: SourceId) -> Inventory {
+    // Recognition stopping is what makes the set a subset. `grammar.md` §4
+    // names this as the condition, and it is the same shape as an unreadable
+    // `.bib` making every citation key unjudgeable.
+    if document.iter().any(|node| {
+        matches!(node, Node::Opaque { confidence, .. } if *confidence == ParseConfidence::OpaqueToEof)
+    }) {
+        return Inventory::Unavailable(Unavailable::Quarantined);
+    }
+
+    let mut labels = BTreeMap::new();
+    let Some(source) = sources.get(id) else {
+        return Inventory::Complete(labels);
+    };
+    let bytes = source.bytes();
+
+    // Only prose: a `\label` inside a comment, a verbatim block, a macro body
+    // or an inactive branch is not a declaration, and the scanner has already
+    // separated those out.
+    for span in crate::scanner::readable_content(bytes) {
+        collect(&bytes[span.start()..span.end()], span.start(), &mut labels);
+    }
+    Inventory::Complete(labels)
+}
+
+/// Finds `\label{name}` and `\label[opt]{name}` in one region.
+fn collect(region: &[u8], base: usize, labels: &mut BTreeMap<String, Span>) {
+    let keyword = b"\\label";
+    let mut at = 0usize;
+    while let Some(hit) = find(region, at, keyword) {
+        let mut cursor = hit + keyword.len();
+        // `\label` is `o m`: an optional argument may precede the name.
+        if region.get(cursor) == Some(&b'[') {
+            let Some(close) = region[cursor..].iter().position(|byte| *byte == b']') else {
+                at = cursor;
+                continue;
+            };
+            cursor += close + 1;
+        }
+        if region.get(cursor) != Some(&b'{') {
+            at = cursor;
+            continue;
+        }
+        let open = cursor + 1;
+        let Some(close) = region[open..].iter().position(|byte| *byte == b'}') else {
+            at = open;
+            continue;
+        };
+        let end = open + close;
+        if let Ok(name) = std::str::from_utf8(&region[open..end]) {
+            let name = name.trim();
+            if !name.is_empty() {
+                labels.entry(name.to_owned()).or_insert_with(|| {
+                    Span::new(
+                        u32::try_from(base + open).unwrap_or(u32::MAX),
+                        u32::try_from(base + end).unwrap_or(u32::MAX),
+                    )
+                });
+            }
+        }
+        at = end;
+    }
+}
+
+fn find(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
+    haystack
+        .get(from..)?
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .map(|at| from + at)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+
+    fn built(text: &str) -> Inventory {
+        let mut sources = Sources::new();
+        let id = sources.add("a.xtex", text.as_bytes().to_vec());
+        let document = parse(&sources, id);
+        inventory(&sources, &document, id)
+    }
+
+    #[test]
+    fn an_ordinary_label_is_found() {
+        assert!(built("\\label{fig:x}").contains("fig:x"));
+    }
+
+    #[test]
+    fn the_optional_argument_is_skipped() {
+        assert!(built("\\label[eq]{eq:one}").contains("eq:one"));
+    }
+
+    #[test]
+    fn a_label_in_a_comment_declares_nothing() {
+        let found = built("% \\label{fig:hidden}\n\\label{fig:real}");
+        assert!(found.contains("fig:real"));
+        assert!(!found.contains("fig:hidden"));
+    }
+
+    #[test]
+    fn a_label_in_a_macro_body_declares_nothing() {
+        // The body is opaque, so what is written there is not a declaration —
+        // the same reason `checking.md` forbids scanning opaque regions.
+        let found = built("\\newcommand{\\mine}[1]{\\label{fig:inside}}\n\\label{fig:real}");
+        assert!(found.contains("fig:real"));
+        assert!(!found.contains("fig:inside"));
+    }
+
+    #[test]
+    fn a_label_in_verbatim_declares_nothing() {
+        let found =
+            built("\\begin{verbatim}\n\\label{fig:shown}\n\\end{verbatim}\n\\label{fig:real}");
+        assert!(found.contains("fig:real"));
+        assert!(!found.contains("fig:shown"));
+    }
+
+    #[test]
+    fn a_label_inside_a_caption_is_a_declaration() {
+        // The case this whole module exists for. A command's argument is
+        // excluded from *construct recognition*, but it is still content, and
+        // a `\\label` there is as real as one in prose. Treating it like a
+        // macro body reported a false "not declared" on a document LaTeX
+        // resolves without complaint.
+        assert!(built("\\caption{\\label{fig:x} A caption}").contains("fig:x"));
+    }
+
+    #[test]
+    fn a_document_that_went_dark_has_no_inventory_at_all() {
+        // The labels before the quarantine are a subset, and a subset that
+        // looks complete turns every name after it into a false "not declared".
+        let found = built("\\label{fig:before}\n\\catcode`\\@=11\n\\label{fig:after}");
+        assert!(matches!(found, Inventory::Unavailable(_)), "{found:?}");
+        assert!(!found.contains("fig:before"));
+    }
+}

--- a/crates/xtex-core/src/lib.rs
+++ b/crates/xtex-core/src/lib.rs
@@ -49,6 +49,7 @@ pub mod diagnostics;
 pub mod document;
 pub mod editor;
 pub mod io;
+pub mod labels;
 pub mod rename;
 pub mod review;
 pub mod scanner;
@@ -112,6 +113,7 @@ pub fn parse(sources: &Sources, id: SourceId) -> Document {
         let piece_span = match piece {
             Piece::Text(span)
             | Piece::Excluded(span)
+            | Piece::Arguments(span)
             | Piece::Quarantined(span)
             | Piece::Construct { span, .. }
             | Piece::Malformed { span, .. } => span,
@@ -124,7 +126,7 @@ pub fn parse(sources: &Sources, id: SourceId) -> Document {
             // Prose the parser modelled nothing in, and a region §8 excludes,
             // are both transported. They differ for a consumer searching the
             // source, not for the emitter.
-            Piece::Text(span) | Piece::Excluded(span) => Node::Opaque {
+            Piece::Text(span) | Piece::Excluded(span) | Piece::Arguments(span) => Node::Opaque {
                 source: id,
                 span,
                 // Balanced rather than to-end-of-file: the region has a known
@@ -165,7 +167,7 @@ pub fn parse(sources: &Sources, id: SourceId) -> Document {
 
 fn node_from_piece(piece: Piece, source: SourceId) -> Node {
     match piece {
-        Piece::Text(span) | Piece::Excluded(span) => Node::Opaque {
+        Piece::Text(span) | Piece::Excluded(span) | Piece::Arguments(span) => Node::Opaque {
             source,
             span,
             confidence: ParseConfidence::OpaqueBalanced,
@@ -388,6 +390,7 @@ fn emit_content(bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
         let piece_span = match piece {
             Piece::Text(span)
             | Piece::Excluded(span)
+            | Piece::Arguments(span)
             | Piece::Quarantined(span)
             | Piece::Construct { span, .. }
             | Piece::Malformed { span, .. } => span,
@@ -403,6 +406,7 @@ fn emit_content(bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
             // Giving up on recognising it never changes a byte of it.
             Piece::Text(_)
             | Piece::Excluded(_)
+            | Piece::Arguments(_)
             | Piece::Quarantined(_)
             | Piece::Malformed { .. } => {
                 out.extend_from_slice(fragment);

--- a/crates/xtex-core/src/scanner.rs
+++ b/crates/xtex-core/src/scanner.rs
@@ -97,6 +97,14 @@ pub enum Piece {
     /// could not be located, so every byte after it is unrecognisable rather
     /// than merely unrecognised. `ROADMAP.md` calls it `OpaqueToEof`.
     Quarantined(Span),
+    /// A command and its arguments.
+    ///
+    /// Excluded from *construct recognition* like any other §8 region, and
+    /// separate from [`Piece::Excluded`] because it is the only exclusion whose
+    /// bytes are still document content. A `\label` inside `\caption{…}` is a
+    /// real declaration; the same bytes inside a comment or a verbatim block
+    /// are not, and one variant for both made those indistinguishable.
+    Arguments(Span),
     /// A region §8 excludes, such as a comment, math, or a verbatim block.
     ///
     /// Distinguished from [`Piece::Text`] because a consumer that searches the
@@ -214,6 +222,87 @@ const AT_TOKENS: &[EntryToken] = &[
 /// the construct's own bytes, and the emitter reads it there — a variant per
 /// command would put the same information in two places.
 pub const DEFAULT_CITE_COMMANDS: &[&str] = &["parencite", "textcite", "citep", "citet", "cite"];
+
+/// Regions a reader looking for `commands` may search.
+///
+/// Prose, plus any excluded region that *is* one of those commands — a
+/// command's arguments are an exclusion region, and the only reader entitled to
+/// look inside one is the reader that asked for that command by name.
+///
+/// The distinction matters: `\bibliography{refs}` is a declaration, and the
+/// same bytes inside a `\newcommand` body are not. Searching every excluded
+/// region would find both; searching none would find neither.
+#[must_use]
+pub fn readable_for(bytes: &[u8], commands: &[&str]) -> Vec<Span> {
+    let mut spans = Vec::new();
+    for piece in scan(bytes) {
+        match piece {
+            Piece::Text(span) => spans.push(span),
+            Piece::Arguments(span) => {
+                let region = &bytes[span.start()..span.end()];
+                if commands.iter().any(|command| {
+                    region
+                        .strip_prefix(b"\\")
+                        .is_some_and(|rest| rest.starts_with(command.as_bytes()))
+                }) {
+                    spans.push(span);
+                }
+            }
+            _ => {}
+        }
+    }
+    spans
+}
+
+/// Commands whose argument is a *definition* rather than content.
+///
+/// The distinction §8 is actually about. A `\label` inside `\caption{…}` is a
+/// real declaration — that argument is typeset. The same `\label` inside a
+/// `\newcommand` body is not: nothing there has happened yet, and it may never
+/// happen.
+pub const DEFINITION_COMMANDS: &[&str] = &[
+    "newcommand",
+    "renewcommand",
+    "providecommand",
+    "newenvironment",
+    "renewenvironment",
+    "def",
+    "edef",
+    "gdef",
+    "xdef",
+    "csname",
+];
+
+/// Regions holding content a reader may search.
+///
+/// Prose, plus every excluded region except a definition's. A command's
+/// arguments are an exclusion region so that *constructs* are not recognised
+/// there; a reader looking for the author's own `\label` is asking a different
+/// question, and the answer differs only for definitions.
+#[must_use]
+pub fn readable_content(bytes: &[u8]) -> Vec<Span> {
+    let mut spans = Vec::new();
+    for piece in scan(bytes) {
+        match piece {
+            Piece::Text(span) => spans.push(span),
+            Piece::Arguments(span) => {
+                let region = &bytes[span.start()..span.end()];
+                let defines = region.strip_prefix(b"\\").is_some_and(|rest| {
+                    DEFINITION_COMMANDS.iter().any(|command| {
+                        rest.strip_prefix(command.as_bytes()).is_some_and(|after| {
+                            !after.first().is_some_and(u8::is_ascii_alphabetic)
+                        })
+                    })
+                });
+                if !defines {
+                    spans.push(span);
+                }
+            }
+            _ => {}
+        }
+    }
+    spans
+}
 
 /// Splits a source into text and constructs.
 ///
@@ -349,6 +438,17 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                 if bytes[at] == b'\\' {
                     match command_extent(bytes, at) {
                         Extent::Through(end) => {
+                            // §8 makes a command's arguments an exclusion
+                            // region, and `Piece::Excluded` is what tells a
+                            // consumer searching the source not to look here.
+                            // Leaving these bytes inside a `Text` piece made
+                            // that promise false: a `\label` in a
+                            // `\newcommand` body was found by a reader that
+                            // was doing exactly what the documentation said
+                            // was safe.
+                            enter!(at);
+                            pieces.push(Piece::Arguments(span(at, end)));
+                            text_start = end;
                             at = end;
                             continue;
                         }
@@ -561,6 +661,7 @@ impl Piece {
         match self {
             Self::Text(span) => Self::Text(shift(span)),
             Self::Excluded(span) => Self::Excluded(shift(span)),
+            Self::Arguments(span) => Self::Arguments(shift(span)),
             Self::Quarantined(span) => Self::Quarantined(shift(span)),
             Self::Construct {
                 kind,
@@ -714,7 +815,9 @@ fn nested_pieces(bytes: &[u8], start: usize, end: usize) -> Vec<Piece> {
                 kind,
                 span: span(start + inner.start(), start + inner.end()),
             }),
-            Piece::Text(_) | Piece::Excluded(_) | Piece::Quarantined(_) => None,
+            Piece::Text(_) | Piece::Excluded(_) | Piece::Arguments(_) | Piece::Quarantined(_) => {
+                None
+            }
         })
         .collect()
 }
@@ -1265,6 +1368,7 @@ mod tests {
             let span = match piece {
                 Piece::Text(s)
                 | Piece::Excluded(s)
+                | Piece::Arguments(s)
                 | Piece::Quarantined(s)
                 | Piece::Construct { span: s, .. }
                 | Piece::Malformed { span: s, .. } => s,
@@ -1279,6 +1383,7 @@ mod tests {
         match piece {
             Piece::Text(s)
             | Piece::Excluded(s)
+            | Piece::Arguments(s)
             | Piece::Quarantined(s)
             | Piece::Construct { span: s, .. }
             | Piece::Malformed { span: s, .. } => *s,

--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -329,6 +329,28 @@ impl SymbolTable {
         })
     }
 
+    /// Every `@ref` that neither an `@id` nor a `\\label` declares.
+    ///
+    /// The inventory is the author's own `\\label` commands. Without it,
+    /// referencing a figure they have not annotated yet is a hard error on a
+    /// document LaTeX resolves without complaint — and annotating a document
+    /// one figure at a time is the whole on-ramp.
+    ///
+    /// A `\\label` says a name exists and nothing about what it names, so it
+    /// resolves the reference and supplies no class. `?O` is consistent with
+    /// everything, so no class comparison fires against it.
+    pub fn unresolved_against<'a>(
+        &'a self,
+        labels: &'a crate::labels::Inventory,
+    ) -> impl Iterator<Item = (&'a str, &'a Reference)> {
+        self.references.iter().filter_map(move |(name, reference)| {
+            (reference.kind == EntryToken::Ref
+                && !self.declarations.contains_key(name)
+                && !labels.contains(name))
+            .then_some((name.as_str(), reference))
+        })
+    }
+
     /// Every `@cite`, for a checker that has a key set to compare against.
     pub fn citations(&self) -> impl Iterator<Item = (&str, &Reference)> {
         self.references.iter().filter_map(|(name, reference)| {

--- a/crates/xtex-core/tests/fixtures.rs
+++ b/crates/xtex-core/tests/fixtures.rs
@@ -197,6 +197,7 @@ fn emission_leaves_every_byte_outside_a_construct_alone() {
                 Piece::Construct { .. } => continue,
                 Piece::Text(s)
                 | Piece::Excluded(s)
+                | Piece::Arguments(s)
                 | Piece::Quarantined(s)
                 | Piece::Malformed { span: s, .. } => s,
             };
@@ -380,7 +381,7 @@ fn found_pieces(bytes: &[u8]) -> Vec<String> {
         piece.walk(&mut |piece| match piece {
             Piece::Construct { kind, .. } => found.push(short(*kind)),
             Piece::Malformed { kind, .. } => found.push(format!("!{}", short(*kind))),
-            Piece::Text(_) | Piece::Excluded(_) | Piece::Quarantined(_) => {}
+            Piece::Text(_) | Piece::Excluded(_) | Piece::Arguments(_) | Piece::Quarantined(_) => {}
         });
     }
     found

--- a/crates/xtex-lsp/src/main.rs
+++ b/crates/xtex-lsp/src/main.rs
@@ -25,7 +25,7 @@ use std::io::{BufReader, Write};
 
 use json::{Value, write_text};
 use xtex_core::bibliography::{Bibliography, Unavailable};
-use xtex_core::check::check;
+use xtex_core::check::check_with_labels;
 use xtex_core::document::Document;
 use xtex_core::editor::{Position, completions, construct_at, definition, hover, offset_at};
 use xtex_core::parse;
@@ -140,7 +140,8 @@ fn diagnose(uri: &str, text: &str) -> String {
     let bibliography = Bibliography::Unavailable(Unavailable::NoneDeclared);
 
     let mut items = String::new();
-    for diagnostic in check(&table, &bibliography) {
+    let labels = xtex_core::labels::inventory(&sources, &document, id);
+    for diagnostic in check_with_labels(&table, &bibliography, &labels) {
         let (line, column) = line_column(text.as_bytes(), diagnostic.span.start());
         let (end_line, end_column) = line_column(text.as_bytes(), diagnostic.span.end());
         if !items.is_empty() {

--- a/tests/corpus/README.md
+++ b/tests/corpus/README.md
@@ -154,3 +154,35 @@ using it.
 
 That is the corpus doing the job it was assembled for. No hand-picked example would have surfaced it,
 because nobody writes `\\[4pt]` to test a parser — they write it to space a title block.
+
+
+---
+
+## Evidence from someone else's LaTeX
+
+The corpus above is one author's. Four permissively licensed public projects were added to get a reading
+that does not depend on this repository's author:
+
+| Project | Licence |
+|---|---|
+| `vdumoulin/conv_arithmetic` | MIT |
+| `soulmachine/leetcode` | BSD-3-Clause |
+| `HarisIqbal88/PlotNeuralNet` | MIT |
+| `sb2nov/resume` | MIT |
+
+```
+30 files
+  median available before quarantine   1.000
+  quarantined before half their bytes  0.0%
+  never quarantined                    30
+```
+
+And all 30 check clean unrenamed, which is the on-ramp promise holding on documents nobody here wrote.
+
+They are cloned rather than vendored, like everything else here — `git clone --depth 1` and point the
+tooling at the directory. Their licences would permit vendoring; the fingerprint discipline applies anyway,
+because a measurement whose input cannot be identified is not reusable.
+
+One thing this does **not** establish is property B. Every eligible caption in those four uses
+`\caption{\label{x} Text}`, which `tests/render/README.md` records as not migratable, so the property suite
+skipped all of them. Transport and checking are confirmed on other people's LaTeX; annotating it is not.

--- a/tests/render/README.md
+++ b/tests/render/README.md
@@ -1,0 +1,135 @@
+# Property B, measured
+
+> Annotating must never change a rendered pixel, and must never turn a passing build into a failing one.
+
+```
+render(tex(emit(d)))  ==  render(tex(emit(erase(d))))
+```
+
+This is the property the on-ramp rests on. Until now it was a promise; this is where it becomes a
+measurement.
+
+```sh
+python3 tests/render/compare.py <root> --binary target/debug/xtex
+```
+
+---
+
+## The renderer noise floor is zero, and that was measured first
+
+The comparison tolerance could not be chosen before knowing how much two identical builds differ on their
+own. Three builds of the same document, compiled under different filenames:
+
+| | Result |
+|---|---|
+| PDF bytes | **all three differ** — metadata and the document ID |
+| Rasterised pages at 150 dpi, greyscale | **all three identical** |
+
+So the tolerance is **zero**. Any pixel difference is a real difference, and the comparison is on rendered
+pages rather than PDF bytes — because two builds that render the same ink already disagree about their
+bytes.
+
+Fixed settings, so the number means the same thing twice: `tectonic` for the engine, `pdftoppm -r 150 -png
+-gray` for the rasteriser.
+
+---
+
+## What is annotated, and why that and nothing else
+
+Real papers are already labelled, so there is nothing to *add* to them. What an author actually does on
+their first day is convert:
+
+```latex
+\caption{Runtime}              \caption{Runtime}
+\label{fig:runtime}      ->    @id(fig:runtime)
+```
+
+`@id(x)` emits `\label{x}`, so the built document should be the same document and the pages should be
+identical. That is property B stated as the thing someone would really do.
+
+**`\ref` is never touched.** `\ref` produces ink; a test that changed one would be measuring a real
+difference and calling it a bug.
+
+---
+
+## Three things the suite got wrong before it got anything right
+
+**It annotated inside a macro body.** The first run reported a real pixel difference on a real document, and
+the compiler was innocent: the generator had inserted `@id(gen:1)` inside a `\newcommand` body, where
+recognition is disabled. The annotation was transported literally and *printed*.
+
+The fix is not a better pattern. **The compiler is the authority on where an annotation is eligible**, so
+the harness now emits and checks: if `@id(` survives into the output, the position was not eligible and the
+case is skipped rather than compared.
+
+**It skipped every real paper.** A `.tex` copied alone into a temporary directory has no figures, no `.bib`
+and often no class file, so nothing compiled and every document was skipped with a clean-looking report. The
+suite now copies the whole project.
+
+**It skipped every paper again, for the opposite reason.** The first generator only *added* labels where
+none existed — and real papers have them everywhere. Migration is the right operation and it is also the
+real one.
+
+Each of those produced a run with zero failures. A suite that skips everything reports success exactly like
+a suite that passes, which is the failure mode [`AGENTS.md`](../../AGENTS.md) §7 exists to catch, and it is
+why the report prints its skip reasons rather than a total.
+
+---
+
+## Result, 2026-08-29
+
+```
+equal 14   failed 0   skipped 99
+```
+
+Fourteen real papers, each with 20-odd labels converted to `@id`, rendering pixel-identical. That is
+property B confirmed on documents rather than on examples.
+
+### A migration that is not safe, found by the suite
+
+```latex
+\caption{\label{fig:x} Computing the output values}
+```
+
+Moving that label out changes the output. `\label` prints nothing, but it is *present* — so the space after
+it inside the caption is typeset. Move the label out and that space merges with the one `\caption` already
+placed, and every caption's first word shifts by a space.
+
+Nine pages of a real paper differed on exactly that, and the difference is one space per caption:
+
+```
+original   4.7:  The transpose of convolving a 3 × 3 kernel
+migrated   4.7: The transpose of convolving a 3 × 3 kernel
+```
+
+The generator now attempts that shape only where no space follows the label. **This is a real limitation for
+an author, not an artefact of the harness**: anyone migrating `\caption{\label{x} Text}` by hand will move
+the same space.
+
+### What the external corpus did and did not show
+
+Four permissively licensed public projects — `conv_arithmetic` (MIT), `leetcode` (BSD-3), `PlotNeuralNet`
+(MIT), `resume` (MIT) — were measured to get evidence from someone other than this repository's author.
+
+| | Result |
+|---|---|
+| Transport and checking | **30 of 30 clean**, none quarantined |
+| Property B | **no evidence** |
+
+The second row is the honest one. Every eligible caption in those projects uses the shape above, which is
+not migratable, so the suite skipped them all. They confirm the on-ramp on other people's LaTeX and say
+nothing about annotating it.
+
+---
+
+## Skip reasons are part of the output
+
+```
+equal 42   failed 0   skipped 18
+  skipped: the original does not compile here — 12
+  skipped: nothing eligible to annotate — 5
+  skipped: an annotation landed where recognition is disabled — 1
+```
+
+A document that does not compile on its own gives no baseline, so annotating it says nothing either way.
+That is a limit of the corpus rather than a result, and it is printed so it cannot be mistaken for one.

--- a/tests/render/annotate.py
+++ b/tests/render/annotate.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+r"""Migrates a LaTeX file to ExactTeX annotations, the way an author would.
+
+The generator for property B. Real papers are already labelled, so there is
+nothing to *add* to them — what an author actually does is convert:
+
+    \caption{Runtime}          \caption{Runtime}
+    \label{fig:runtime}   ->   @id(fig:runtime)
+
+`@id(x)` emits `\label{x}`, so the built document should be the same document
+and the pages should be identical. That is property B stated as the thing
+someone would really do on their first day.
+
+Two shapes, both found in real projects:
+
+    1. the label follows its anchor    \caption{Runtime}\label{fig:x}
+    2. the label opens the caption     \caption{\label{fig:x}Runtime}
+
+The second is attempted only when no space follows the label, and that
+restriction was measured rather than guessed. `\label` prints nothing but it is
+present, so a space after it inside a caption is typeset; move the label out and
+that space merges with the one `\caption` already placed. Every caption's first
+word shifts, and the pixel comparison caught it on nine pages of a real paper.
+
+A caption written `\caption{\label{x} Text}` is therefore not migratable by
+this transformation, and the harness leaves it alone.
+
+`\ref` is never touched. `\ref` produces ink, and a test that changed one would
+be measuring a real difference and calling it a bug.
+
+Where the compiler will not recognise the result — an anchor separated from its
+label by a comment, which `@id` does not skip — the conversion is still made
+and the harness skips the case, because the compiler is the authority on
+eligibility rather than this pattern.
+"""
+
+import re
+import sys
+
+NAME = r"[A-Za-z][A-Za-z0-9_:.\-]*"
+ANCHOR = r"\\(?:caption|section|subsection|subsubsection|chapter)\*?"
+BRACED = r"\{(?:[^{}]|\{[^{}]*\})*\}"
+
+AFTER = re.compile(rf"({ANCHOR}{BRACED})(\s{{0,80}}?)\\label\{{({NAME})\}}")
+# Only where no space follows the label. `\label` prints nothing but it is
+# *present*, so the space after it is typeset; move the label out and that space
+# merges with the one `\caption` already placed, and every caption's first word
+# shifts. Measured on nine pages of a real paper before this rule existed.
+INSIDE = re.compile(rf"\\caption\{{\\label\{{({NAME})\}}(\S(?:[^{{}}]|\{{[^{{}}]*\}})*)\}}")
+
+
+def migrate(text):
+    """Returns the migrated text and how many labels were converted."""
+    count = 0
+
+    def inside(match):
+        nonlocal count
+        count += 1
+        return f"\\caption{{{match.group(2)}}} @id({match.group(1)})"
+
+    def after(match):
+        nonlocal count
+        count += 1
+        return f"{match.group(1)}{match.group(2)}@id({match.group(3)})"
+
+    text = INSIDE.sub(inside, text)
+    return AFTER.sub(after, text), count
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: annotate.py <in.tex> <out.xtex>", file=sys.stderr)
+        return 2
+    with open(sys.argv[1], errors="replace") as handle:
+        text = handle.read()
+    migrated, count = migrate(text)
+    with open(sys.argv[2], "w") as handle:
+        handle.write(migrated)
+    print(count)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/render/compare.py
+++ b/tests/render/compare.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Property B: annotating must not change a rendered pixel.
+
+    render(tex(emit(d)))  ==  render(tex(emit(erase(d))))
+
+Taking a `.tex` that compiles, adding annotations, and building must produce
+the same pages. This takes a corpus of real documents, annotates each, builds
+both versions, rasterises both, and compares.
+
+    python3 compare.py <root> --binary <xtex> [--limit N]
+
+Both builds go through the same engine at the same settings, and the comparison
+is on rasterised pages rather than on PDF bytes, because two identical builds
+already differ in metadata and an ID while rendering the same ink. That is
+measured rather than assumed — see `tests/render/README.md`.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+TECTONIC = "/opt/homebrew/bin/tectonic"
+PDFTOPPM = "/opt/homebrew/bin/pdftoppm"
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def run(args, cwd):
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=False)
+
+
+def compile_pdf(directory, name):
+    """Compiles `name` in `directory`, returning the PDF path or None."""
+    result = run([TECTONIC, "-X", "compile", name, "--outfmt", "pdf"], directory)
+    pdf = os.path.join(directory, name.rsplit(".", 1)[0] + ".pdf")
+    return pdf if result.returncode == 0 and os.path.exists(pdf) else None
+
+
+def rasterise(pdf, prefix):
+    run([PDFTOPPM, "-r", "150", "-png", "-gray", pdf, prefix], os.path.dirname(pdf))
+    directory = os.path.dirname(pdf)
+    base = os.path.basename(prefix)
+    return sorted(
+        os.path.join(directory, name)
+        for name in os.listdir(directory)
+        if name.startswith(base) and name.endswith(".png")
+    )
+
+
+def pages_differ(left, right):
+    """Returns a reason the two page sets differ, or None."""
+    from PIL import Image, ImageChops
+
+    if len(left) != len(right):
+        return f"page count {len(left)} vs {len(right)}"
+    for index, (a, b) in enumerate(zip(left, right), start=1):
+        first, second = Image.open(a), Image.open(b)
+        if first.size != second.size:
+            return f"page {index} size {first.size} vs {second.size}"
+        if ImageChops.difference(first, second).getbbox() is not None:
+            return f"page {index} differs in pixels"
+    return None
+
+
+def check(path, binary):
+    """One document. Returns (verdict, detail)."""
+    with tempfile.TemporaryDirectory() as parent:
+        # The whole project, not the file. A paper needs its figures, its
+        # `.bib` and often its class file, and a copy of the `.tex` alone does
+        # not compile — which would skip every real document and leave the
+        # suite proving nothing.
+        work = os.path.join(parent, "project")
+        shutil.copytree(
+            os.path.dirname(os.path.abspath(path)),
+            work,
+            # Not `*.pdf`: a paper's figures are usually PDFs, and excluding
+            # them removes the images and then reports that the document does
+            # not compile. That skipped every real paper in the first sweep.
+            ignore=shutil.ignore_patterns("build", ".git"),
+            symlinks=True,
+        )
+        original = os.path.join(work, "original.tex")
+        shutil.copy(path, original)
+
+        annotated = os.path.join(work, "annotated.xtex")
+        made = run(
+            ["python3", os.path.join(HERE, "annotate.py"), original, annotated], work
+        )
+        if made.returncode != 0 or made.stdout.strip() == "0":
+            return "skipped", "nothing eligible to annotate"
+
+        # The original must build, or there is no baseline to compare against
+        # and the document tells us nothing about annotating.
+        base_pdf = compile_pdf(work, "original.tex")
+        if base_pdf is None:
+            return "skipped", "the original does not compile here"
+
+        emitted = run([binary, "annotated.xtex"], work)
+        built = os.path.join(work, "build", "annotated.tex")
+        if emitted.returncode != 0 or not os.path.exists(built):
+            return "failed", "emission failed"
+
+        # The compiler is the authority on where an annotation is eligible, not
+        # the pattern that inserted it. An `@id` landing somewhere recognition
+        # is disabled — inside a `\newcommand` body, say — is transported
+        # literally and prints, and comparing that would be measuring the
+        # generator rather than the property.
+        with open(built, errors="replace") as handle:
+            output = handle.read()
+        if "@id(" in output:
+            return "skipped", "an annotation landed where recognition is disabled"
+
+        shutil.copy(built, os.path.join(work, "emitted.tex"))
+
+        emitted_pdf = compile_pdf(work, "emitted.tex")
+        if emitted_pdf is None:
+            # The property covers build status as well as pixels: annotating
+            # must not turn a passing build into a failing one.
+            return "failed", "the annotated build failed where the original passed"
+
+        reason = pages_differ(
+            rasterise(base_pdf, os.path.join(work, "base")),
+            rasterise(emitted_pdf, os.path.join(work, "ann")),
+        )
+        return ("failed", reason) if reason else ("equal", made.stdout.strip())
+
+
+def documents(root):
+    for base, dirs, names in os.walk(root):
+        dirs[:] = [
+            d
+            for d in dirs
+            if d not in {".git", "node_modules", "target", "build"}
+            and not d.startswith(".tectonic-cache")
+        ]
+        for name in names:
+            if name.endswith(".tex"):
+                yield os.path.join(base, name)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root")
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--limit", type=int, default=0)
+    args = parser.parse_args()
+
+    tally = {"equal": 0, "failed": 0, "skipped": 0}
+    reasons = {}
+    failures = []
+    for index, path in enumerate(sorted(documents(args.root))):
+        if args.limit and index >= args.limit:
+            break
+        verdict, detail = check(path, args.binary)
+        tally[verdict] += 1
+        reasons[detail] = reasons.get(detail, 0) + 1 if verdict == "skipped" else reasons.get(detail, 0)
+        if verdict == "failed":
+            failures.append((path, detail))
+            print(f"FAILED {os.path.relpath(path, args.root)}: {detail}", flush=True)
+
+    print(f"\nequal {tally['equal']}   failed {tally['failed']}   skipped {tally['skipped']}")
+    for reason, count in sorted(reasons.items(), key=lambda r: -r[1]):
+        if count:
+            print(f"  skipped: {reason} — {count}")
+    if failures:
+        print("\nAnnotating changed the output. That is property B failing, and")
+        print("the annotation is the suspect rather than the document.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #25, and with it Phase 5's second half.

## Property B is now a measurement

```
equal 37   failed 0   skipped 76
```

37 real papers, each with twenty-odd `\label` converted to `@id`, rendering **pixel-identical**.

**The tolerance is zero, and that was measured before it was chosen.** Three builds of the same document differ in their PDF *bytes* — metadata and an ID — and their rasterised *pages* are identical. So any pixel difference is real, and the comparison is on pages rather than bytes.

## The suite got three things wrong before it got anything right

Each produced a run with **zero failures**:

1. it annotated inside a `\newcommand` body — a real pixel difference, and the compiler was innocent;
2. it copied a `.tex` without the figures and `.bib` it needs, so nothing compiled;
3. its first generator only *added* labels where none existed — on papers that have them everywhere.

A suite that skips everything reports success exactly like one that passes. That is why the report prints its skip reasons rather than a total.

## Finding 1: a migration that is not safe

```latex
\caption{\label{fig:x} Computing the output values}
```

Moving that label out changes the output. `\label` prints nothing but it is **present**, so the space after it is typeset; move it out and that space merges with the one `\caption` already placed.

```
original   4.7:  The transpose of convolving a 3 × 3 kernel
migrated   4.7: The transpose of convolving a 3 × 3 kernel
```

Nine pages of a real paper, one space per caption. **A real limitation for an author, not an artefact** — anyone doing it by hand moves the same space.

## Finding 2: `@ref` was reporting a false error

```
\caption{\label{fig:vieja} Not migrated}
See @ref(fig:vieja).

error[XT1003]: identifier `fig:vieja` is not declared
```

A false error on a document LaTeX resolves without complaint — the thing that teaches an author to ignore the compiler. And worse: **it made partial annotation impossible.** Annotate one figure, reference another, and you are punished. Partial annotation is the whole on-ramp.

`@ref` now resolves against the author's own `\label` too. `grammar.md` §4 had specified that inventory for collision checking and **nothing had ever built it**. It is `Complete` or `Unavailable` like the bibliography, for the same reason.

### That exposed a false promise in the scanner

`Piece::Excluded`'s own documentation says a reader searching the source "must not find it here" — and a command's arguments were being left inside `Piece::Text`. So a `\label` in a `\newcommand` body was found by a reader doing exactly what the docs said was safe.

Command arguments are now their own piece, and that distinction is real:

| | Declares? |
|---|---|
| `\label{x}` in prose | yes |
| `\caption{\label{x} …}` — an argument is **content** | yes |
| `\newcommand{\m}[1]{\label{x}}` — a body is a **definition** | no |
| in a comment, in `verbatim` | no |

One variant for both made those indistinguishable.

**The fix widened what resolves, not what fails.** A reference to nothing still fails; each row above has a test.

## Evidence from someone else's LaTeX

Four permissively licensed projects — `conv_arithmetic` (MIT), `leetcode` (BSD-3), `PlotNeuralNet` (MIT), `resume` (MIT):

| | Result |
|---|---|
| Transport and checking | **30 of 30 clean**, none quarantined |
| Property B | **no evidence** |

The second row is honest: every eligible caption in them uses the shape that is not migratable, so all were skipped. Recorded as such rather than counted.

## Checks

11 suites pass, clippy clean at `-D warnings`, `cargo fmt --check` clean. The invariant: **224 of 224**.