### PR TITLE
Report an unreadable bibliography by default when the document cites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,9 @@ exists today.
   reordering arguments — breaks transport silently.
 - **A hard error only ever comes from an explicit ExactTeX construct.** `?O` is consistent with every type, so
   an unannotated `\ref{x}` cannot fail. A renamed `.tex` checks clean by construction. Everything else is
-  `advisory`, behind `--strict-tex`, and never touches the exit code.
+  `advisory` and never touches the exit code. An advisory is printed by default when an explicit construct
+  asked for a check that could not be performed, and behind `--strict-tex` when it is only an observation
+  about plain LaTeX.
 - **Unknown LaTeX is never a fatal error.** The parser downgrades confidence and preserves. Fatal is reserved
   for I/O failure, invalid annotation encoding, resource limits, and broken internal invariants.
 - **A diagnostic names its blame side.** Author LaTeX, ExactTeX construct, or emitted output. With no map

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -135,7 +135,10 @@ Ordinary LaTeX is `?O`, the unknown *open* datatype: any package may define new 
 not merely unknown, it is unbounded. `?O` is consistent with every type. Therefore an unannotated `\ref{x}`
 can never produce a hard error, and a renamed `.tex` checks clean by construction.
 
-Everything else is `advisory`, behind `--strict-tex`, and never affects the exit code.
+Everything else is `advisory` and never affects the exit code. Which advisories are printed depends on who
+asked. An observation about plain LaTeX that nobody asked us to check is printed only behind `--strict-tex`.
+A check an explicit construct *did* ask for, and that we could not perform, is printed by default — staying
+quiet there reports a document as checked when it was not.
 
 Never scan inside opaque regions for `\label`, `\ref` or `\cite` and treat what you find as checkable. Such a
 scan matches inside a `\newcommand` body, inside verbatim text, and inside an inactive `\if` branch.

--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -9,8 +9,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
-use xtex_core::bibliography::{Bibliography, Declared, Unavailable, assemble, declared_in};
-use xtex_core::check::{Diagnostic, check_documents, check_with_labels, to_json};
+use xtex_core::bibliography::{Bibliography, Declared, assemble, declared_in};
+use xtex_core::check::{Blame, Diagnostic, Severity, check_documents, check_with_labels, to_json};
 use xtex_core::diagnostics::map_emitted_diagnostic;
 use xtex_core::document::Node;
 use xtex_core::editor::entity_at;
@@ -223,7 +223,6 @@ fn sole_document() -> Result<String, String> {
 
 fn check_command(args: &[String]) -> ExitCode {
     let json = args.iter().any(|arg| arg == "--json");
-    let strict = args.iter().any(|arg| arg == "--strict-tex");
     let inputs: Vec<&str> = args
         .iter()
         .filter(|arg| !arg.starts_with("--"))
@@ -235,7 +234,7 @@ fn check_command(args: &[String]) -> ExitCode {
     }
 
     match run_check(inputs[0]) {
-        Ok((sources, diagnostics, coverage, bibliography)) => {
+        Ok((sources, diagnostics, coverage, _bibliography)) => {
             if json {
                 {
                     // One renderer, shared with the WebAssembly build, so the two
@@ -248,14 +247,12 @@ fn check_command(args: &[String]) -> ExitCode {
                 for diagnostic in &diagnostics {
                     print_human(&sources, diagnostic);
                 }
-                if strict {
-                    if let Bibliography::Unavailable(reason) = bibliography {
-                        print_bibliography_advisory(&reason);
-                    }
-                }
                 println!("coverage: {:.1}%", coverage * 100.0);
             }
-            if diagnostics.is_empty() {
+            if diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.severity == Severity::Advisory)
+            {
                 ExitCode::SUCCESS
             } else {
                 ExitCode::from(1)
@@ -330,6 +327,8 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
                         span,
                         message: format!("import path `{path}` does not resolve"),
                         related: Vec::new(),
+                        severity: Severity::Error,
+                        blame: Blame::XtexConstruct,
                     });
                 }
                 Err(error) => return Err(error),
@@ -345,6 +344,7 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
     // missing. Merged across the root, like every other declaration.
     let inventory = root_inventory(labels, labels_available);
     let mut diagnostics = check_with_labels(&table, &bibliography, &inventory);
+    diagnostics.extend(bibliography_advisory(&table, &bibliography));
     diagnostics.extend(check_documents(&sources, &documents, |source, name| {
         let base = sources
             .get(source)
@@ -448,8 +448,22 @@ fn parse_prefixes(text: &str) -> Option<PrefixMap> {
     found.then_some(map)
 }
 
-fn print_bibliography_advisory(reason: &Unavailable) {
-    println!("advisory: citation checking unavailable ({reason:?})");
+fn bibliography_advisory(table: &SymbolTable, bibliography: &Bibliography) -> Option<Diagnostic> {
+    let Bibliography::Unavailable(reason) = bibliography else {
+        return None;
+    };
+    let (_, citation) = table.citations().next()?;
+    Some(Diagnostic {
+        code: "XT2001",
+        entity: EntityClass::Citation,
+        name: None,
+        source: citation.payload.source,
+        span: citation.payload.span,
+        message: format!("citation checking unavailable: {}", reason.reason()),
+        related: Vec::new(),
+        severity: Severity::Advisory,
+        blame: Blame::Unresolved,
+    })
 }
 
 fn build(
@@ -1061,7 +1075,10 @@ fn offset_line_column(bytes: &[u8], offset: usize) -> (usize, usize) {
 /// Prints one diagnostic the way a person reads it.
 fn print_human(sources: &Sources, diagnostic: &Diagnostic) {
     let (file, line, column) = location(sources, diagnostic.source, diagnostic.span);
-    println!("error[{}]: {}", diagnostic.code, diagnostic.message);
+    match diagnostic.severity {
+        Severity::Error => println!("error[{}]: {}", diagnostic.code, diagnostic.message),
+        Severity::Advisory => println!("advisory: {}", diagnostic.message),
+    }
     println!("  --> {file}:{line}:{column}");
     println!("  entity: {}", diagnostic.entity.name());
     if let Some(name) = &diagnostic.name {
@@ -1076,7 +1093,7 @@ fn print_human(sources: &Sources, diagnostic: &Diagnostic) {
         let (file, line, column) = location(sources, related.source, related.span);
         println!("  --> {file}:{line}:{column}: {}", related.message);
     }
-    println!("  blame: xtex-construct");
+    println!("  blame: {}", diagnostic.blame.as_str());
 }
 
 /// File, one-based line and one-based column of a span.
@@ -1343,5 +1360,94 @@ fn root_inventory(
         xtex_core::labels::Inventory::Complete(labels)
     } else {
         xtex_core::labels::Inventory::Unavailable(xtex_core::labels::Unavailable::Quarantined)
+    }
+}
+
+#[cfg(test)]
+mod bibliography_advisory_tests {
+    use super::*;
+    use xtex_core::bibliography::Unavailable;
+
+    fn table(text: &str) -> (Sources, SymbolTable) {
+        let mut sources = Sources::new();
+        let id = sources.add("main.xtex", text.as_bytes().to_vec());
+        let document = parse(&sources, id);
+        let mut table = SymbolTable::new();
+        table.merge(&sources, &document);
+        (sources, table)
+    }
+
+    #[test]
+    fn unreadable_bibliography_with_a_citation_is_an_advisory_in_json() {
+        let (sources, table) = table("See @cite(knuth1984).");
+        let bibliography = Bibliography::Unavailable(Unavailable::Unreadable {
+            name: "refs.bib".to_owned(),
+        });
+        let advisory = bibliography_advisory(&table, &bibliography)
+            .expect("the explicit citation requests bibliography checking");
+
+        assert_eq!(advisory.severity, Severity::Advisory);
+        assert_eq!(advisory.blame, Blame::Unresolved);
+        assert_eq!(advisory.name, None, "the advisory is not about a key");
+        let mut json = String::new();
+        to_json(&sources, &[advisory], 1.0, &mut json);
+        assert!(json.contains("\"severity\":\"advisory\""), "{json}");
+        assert!(
+            json.contains("citation checking unavailable: `refs.bib` could not be read"),
+            "{json}"
+        );
+    }
+
+    #[test]
+    fn no_advisory_message_carries_a_derived_debug_spelling() {
+        // The reader of this line is the author, not the compiler. Field names
+        // and byte offsets belong in neither output form.
+        let (_, table) = table("See @cite(knuth1984).");
+        for reason in [
+            Unavailable::NoneDeclared,
+            Unavailable::ComputedPath {
+                span: xtex_core::source::Span::new(0, 1),
+            },
+            Unavailable::Unreadable {
+                name: "refs.bib".to_owned(),
+            },
+            Unavailable::UnparsableEntry {
+                name: "refs.bib".to_owned(),
+            },
+        ] {
+            let message = bibliography_advisory(&table, &Bibliography::Unavailable(reason.clone()))
+                .expect("the explicit citation requests bibliography checking")
+                .message;
+            for tell in ["{", "}", "Span", "start:", "name:"] {
+                assert!(
+                    !message.contains(tell),
+                    "`{tell}` leaked into `{message}` from `{reason:?}`"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unreadable_bibliography_without_a_citation_says_nothing() {
+        // Declarations, references and a plain LaTeX `\cite` — every kind of
+        // construct except the one that asks about a bibliography. Anchoring on
+        // any of them would report an unreadable file at a document that never
+        // asked, which is the invariant in `AGENTS.md` §4.
+        let (_, table) = table(
+            "@id(intro) here, @ref(intro) and @ref(absent).\n\\cite{knuth1984}\n\\bibliography{refs}",
+        );
+        let bibliography = Bibliography::Unavailable(Unavailable::Unreadable {
+            name: "refs.bib".to_owned(),
+        });
+
+        assert!(bibliography_advisory(&table, &bibliography).is_none());
+    }
+
+    #[test]
+    fn complete_bibliography_says_nothing() {
+        let (_, table) = table("See @cite(knuth1984).");
+        let bibliography = Bibliography::Complete(BTreeSet::from(["knuth1984".to_owned()]));
+
+        assert!(bibliography_advisory(&table, &bibliography).is_none());
     }
 }

--- a/crates/xtex-core/src/bibliography.rs
+++ b/crates/xtex-core/src/bibliography.rs
@@ -51,6 +51,26 @@ pub enum Unavailable {
     },
 }
 
+impl Unavailable {
+    /// Why the key set is missing, in the words a reader of the diagnostic needs.
+    ///
+    /// The derived `Debug` spelling carries field names and byte offsets, which
+    /// are the compiler's business rather than the author's.
+    #[must_use]
+    pub fn reason(&self) -> String {
+        match self {
+            Self::NoneDeclared => "the document declares no bibliography".to_owned(),
+            Self::ComputedPath { .. } => {
+                "the declared bibliography path is computed rather than literal".to_owned()
+            }
+            Self::Unreadable { name } => format!("`{name}` could not be read"),
+            Self::UnparsableEntry { name } => {
+                format!("an entry boundary in `{name}` could not be located")
+            }
+        }
+    }
+}
+
 /// What the document's bibliography amounts to.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Bibliography {

--- a/crates/xtex-core/src/check.rs
+++ b/crates/xtex-core/src/check.rs
@@ -36,6 +36,50 @@ pub struct Diagnostic {
     pub message: String,
     /// Locations that explain the primary finding.
     pub related: Vec<Related>,
+    /// Whether the finding can change the process exit code.
+    pub severity: Severity,
+    /// Which side of the source boundary the finding belongs to.
+    pub blame: Blame,
+}
+
+/// How strongly a diagnostic is substantiated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// A substantiated failure in an explicit ExactTeX construct.
+    Error,
+    /// A condition worth reporting that does not change the exit code.
+    Advisory,
+}
+
+impl Severity {
+    /// The stable spelling used by both renderers.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Advisory => "advisory",
+        }
+    }
+}
+
+/// The side of the source boundary responsible for a diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Blame {
+    /// An explicit ExactTeX construct.
+    XtexConstruct,
+    /// The available evidence does not establish a side.
+    Unresolved,
+}
+
+impl Blame {
+    /// The stable spelling used by both renderers.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::XtexConstruct => "xtex-construct",
+            Self::Unresolved => "unresolved",
+        }
+    }
 }
 
 /// Runs the checks whose evidence is already assembled for one document root.
@@ -84,6 +128,8 @@ pub fn check_with_labels(
                         span: *first,
                         message: "first declared here".to_owned(),
                     }],
+                    severity: Severity::Error,
+                    blame: Blame::XtexConstruct,
                 });
             }
             SymbolError::Malformed { source, construct } => diagnostics.push(Diagnostic {
@@ -94,6 +140,8 @@ pub fn check_with_labels(
                 span: *construct,
                 message: "identifier is empty or contains unsupported bytes".to_owned(),
                 related: Vec::new(),
+                severity: Severity::Error,
+                blame: Blame::XtexConstruct,
             }),
         }
     }
@@ -106,6 +154,8 @@ pub fn check_with_labels(
             span: reference.payload.span,
             message: format!("identifier `{name}` is not declared"),
             related: Vec::new(),
+            severity: Severity::Error,
+            blame: Blame::XtexConstruct,
         });
     }
     for (name, reference, demand, declaration) in table.inconsistent_references() {
@@ -125,6 +175,8 @@ pub fn check_with_labels(
                 span: declaration.payload.span,
                 message: format!("{} declared here", declaration.class.name()),
             }],
+            severity: Severity::Error,
+            blame: Blame::XtexConstruct,
         });
     }
     for (key, reference) in missing_citations(table, bibliography) {
@@ -136,6 +188,8 @@ pub fn check_with_labels(
             span: reference.payload.span,
             message: format!("citation key `{key}` is not in the bibliography"),
             related: Vec::new(),
+            severity: Severity::Error,
+            blame: Blame::XtexConstruct,
         });
     }
     diagnostics
@@ -222,6 +276,8 @@ fn check_block(
                     span,
                     message: "percentage must be between 0 and 100".to_owned(),
                     related: Vec::new(),
+                    severity: Severity::Error,
+                    blame: Blame::XtexConstruct,
                 });
             }
         }
@@ -242,6 +298,8 @@ fn check_block(
                     span,
                     message: format!("image file `{path}` does not resolve"),
                     related: Vec::new(),
+                    severity: Severity::Error,
+                    blame: Blame::XtexConstruct,
                 });
             }
         }
@@ -299,6 +357,8 @@ fn block_error(source: SourceId, kind: BlockKind, error: BlockError, bytes: &[u8
         span,
         message,
         related: Vec::new(),
+        severity: Severity::Error,
+        blame: Blame::XtexConstruct,
     }
 }
 
@@ -509,8 +569,10 @@ pub fn to_json(sources: &Sources, diagnostics: &[Diagnostic], coverage: f64, out
         }
         let _ = write!(
             out,
-            "{{\"code\":\"{}\",\"severity\":\"error\",\"blame\":\"xtex-construct\",\"entity\":\"{}\",\"name\":",
+            "{{\"code\":\"{}\",\"severity\":\"{}\",\"blame\":\"{}\",\"entity\":\"{}\",\"name\":",
             diagnostic.code,
+            diagnostic.severity.as_str(),
+            diagnostic.blame.as_str(),
             diagnostic.entity.name()
         );
         match &diagnostic.name {

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -137,18 +137,27 @@ Exit `2` is never reachable from unknown LaTeX. Unknown LaTeX downgrades confide
 
 ## 4 · Advisory
 
-An advisory names something the compiler noticed but cannot substantiate. It is:
+An advisory names something the compiler noticed but cannot substantiate. It is **never** able to change the
+exit code, and it is marked `severity: advisory` in both output forms.
 
-- **off by default** — printed only behind `--strict-tex`;
-- **never** able to change the exit code;
-- marked `severity: advisory` in both output forms.
+Whether it is printed by default depends on who asked for the check.
+
+| | Printed | Because |
+|---|---|---|
+| An explicit construct asked for a check we could not perform | **by default** | staying quiet reports the document as checked when it was not |
+| We merely observed something in plain LaTeX | behind `--strict-tex` | nobody asked, and the observation may be about text TeX never reads |
 
 The class of things that are advisory and not errors:
 
-- an unresolved `\ref` or `\cite` written in plain LaTeX;
-- a `\label` in an opaque region that appears to collide with an `@id`;
-- a bibliography that could not be read (see §7) — the advisory is about the file, never about a key;
-- a region that entered quarantine early, which is a coverage signal rather than a defect.
+| Code | Condition | Printed |
+|---|---|---|
+| `XT2001` | The document contains `@cite`, and the bibliography is `Unavailable` (see §7) — the advisory is about the file, never about a key | by default |
+| — | An unresolved `\ref` or `\cite` written in plain LaTeX | `--strict-tex` |
+| — | A `\label` in an opaque region that appears to collide with an `@id` | `--strict-tex` |
+| — | A region that entered quarantine early, which is a coverage signal rather than a defect | `--strict-tex` |
+
+Codes are assigned in two ranges that do not overlap: `XT1nnn` is a hard error, `XT2nnn` an advisory. A row
+without a code is not implemented yet.
 
 **Never scan inside an opaque region and treat what you find as checkable.** Such a scan matches inside a
 `\newcommand` body, inside verbatim text, and inside an inactive `\if` branch. This was a design error caught
@@ -224,6 +233,13 @@ diagnostic that survives is about the file, not about the citation.
   be resolved without running TeX, which the compiler does not do.
 - **`Unreadable`** — a declared resource was not found.
 - **`UnparsableEntry`** — an entry in a resource that was read has no locatable boundary.
+
+When the document contains at least one `@cite`, an `Unavailable` bibliography is reported as advisory
+`XT2001` without being asked for. The construct requested a check; printing `coverage` and exiting `0`
+without saying the check never ran would answer a question the compiler did not look at. The advisory names
+the file and the reason, never a key, and the exit code stays `0` — `\bibliography{refs}` is plain LaTeX, and
+§3 admits no hard error from it. A document with no `@cite` stays silent whatever state its bibliography is
+in, which is the §11 invariant.
 
 ### Where bibliographies are declared
 


### PR DESCRIPTION
Closes #64.

## What changed

`xtex check p.xtex` on a document that cites, with a bibliography it cannot read:

```
advisory: citation checking unavailable: `refs.bib` could not be read
  --> p.xtex:3:20
  entity: citation
  blame: unresolved
coverage: 12.8%
exit=0
```

Before, that output was `coverage: 12.8%` and exit 0 — nothing else. The advisory existed, but only behind `--strict-tex`.

## The four cases, run end to end

| Document | Bibliography | Says |
|---|---|---|
| has `@cite` | absent, or unreadable, or a computed path, or no declaration | advisory `XT2001`, exit 0 |
| has `@cite` | read completely, key present | nothing |
| has `@cite` | read completely, key absent | `XT1005`, exit 1 — unchanged |
| no `@cite` | anything, including unreadable | nothing |

The last row is the invariant in `AGENTS.md` §4, and its test now carries `@id`, `@ref` and a plain LaTeX `\cite` — every kind of construct except the one that asks about a bibliography. Anchoring the advisory on any of them makes that test fail.

## Three things the advisory deliberately does not do

- **It never names a key.** `Unavailable` means no key may be called missing (`checking.md` §7). `name` is `null`.
- **It never changes the exit code.** `\bibliography{refs}` is plain LaTeX, and §3 admits no hard error from plain LaTeX.
- **It says nothing about a document with no `@cite`.** Nobody asked.

## Also in here

`severity` and `blame` move onto `Diagnostic`. They were literals inside the JSON renderer, so both output forms could only ever say `error` and `xtex-construct` — the advisory had nowhere to be represented.

The reason is written for the author rather than derived from `Debug`. The default output would otherwise have read:

```
advisory: citation checking unavailable (ComputedPath { span: Span { start: 56, end: 79 } })
```

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`: clean.
- Each new test fails when its defect is put back: the advisory removed, the `Debug` spelling restored, and the `@cite` guard loosened to any reference.
- 223 unmodified `.tex` files in the author's workspace exit 0 — the same result as before the change, from the same sweep.

## Known limit, unchanged and documented

A `.bib` with an unclosed field brace is still read as `Complete` and stays silent. The key reader locates entry boundaries and does not read fields, which `checking.md` §7 states and justifies. Detecting malformed fields is a different piece of work.