### PR TITLE
Notice a .bib file that BibTeX itself would reject

### DIFF
--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -1413,6 +1413,7 @@ mod bibliography_advisory_tests {
             },
             Unavailable::UnparsableEntry {
                 name: "refs.bib".to_owned(),
+                detail: "a value opened at line 3 is never closed".to_owned(),
             },
         ] {
             let message = bibliography_advisory(&table, &Bibliography::Unavailable(reason.clone()))

--- a/crates/xtex-core/src/bibliography.rs
+++ b/crates/xtex-core/src/bibliography.rs
@@ -48,6 +48,8 @@ pub enum Unavailable {
     UnparsableEntry {
         /// The resource the entry is in.
         name: String,
+        /// A location and description that can be printed without a source map.
+        detail: String,
     },
 }
 
@@ -64,8 +66,8 @@ impl Unavailable {
                 "the declared bibliography path is computed rather than literal".to_owned()
             }
             Self::Unreadable { name } => format!("`{name}` could not be read"),
-            Self::UnparsableEntry { name } => {
-                format!("an entry boundary in `{name}` could not be located")
+            Self::UnparsableEntry { name, detail } => {
+                format!("`{name}` did not parse — {detail}")
             }
         }
     }
@@ -287,11 +289,12 @@ pub fn assemble(
                 name: resource.name.clone(),
             });
         };
-        match keys_in_bib(&bytes) {
-            Some(found) => keys.extend(found),
-            None => {
+        match scan_bib(&bytes) {
+            Ok(found) => keys.extend(found),
+            Err(detail) => {
                 return Bibliography::Unavailable(Unavailable::UnparsableEntry {
                     name: resource.name.clone(),
+                    detail,
                 });
             }
         }
@@ -305,6 +308,10 @@ pub fn assemble(
 /// `@string` declare no citation key and are skipped.
 #[must_use]
 pub fn keys_in_bib(bytes: &[u8]) -> Option<BTreeSet<String>> {
+    scan_bib(bytes).ok()
+}
+
+fn scan_bib(bytes: &[u8]) -> Result<BTreeSet<String>, String> {
     let mut keys = BTreeSet::new();
     let mut at = 0usize;
     while at < bytes.len() {
@@ -320,32 +327,149 @@ pub fn keys_in_bib(bytes: &[u8]) -> Option<BTreeSet<String>> {
         let entry_type = bytes[type_start..cursor].to_ascii_lowercase();
         cursor = skip_space(bytes, cursor);
         let opener = match bytes.get(cursor) {
-            Some(b'{') => b'}',
-            Some(b'(') => b')',
+            Some(b'{') => (b'{', b'}'),
+            Some(b'(') => (b'(', b')'),
             _ => {
                 at = type_start;
                 continue;
             }
         };
+        let entry_line = line_at(bytes, cursor);
         cursor += 1;
-        if matches!(entry_type.as_slice(), b"comment" | b"preamble" | b"string") {
+        // `@comment` is the one entry type BibTeX does not read. It skips to the
+        // next `@` and resumes there, so an unbalanced brace inside a comment is
+        // not an error, and an entry a writer commented out by wrapping it is
+        // still a database entry. Measured against BibTeX 0.99e, both ways:
+        // `@comment{a stray { brace}` is accepted, and a `@book` inside a
+        // `@comment` still resolves when cited.
+        if entry_type == b"comment" {
             at = cursor;
             continue;
         }
+        let body_start = cursor;
+        let close = entry_end(
+            bytes,
+            cursor,
+            opener.0,
+            opener.1,
+            entry_line,
+            entry_type == b"preamble",
+        )?;
         let key_start = skip_space(bytes, cursor);
         let mut key_end = key_start;
-        while matches!(bytes.get(key_end), Some(b) if !b.is_ascii_whitespace() && *b != b',' && *b != opener)
+        while matches!(bytes.get(key_end), Some(b) if !b.is_ascii_whitespace() && *b != b',' && *b != opener.1)
         {
             key_end += 1;
         }
-        if key_end > key_start {
+        if !matches!(entry_type.as_slice(), b"preamble" | b"string") {
+            validate_field_separators(bytes, body_start, close)?;
+        }
+        if !matches!(entry_type.as_slice(), b"preamble" | b"string") && key_end > key_start {
             if let Ok(key) = std::str::from_utf8(&bytes[key_start..key_end]) {
                 keys.insert(key.to_owned());
             }
         }
-        at = key_end.max(cursor);
+        at = close + 1;
     }
-    Some(keys)
+    Ok(keys)
+}
+
+fn entry_end(
+    bytes: &[u8],
+    mut at: usize,
+    open: u8,
+    close: u8,
+    entry_line: usize,
+    mut value_position: bool,
+) -> Result<usize, String> {
+    let mut braces = Vec::new();
+    let mut quote = None;
+    while let Some(&byte) = bytes.get(at) {
+        if quote.is_some() && byte == b'"' && braces.is_empty() {
+            quote = None;
+        } else if quote.is_none() && value_position && byte == b'"' && braces.is_empty() {
+            quote = Some(line_at(bytes, at));
+            value_position = false;
+        } else if byte == b'{' {
+            braces.push(line_at(bytes, at));
+        } else if byte == b'}' && !braces.is_empty() {
+            braces.pop();
+        } else if byte == close && braces.is_empty() && quote.is_none() {
+            return Ok(at);
+        } else if braces.is_empty() && quote.is_none() {
+            if matches!(byte, b'=' | b'#') {
+                value_position = true;
+            } else if !byte.is_ascii_whitespace() {
+                value_position = false;
+            }
+        }
+        at += 1;
+    }
+    if let Some(line) = quote {
+        Err(format!(
+            "a quoted value opened at line {line} is never closed"
+        ))
+    } else if let Some(line) = braces.first() {
+        Err(format!("a value opened at line {line} is never closed"))
+    } else {
+        let delimiter = char::from(open);
+        Err(format!(
+            "an entry delimiter `{delimiter}` opened at line {entry_line} is never closed"
+        ))
+    }
+}
+
+fn validate_field_separators(bytes: &[u8], start: usize, end: usize) -> Result<(), String> {
+    let mut at = start;
+    let mut braces = 0usize;
+    let mut quoted = false;
+    while at < end {
+        match bytes[at] {
+            b'"' if braces == 0 => quoted = !quoted,
+            b'{' if !quoted => braces += 1,
+            b'}' if !quoted => braces = braces.saturating_sub(1),
+            _ => {}
+        }
+        if braces == 0
+            && !quoted
+            && matches!(bytes[at], b'}' | b'"' | b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z')
+        {
+            let mut next = at + 1;
+            while next < end && bytes[next].is_ascii_whitespace() {
+                next += 1;
+            }
+            let value_just_closed = matches!(bytes[at], b'}' | b'"');
+            if (value_just_closed || next > at + 1)
+                && bytes.get(next).is_some_and(u8::is_ascii_alphabetic)
+            {
+                let mut equals = next + 1;
+                while equals < end
+                    && (bytes[equals].is_ascii_alphanumeric() || bytes[equals] == b'_')
+                {
+                    equals += 1;
+                }
+                equals = skip_space(bytes, equals);
+                if bytes.get(equals) == Some(&b'=') {
+                    return Err(format!(
+                        "two fields at line {} have no comma between them",
+                        line_at(bytes, next)
+                    ));
+                }
+            }
+        }
+        at += 1;
+    }
+    Ok(())
+}
+
+fn line_at(bytes: &[u8], at: usize) -> usize {
+    let mut line = 1;
+    for &byte in &bytes[..at.min(bytes.len())] {
+        if byte == b'\n' {
+            line += 1;
+        }
+    }
+    line
 }
 
 fn find(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
@@ -546,6 +670,139 @@ mod tests {
     fn a_bib_entry_may_use_parentheses() {
         let keys = keys_in_bib(b"@article(paren_style, title = {T})").unwrap();
         assert!(keys.contains("paren_style"));
+    }
+
+    #[test]
+    fn validation_matches_bibtex_on_the_experiment_corpus() {
+        let rejected = [
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-01-unclosed-field.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-02-unclosed-entry.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-03-missing-comma.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-04-unclosed-quote.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-08-preamble-unbalanced.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-09-string-unbalanced.bib"
+            )
+            .as_slice(),
+            b"@article{k, title={A}year={2020}}",
+        ];
+        for bytes in rejected {
+            assert!(keys_in_bib(bytes).is_none());
+        }
+
+        let accepted = [
+            include_bytes!("../../../tests/experiments/bib-validator/corpus/bad-05-no-key.bib")
+                .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-06-stray-brace.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-07-undefined-string.bib"
+            )
+            .as_slice(),
+            include_bytes!("../../../tests/experiments/bib-validator/corpus/ok-01-plain.bib")
+                .as_slice(),
+            include_bytes!("../../../tests/experiments/bib-validator/corpus/ok-02-quotes.bib")
+                .as_slice(),
+            include_bytes!("../../../tests/experiments/bib-validator/corpus/ok-03-strings.bib")
+                .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/ok-04-preamble-hash.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/ok-05-comment-and-junk.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/ok-06-nested-braces.bib"
+            )
+            .as_slice(),
+            include_bytes!("../../../tests/experiments/bib-validator/corpus/ok-07-concat.bib")
+                .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/ok-08-comment-unbalanced.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/ok-09-comment-wraps-an-entry.bib"
+            )
+            .as_slice(),
+            b"@comment{\" is ordinary comment text}\n@book{k, title={T}}",
+            b"@article{k\"x, title={T}, year=2020}",
+        ];
+        for bytes in accepted {
+            assert!(keys_in_bib(bytes).is_some());
+        }
+    }
+
+    #[test]
+    fn a_comment_is_skipped_to_the_next_at_sign_the_way_bibtex_skips_it() {
+        // Both halves were settled by running the files through BibTeX 0.99e.
+        // It accepts an unbalanced brace inside `@comment`, because it never
+        // reads the body; and an entry a writer commented out by wrapping it
+        // still resolves when cited, because the skip stops at the next `@`.
+        // Validating the body would reject the first and lose the key in the
+        // second, and losing a key turns a correct `@cite` into `XT1005`.
+        let unbalanced = include_bytes!(
+            "../../../tests/experiments/bib-validator/corpus/ok-08-comment-unbalanced.bib"
+        );
+        assert_eq!(
+            keys_in_bib(unbalanced),
+            Some(BTreeSet::from(["k1".to_owned()]))
+        );
+
+        let wrapped = include_bytes!(
+            "../../../tests/experiments/bib-validator/corpus/ok-09-comment-wraps-an-entry.bib"
+        );
+        assert_eq!(
+            keys_in_bib(wrapped),
+            Some(BTreeSet::from([
+                "commented_out".to_owned(),
+                "k1".to_owned()
+            ]))
+        );
+    }
+
+    #[test]
+    fn an_invalid_file_makes_the_whole_bibliography_unavailable() {
+        let d = declared("\\bibliography{refs}");
+        let bibliography = assemble(&d, |_| Some(b"@book{k,\n title = {never closed\n".to_vec()));
+        assert_eq!(
+            bibliography,
+            Bibliography::Unavailable(Unavailable::UnparsableEntry {
+                name: "refs.bib".to_owned(),
+                detail: "a value opened at line 2 is never closed".to_owned(),
+            })
+        );
+        assert!(!bibliography.is_missing("anything"));
+
+        let mut sources = Sources::new();
+        let id = sources.add("main.xtex", b"@cite(anything)".to_vec());
+        let document = crate::parse(&sources, id);
+        let mut table = SymbolTable::new();
+        table.merge(&sources, &document);
+        assert!(
+            crate::check::check(&table, &bibliography)
+                .iter()
+                .all(|diagnostic| diagnostic.code != "XT1005")
+        );
     }
     /// The three outcomes issue #12 requires, driven through the real pipeline:
     /// parse, build the symbol table, assemble the bibliography, compare.

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -232,7 +232,9 @@ diagnostic that survives is about the file, not about the citation.
 - **`ComputedPath`** — a declaration whose path is built by a macro rather than written literally. It cannot
   be resolved without running TeX, which the compiler does not do.
 - **`Unreadable`** — a declared resource was not found.
-- **`UnparsableEntry`** — an entry in a resource that was read has no locatable boundary.
+- **`UnparsableEntry`** — a resource was read and does not parse. Four shapes are detected, and they are the
+  four that BibTeX itself rejects: a field value whose `{` never closes, an entry whose delimiter never
+  closes, two fields with no comma between them, and a quoted value whose `"` never closes.
 
 When the document contains at least one `@cite`, an `Unavailable` bibliography is reported as advisory
 `XT2001` without being asked for. The construct requested a check; printing `coverage` and exiting `0`
@@ -288,8 +290,21 @@ crate would silence citation checking for that document entirely — trading a d
 a file that works.
 
 The key reader locates entry keys and nothing else. It does not read fields, resolve `@string` macros, or
-validate an entry, because none of that is needed to answer the only question asked: does this key exist.
+interpret a value, because none of that is needed to answer the only question asked: does this key exist.
 `@string`, `@comment` and `@preamble` declare no citation key and are skipped.
+
+Validating the file is a separate job from reading its keys, and separating them is what makes it cheap. The
+reader must be lenient and must never fail, because a failure silences citation checking for the whole
+document. The validator is strict, and because a failure only reaches the author as an advisory it can
+afford to be. Detecting a broken file does not require understanding a correct one, so no BibTeX parser is
+involved and no dependency was added.
+
+`@comment` is the one entry type BibTeX does not read: it skips to the next `@` and resumes there. So an
+unbalanced brace inside a comment is not an error, and an entry a writer commented out by wrapping it is
+still a database entry that resolves when cited. `@preamble` and `@string` are read, and BibTeX does reject
+an unbalanced brace in either. Reproduce all of it with
+[`tests/experiments/bib-validator`](../tests/experiments/bib-validator/), whose ground truth is BibTeX 0.99e
+rather than a reading of the grammar.
 
 Reproduce it with [`tests/experiments/bib-parser`](../tests/experiments/bib-parser/). The evidence above is
 a single run over one author's corpus, and it is what the decision rests on. A corpus where the crate parses

--- a/tests/experiments/bib-validator/README.md
+++ b/tests/experiments/bib-validator/README.md
@@ -53,8 +53,33 @@ crates.io is MIT or MIT/Apache-2.0. Three other things are.
 all. It is not a candidate: it needs an `.aux` and a `.bst`, and using it would mean running the program,
 which the compiler does not do.
 
+## What the corpus decided
+
+The validator that came out of this is a detector, not a parser: it locates the four shapes BibTeX rejects
+and nothing else. Finding keys and validating syntax stay separate jobs, because the key reader must never
+fail — a failure silences citation checking for a whole document — while a validator only produces an
+advisory and so can afford to be strict.
+
+Two files in the corpus were added after the first attempt, because they refuted it.
+
+**`@comment` is the one entry type BibTeX does not read.** It skips to the next `@` and resumes there. A
+validator that checks the body instead rejects `ok-08`, which BibTeX accepts, and that is the expensive
+direction of error: a false rejection costs a document its citation checking.
+
+**A commented-out entry is still a database entry.** In `ok-09` a `@book` sits inside a `@comment{...}`
+wrapper. Because BibTeX's skip stops at the next `@`, it reads that entry and resolves it when cited —
+verified by citing `commented_out` and watching BibTeX not complain. A validator that skipped to the
+comment's closing brace would lose the key, and a lost key turns a correct `@cite` into `XT1005` against an
+author who did nothing wrong.
+
+`bad-08` and `bad-09` are the other side of the same question: BibTeX *does* check brace balance inside
+`@preamble` and `@string`, and rejects both. The three types are not interchangeable.
+
 ## Boundary
 
-One run. The seven malformed shapes were chosen by hand, and a different set could reorder the table. The 37
-real files are one author's corpus. What the numbers support is a decision about this codebase, not a claim
+One run. The malformed shapes were chosen by hand, and a different set could reorder the table. The 37 real
+files are one author's corpus. Eighteen further probes — CRLF endings, parenthesis-delimited entries, an `@`
+inside a value, a URL with `%` and `=`, non-ASCII names, `#` concatenation — agree with BibTeX, and one of
+them does not: BibTeX counts a backslash-escaped `\{` as an opening brace and rejects the file, where the
+validator accepts it. That is a shape it does not detect, not a file it wrongly rejects. What the numbers support is a decision about this codebase, not a claim
 about BibTeX parsers in general.

--- a/tests/experiments/bib-validator/README.md
+++ b/tests/experiments/bib-validator/README.md
@@ -1,0 +1,60 @@
+# What a broken `.bib` looks like, and who notices
+
+`#64` made the compiler say when it could not *read* a bibliography. It still says nothing when it reads one
+that is *broken*. This measures what it would take to notice, and what it would cost.
+
+## Ground truth is BibTeX, not judgement
+
+Whether a `.bib` file is "valid" is not a question about the BibTeX grammar in the abstract. It is a question
+about the program that consumes it. `groundtruth.py` runs each file through **BibTeX 0.99e** over a minimal
+`.aux` that cites everything, and records whether it reported an error.
+
+```sh
+python3 groundtruth.py corpus/*.bib
+```
+
+Result, BibTeX 0.99e (TeX Live 2026):
+
+| Files | Verdict |
+|---|---|
+| `bad-01` … `bad-04` | rejected — `Illegal end of database file`, `I was expecting a ',' or a '}'`, `Unbalanced braces` |
+| `bad-05` … `bad-07` | **accepted**, with warnings — an empty key, a stray brace, an undefined `@string` |
+| `ok-01` … `ok-07` | accepted |
+
+The three `bad-` files BibTeX accepts are in the corpus deliberately. A validator that rejects them is wrong,
+however reasonable the rejection looks.
+
+## What the candidates do
+
+The same 14 files, plus 37 real `.bib` files from the author's projects, through both crates and our own key
+reader. Measured 2026-08-29.
+
+| | Detects the 4 real errors | Falsely rejects a valid file | Message | New dependencies |
+|---|---|---|---|---|
+| our key reader | **0 of 4** | 0 | — | 0 |
+| `nom-bibtex` 0.6, MIT | 4 of 4 | 0 of 44 | unusable | +12 crates, two versions of `nom` |
+| `biblatex` 0.12, MIT OR Apache-2.0 | 4 of 4 | **3 of 44** | clear | +8 crates |
+
+Licence was the first thing checked and it turned out not to be the constraint: every serious candidate on
+crates.io is MIT or MIT/Apache-2.0. Three other things are.
+
+1. **`nom-bibtex`'s message names its own combinators.** For an unclosed brace on line 3 of a 5-line file:
+   `Parsing error. Reason: 0: at line 1, in IsNot: @book{knuth1984, ^`.
+2. **No parser locates the author's mistake for an unclosed delimiter.** `biblatex` reports byte 96 of a
+   96-byte file; BibTeX itself says `Illegal end of database file---line 5`. A delimiter that never closes is
+   only detectable at end of input, so "parsing stopped here" is the strongest honest claim available.
+3. **`biblatex`'s three false rejections include a real file.** `irace-package.bib`, shipped in the `irace` R
+   package, opens with an `@preamble` concatenating brace groups with `#`; the crate expects a quotation mark
+   and stops at byte 12. It also rejects an undefined `@string`, which BibTeX only warns about. Under
+   [`checking.md`](../../../docs/checking.md) §7 each of those silences citation checking for a whole
+   document.
+
+`tectonic_engine_bibtex` (MIT) is BibTeX itself as a crate, and is the reason ground truth was available at
+all. It is not a candidate: it needs an `.aux` and a `.bst`, and using it would mean running the program,
+which the compiler does not do.
+
+## Boundary
+
+One run. The seven malformed shapes were chosen by hand, and a different set could reorder the table. The 37
+real files are one author's corpus. What the numbers support is a decision about this codebase, not a claim
+about BibTeX parsers in general.

--- a/tests/experiments/bib-validator/corpus/bad-01-unclosed-field.bib
+++ b/tests/experiments/bib-validator/corpus/bad-01-unclosed-field.bib
@@ -1,0 +1,5 @@
+@book{knuth1984,
+  author = {Knuth, Donald E.},
+  title  = {The {\TeX}book,
+  year   = {1984}
+}

--- a/tests/experiments/bib-validator/corpus/bad-02-unclosed-entry.bib
+++ b/tests/experiments/bib-validator/corpus/bad-02-unclosed-entry.bib
@@ -1,0 +1,1 @@
+@book{k1, author = {A}, year = {1984}

--- a/tests/experiments/bib-validator/corpus/bad-03-missing-comma.bib
+++ b/tests/experiments/bib-validator/corpus/bad-03-missing-comma.bib
@@ -1,0 +1,1 @@
+@book{k1, author = {A} year = {1984}}

--- a/tests/experiments/bib-validator/corpus/bad-04-unclosed-quote.bib
+++ b/tests/experiments/bib-validator/corpus/bad-04-unclosed-quote.bib
@@ -1,0 +1,1 @@
+@article{k1, author = "Lamport, title = {T}, year = 1994}

--- a/tests/experiments/bib-validator/corpus/bad-05-no-key.bib
+++ b/tests/experiments/bib-validator/corpus/bad-05-no-key.bib
@@ -1,0 +1,1 @@
+@book{, author = {A}, year = {1984}}

--- a/tests/experiments/bib-validator/corpus/bad-06-stray-brace.bib
+++ b/tests/experiments/bib-validator/corpus/bad-06-stray-brace.bib
@@ -1,0 +1,1 @@
+@book{k1, author = {A}}, year = {1984}}

--- a/tests/experiments/bib-validator/corpus/bad-07-undefined-string.bib
+++ b/tests/experiments/bib-validator/corpus/bad-07-undefined-string.bib
@@ -1,0 +1,1 @@
+@article{k1, publisher = nosuchstring, title = {T}, year = 2000}

--- a/tests/experiments/bib-validator/corpus/bad-08-preamble-unbalanced.bib
+++ b/tests/experiments/bib-validator/corpus/bad-08-preamble-unbalanced.bib
@@ -1,0 +1,2 @@
+@preamble{ {\noop} { unbalanced }
+@book{k1, title = {T}}

--- a/tests/experiments/bib-validator/corpus/bad-09-string-unbalanced.bib
+++ b/tests/experiments/bib-validator/corpus/bad-09-string-unbalanced.bib
@@ -1,0 +1,2 @@
+@string{jj = {unbalanced { here}}
+@article{k1, journal = jj}

--- a/tests/experiments/bib-validator/corpus/ok-01-plain.bib
+++ b/tests/experiments/bib-validator/corpus/ok-01-plain.bib
@@ -1,0 +1,5 @@
+@book{knuth1984,
+  author = {Knuth, Donald E.},
+  title  = {The {\TeX}book},
+  year   = {1984}
+}

--- a/tests/experiments/bib-validator/corpus/ok-02-quotes.bib
+++ b/tests/experiments/bib-validator/corpus/ok-02-quotes.bib
@@ -1,0 +1,1 @@
+@article{lamport1994, author = "Lamport, Leslie", title = "LaTeX", year = "1994"}

--- a/tests/experiments/bib-validator/corpus/ok-03-strings.bib
+++ b/tests/experiments/bib-validator/corpus/ok-03-strings.bib
@@ -1,0 +1,2 @@
+@string{acm = {Association for Computing Machinery}}
+@inproceedings{a1, author = {A}, publisher = acm, year = 2020}

--- a/tests/experiments/bib-validator/corpus/ok-04-preamble-hash.bib
+++ b/tests/experiments/bib-validator/corpus/ok-04-preamble-hash.bib
@@ -1,0 +1,2 @@
+@preamble{ {\newcommand{\noopsort}[1]{}} # {\newcommand{\singleletter}[1]{#1}} }
+@book{irace1, author = {L{\'o}pez-Ib{\'a}{\~n}ez, Manuel}, title = {irace}, year = {2016}}

--- a/tests/experiments/bib-validator/corpus/ok-05-comment-and-junk.bib
+++ b/tests/experiments/bib-validator/corpus/ok-05-comment-and-junk.bib
@@ -1,0 +1,3 @@
+This text outside an entry is ignored by BibTeX.
+@comment{anything at all here}
+@misc{m1, title = {M}, year = {2021}}

--- a/tests/experiments/bib-validator/corpus/ok-06-nested-braces.bib
+++ b/tests/experiments/bib-validator/corpus/ok-06-nested-braces.bib
@@ -1,0 +1,1 @@
+@book{b1, title = {A {Nested {Deeply} Braced} Title}, year = {1999}}

--- a/tests/experiments/bib-validator/corpus/ok-07-concat.bib
+++ b/tests/experiments/bib-validator/corpus/ok-07-concat.bib
@@ -1,0 +1,2 @@
+@string{jan = "January"}
+@article{c1, month = jan # " 15", title = {T}, year = 2000}

--- a/tests/experiments/bib-validator/corpus/ok-08-comment-unbalanced.bib
+++ b/tests/experiments/bib-validator/corpus/ok-08-comment-unbalanced.bib
@@ -1,0 +1,2 @@
+@comment{a stray { brace}
+@book{k1, title = {T}}

--- a/tests/experiments/bib-validator/corpus/ok-09-comment-wraps-an-entry.bib
+++ b/tests/experiments/bib-validator/corpus/ok-09-comment-wraps-an-entry.bib
@@ -1,0 +1,4 @@
+@comment{
+@book{commented_out, title = {T}}
+}
+@book{k1, title = {T}}

--- a/tests/experiments/bib-validator/groundtruth.py
+++ b/tests/experiments/bib-validator/groundtruth.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Ground truth: what real BibTeX 0.99e does with a .bib file.
+
+Runs bibtex over a minimal .aux that cites everything, and records whether it
+reported an error. This is the reference the survey is measured against: the
+question is never "is this file good BibTeX" in the abstract, it is "does the
+program that consumes it accept it".
+"""
+import os, re, shutil, subprocess, sys, tempfile
+
+def run(bib):
+    d = tempfile.mkdtemp()
+    try:
+        shutil.copy(bib, os.path.join(d, "refs.bib"))
+        with open(os.path.join(d, "x.aux"), "w") as f:
+            f.write("\\relax\n\\citation{*}\n\\bibstyle{plain}\n\\bibdata{refs}\n")
+        r = subprocess.run(["bibtex", "x"], cwd=d, capture_output=True, text=True)
+        out = r.stdout + r.stderr
+        errors = [l for l in out.splitlines()
+                  if re.search(r"^(I was expecting|Sorry|Illegal|You're missing|Repeated entry"
+                               r"|A bad cross reference|I found no|Warning--|.*---line \d+)", l)
+                  or "error message" in l]
+        hard = [l for l in errors if not l.startswith("Warning--")]
+        return r.returncode, hard, out
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+for bib in sys.argv[1:]:
+    code, hard, out = run(bib)
+    verdict = "REJECT" if hard else "accept"
+    print(f"{verdict:7} exit={code}  {os.path.basename(bib)}")
+    for l in hard[:2]:
+        print(f"         {l.strip()[:100]}")


### PR DESCRIPTION
Closes #66. Based on `#65`, whose advisory carries this one's message — review that first.

## What changed

```
$ xtex check p.xtex          # refs.bib has an unclosed brace in a field
advisory: citation checking unavailable: `refs.bib` did not parse — an entry delimiter `{` opened at line 1 is never closed
coverage: 12.8%
exit=0
```

Before, the same file was read as complete and produced no advisory at all.

## The four shapes, end to end

| `.bib` | Message |
|---|---|
| a field's `{` never closes | `an entry delimiter '{' opened at line 1 is never closed` |
| an entry's delimiter never closes | same |
| two fields with no comma | `two fields at line 1 have no comma between them` |
| a quoted value's `"` never closes | `a quoted value opened at line 2 is never closed` |

A broken file is `Unavailable`, so `XT1005` cannot fire on it. Verified directly: a document citing a key that is genuinely absent from a *broken* bibliography gets the advisory and exit 0, not the hard error.

It is a detector, not a parser. **`Cargo.lock` still holds four packages.**

## `@comment` — the corpus refuted the first attempt

Two files were added to the corpus because they broke it, and both were adjudicated by running them through BibTeX 0.99e rather than by reading the grammar.

**BibTeX does not read a comment.** It skips to the next `@` and resumes there. Validating the body rejected `ok-08`, which BibTeX accepts — a false rejection, and that is the expensive direction: it costs a whole document its citation checking.

**A commented-out entry is still a database entry.** In `ok-09` a `@book` sits inside a `@comment{...}` wrapper. BibTeX reads it and resolves it when cited — confirmed by citing `commented_out` and watching BibTeX not complain. Skipping to the comment's closing brace loses that key, and a lost key turns a correct `@cite` into `XT1005` against an author who did nothing wrong. Only the second test catches this; the corpus test still passes.

`bad-08` and `bad-09` are the other side: BibTeX *does* check brace balance inside `@preamble` and `@string` and rejects both. The three types are not interchangeable.

## Verification

| Check | Result |
|---|---|
| 18-file corpus vs BibTeX 0.99e | 18 of 18 agree |
| 18 further probes (CRLF, `(`-delimited entries, `@` in a value, URLs with `%` and `=`, non-ASCII, `#` concatenation) | 17 agree; 1 shape not detected, none wrongly rejected |
| Key sets of 37 real `.bib` files, before vs after | byte-for-byte identical |
| Unmodified `.tex` files in the author's workspace | exit 0, same as before |
| `fmt`, `clippy -D warnings`, `test --workspace` | clean |

Each test was checked by removing the behaviour it covers and confirming it fails.

## Known limit

BibTeX counts a backslash-escaped `\{` as an opening brace and rejects `@book{k, title = {A \{ literal brace}, year = {2020}}`. The validator accepts it. That is a shape it does not detect, not a file it wrongly rejects — the safe direction, and it leaves that case exactly where it was before this PR.