### PR TITLE
Read the assembly the author already wrote

### DIFF
--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -282,7 +282,7 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
     // `\label` in an imported file declares its name for the root, exactly as
     // an `@id` there does.
     let mut labels: BTreeMap<String, xtex_core::source::Span> = BTreeMap::new();
-    let mut labels_available = true;
+    let mut labels_unavailable = None;
 
     while let Some(id) = pending.pop() {
         let name = sources
@@ -300,9 +300,16 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
             // One file that went dark makes the root's inventory a subset, and
             // a subset that looks complete turns every name it missed into a
             // false "not declared".
-            xtex_core::labels::Inventory::Unavailable(_) => labels_available = false,
+            xtex_core::labels::Inventory::Unavailable(reason) => labels_unavailable = Some(reason),
         }
         merge_declared(&mut declared, declared_in(&sources, id));
+        follow_latex_edges(
+            &loader,
+            id,
+            &mut sources,
+            &mut pending,
+            &mut labels_unavailable,
+        )?;
         let mut imports = Vec::new();
         document.walk(|node| {
             if let Node::Construct {
@@ -319,6 +326,7 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
             match loader.load(&path, Some(id), &mut sources) {
                 Ok(imported) => pending.push(imported),
                 Err(IoError::NotFound { .. } | IoError::Unresolvable { .. }) => {
+                    labels_unavailable = Some(xtex_core::labels::Unavailable::UnreadableEdge);
                     import_diagnostics.push(Diagnostic {
                         code: "XT1009",
                         entity: EntityClass::UnknownOpen,
@@ -342,7 +350,7 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
     // The author's own `\label` commands resolve `@ref` too, so annotating a
     // document one figure at a time does not report the unannotated ones as
     // missing. Merged across the root, like every other declaration.
-    let inventory = root_inventory(labels, labels_available);
+    let inventory = root_inventory(labels, labels_unavailable);
     let mut diagnostics = check_with_labels(&table, &bibliography, &inventory);
     diagnostics.extend(bibliography_advisory(&table, &bibliography));
     diagnostics.extend(check_documents(&sources, &documents, |source, name| {
@@ -353,30 +361,129 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
         base.join(name).is_file()
     }));
     diagnostics.extend(import_diagnostics);
-    let total_bytes: f64 = documents
-        .iter()
-        .filter_map(|document| sources.get(document.source()))
-        .map(|source| {
-            f64::from(u32::try_from(source.bytes().len()).expect("source exceeds u32 addressing"))
-        })
-        .sum();
-    let checked_bytes: f64 = documents
-        .iter()
-        .filter_map(|document| {
-            sources.get(document.source()).map(|source| {
-                document.coverage()
-                    * f64::from(
-                        u32::try_from(source.bytes().len()).expect("source exceeds u32 addressing"),
-                    )
-            })
-        })
-        .sum();
-    let coverage = if total_bytes == 0.0 {
-        1.0
-    } else {
-        checked_bytes / total_bytes
-    };
+    let coverage = root_coverage(&sources, &documents);
     Ok((sources, diagnostics, coverage, bibliography))
+}
+
+fn root_coverage(sources: &Sources, documents: &[xtex_core::document::Document]) -> f64 {
+    let mut total = 0.0;
+    let mut checked = 0.0;
+    for document in documents {
+        let Some(source) = sources.get(document.source()) else {
+            continue;
+        };
+        let bytes =
+            f64::from(u32::try_from(source.bytes().len()).expect("source exceeds u32 addressing"));
+        total += bytes;
+        checked += document.coverage() * bytes;
+    }
+    if total == 0.0 { 1.0 } else { checked / total }
+}
+
+fn follow_latex_edges(
+    loader: &impl SourceLoader,
+    id: SourceId,
+    sources: &mut Sources,
+    pending: &mut Vec<SourceId>,
+    unavailable: &mut Option<xtex_core::labels::Unavailable>,
+) -> Result<(), IoError> {
+    let (edges, computed) = sources
+        .get(id)
+        .map(|source| latex_inventory_edges(source.bytes()))
+        .unwrap_or_default();
+    if computed {
+        *unavailable = Some(xtex_core::labels::Unavailable::UnreadableEdge);
+    }
+    for path in edges {
+        match load_latex_edge(loader, &path, id, sources) {
+            Ok(included) => pending.push(included),
+            Err(error @ IoError::TooLarge { .. }) => return Err(error),
+            Err(_) => *unavailable = Some(xtex_core::labels::Unavailable::UnreadableEdge),
+        }
+    }
+    Ok(())
+}
+
+fn load_latex_edge(
+    loader: &impl SourceLoader,
+    path: &str,
+    relative_to: SourceId,
+    sources: &mut Sources,
+) -> Result<SourceId, IoError> {
+    if Path::new(path).extension().is_some() {
+        return loader.load(path, Some(relative_to), sources);
+    }
+    match loader.load(&format!("{path}.tex"), Some(relative_to), sources) {
+        Ok(id) => Ok(id),
+        Err(IoError::NotFound { .. }) => {
+            loader.load(&format!("{path}.xtex"), Some(relative_to), sources)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn latex_inventory_edges(bytes: &[u8]) -> (Vec<String>, bool) {
+    let mut edges = Vec::new();
+    let mut computed = false;
+    for span in xtex_core::scanner::readable_for(bytes, &["include", "input"]) {
+        let region = &bytes[span.start()..span.end()];
+        computed |= collect_latex_edges(region, &mut edges);
+    }
+    (edges, computed)
+}
+
+fn collect_latex_edges(mut region: &[u8], edges: &mut Vec<String>) -> bool {
+    let mut computed = false;
+    while let Some(at) = region.windows(2).position(|window| window == b"\\i") {
+        region = &region[at..];
+        let command_len = if region.starts_with(b"\\include") {
+            b"\\include".len()
+        } else if region.starts_with(b"\\input") {
+            b"\\input".len()
+        } else {
+            region = &region[2..];
+            continue;
+        };
+        if region
+            .get(command_len)
+            .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'@')
+        {
+            region = &region[command_len..];
+            continue;
+        }
+        let rest = &region[command_len..];
+        let whitespace = rest
+            .iter()
+            .position(|byte| !byte.is_ascii_whitespace())
+            .unwrap_or(rest.len());
+        let rest = &rest[whitespace..];
+        let Some(body) = rest.strip_prefix(b"{") else {
+            computed = true;
+            region = rest;
+            continue;
+        };
+        let Some(close) = body.iter().position(|byte| *byte == b'}') else {
+            return true;
+        };
+        let path = &body[..close];
+        if path
+            .iter()
+            .any(|byte| matches!(byte, b'\\' | b'{' | b'}' | b'#'))
+        {
+            computed = true;
+        } else if let Ok(path) = std::str::from_utf8(path) {
+            let path = path.trim();
+            if path.is_empty() {
+                computed = true;
+            } else {
+                edges.push(path.to_owned());
+            }
+        } else {
+            computed = true;
+        }
+        region = &body[close + 1..];
+    }
+    computed
 }
 
 fn literal_import(
@@ -1354,12 +1461,11 @@ fn report_record(
 /// whole inventory exists to prevent.
 fn root_inventory(
     labels: BTreeMap<String, xtex_core::source::Span>,
-    available: bool,
+    unavailable: Option<xtex_core::labels::Unavailable>,
 ) -> xtex_core::labels::Inventory {
-    if available {
-        xtex_core::labels::Inventory::Complete(labels)
-    } else {
-        xtex_core::labels::Inventory::Unavailable(xtex_core::labels::Unavailable::Quarantined)
+    match unavailable {
+        Some(reason) => xtex_core::labels::Inventory::Unavailable(reason),
+        None => xtex_core::labels::Inventory::Complete(labels),
     }
 }
 

--- a/crates/xtex-cli/tests/include_inventory.rs
+++ b/crates/xtex-cli/tests/include_inventory.rs
@@ -1,0 +1,175 @@
+//! Filesystem-level checks for LaTeX inventory edges.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT: AtomicU64 = AtomicU64::new(0);
+
+struct Case(PathBuf);
+
+impl Case {
+    fn new() -> Self {
+        let id = NEXT.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!("xtex-include-{}-{id}", std::process::id()));
+        fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+
+    fn write(&self, name: &str, text: &str) {
+        let path = self.0.join(name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, text).unwrap();
+    }
+
+    fn check(&self) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_xtex"))
+            .args(["check", "book.xtex"])
+            .current_dir(&self.0)
+            .output()
+            .unwrap()
+    }
+}
+
+impl Drop for Case {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn include_and_input_labels_share_the_root_inventory() {
+    let case = Case::new();
+    case.write(
+        "book.xtex",
+        "\\include{chapters/one}\n\\input{chapters/two}\n",
+    );
+    case.write("chapters/one.tex", "\\label{sec:one}\n");
+    case.write("chapters/two.xtex", "@ref(sec:one)\n@ref(sec:missing)\n");
+
+    let output = case.check();
+
+    assert_eq!(output.status.code(), Some(1));
+    let diagnostics = stdout(&output);
+    assert!(!diagnostics.contains("identifier `sec:one` is not declared"));
+    assert!(
+        diagnostics.contains("chapters/two.xtex:2:6"),
+        "{diagnostics}"
+    );
+    assert!(diagnostics.contains("identifier `sec:missing` is not declared"));
+}
+
+#[test]
+fn unreadable_or_quarantined_edges_suppress_missing_reference_errors() {
+    for root in [
+        "\\include{absent}\n@ref(sec:possibly-there)\n",
+        "\\include{dark}\n@ref(sec:possibly-there)\n",
+        "\\input{   }\n@ref(sec:possibly-there)\n",
+    ] {
+        let case = Case::new();
+        case.write("book.xtex", root);
+        case.write(
+            "dark.tex",
+            "\\catcode`\\@=11\n\\label{sec:possibly-there}\n",
+        );
+
+        let output = case.check();
+
+        assert!(output.status.success(), "{}", stderr(&output));
+        assert!(!stdout(&output).contains("XT1003"));
+    }
+}
+
+#[test]
+fn a_missing_import_reports_the_import_but_not_a_possibly_hidden_label() {
+    let case = Case::new();
+    case.write(
+        "book.xtex",
+        "@import(\"absent.xtex\")\n@ref(sec:possibly-there)\n",
+    );
+
+    let output = case.check();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout(&output).contains("XT1009"));
+    assert!(!stdout(&output).contains("XT1003"));
+}
+
+#[test]
+fn excluded_includes_are_not_followed() {
+    let case = Case::new();
+    case.write(
+        "book.xtex",
+        concat!(
+            "% \\include{comment}\n",
+            "\\begin{verbatim}\n\\include{verbatim}\n\\end{verbatim}\n",
+            "\\newcommand{\\loadit}{\\include{macro-body}}\n",
+            "@ref(sec:missing)\n",
+        ),
+    );
+
+    let output = case.check();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout(&output).contains("identifier `sec:missing` is not declared"));
+}
+
+#[test]
+fn a_computed_include_makes_the_inventory_unavailable_without_an_error() {
+    for root in [
+        "\\include{\\chaptername}\n@ref(sec:possibly-computed)\n",
+        "\\input\\othername\n@ref(sec:possibly-computed)\n",
+    ] {
+        let case = Case::new();
+        case.write("book.xtex", root);
+
+        let output = case.check();
+
+        assert!(output.status.success(), "{}", stderr(&output));
+        assert!(!stdout(&output).contains("XT1003"));
+    }
+}
+
+#[test]
+fn include_cycles_terminate() {
+    let case = Case::new();
+    case.write("book.xtex", "\\include{other}\n@ref(sec:other)\n");
+    case.write("other.tex", "\\input{book.xtex}\n\\label{sec:other}\n");
+
+    let output = case.check();
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert!(!stdout(&output).contains("XT1003"));
+}
+
+#[test]
+fn plain_latex_edges_do_not_change_emission() {
+    let case = Case::new();
+    let input = "before\\include{chapter}\nafter\n";
+    case.write("book.xtex", input);
+    case.write("chapter.tex", "chapter\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_xtex"))
+        .arg("book.xtex")
+        .current_dir(&case.0)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(
+        fs::read(case.0.join("build/book.tex")).unwrap(),
+        input.as_bytes()
+    );
+    assert!(!Path::new(&case.0.join("build/chapter.tex")).exists());
+}

--- a/crates/xtex-core/src/labels.rs
+++ b/crates/xtex-core/src/labels.rs
@@ -33,6 +33,8 @@ pub enum Unavailable {
     /// A `\label` after that point cannot be seen, so the ones before it are a
     /// subset rather than a set.
     Quarantined,
+    /// A literal LaTeX project edge did not resolve or could not be read.
+    UnreadableEdge,
 }
 
 /// What a document's own `\label` commands amount to.

--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -344,7 +344,8 @@ impl SymbolTable {
         labels: &'a crate::labels::Inventory,
     ) -> impl Iterator<Item = (&'a str, &'a Reference)> {
         self.references.iter().filter_map(move |(name, reference)| {
-            (reference.kind == EntryToken::Ref
+            (matches!(labels, crate::labels::Inventory::Complete(_))
+                && reference.kind == EntryToken::Ref
                 && !self.declarations.contains_key(name)
                 && !labels.contains(name))
             .then_some((name.as_str(), reference))
@@ -589,6 +590,15 @@ mod tests {
         )]);
         let unresolved: Vec<_> = t.unresolved_references().map(|(n, _)| n).collect();
         assert_eq!(unresolved, ["missing"]);
+    }
+
+    #[test]
+    fn an_unavailable_label_inventory_reports_nothing_missing() {
+        let (_, t) = table(&[("a.xtex", "@ref(possibly-in-an-unread-file)")]);
+        let labels =
+            crate::labels::Inventory::Unavailable(crate::labels::Unavailable::UnreadableEdge);
+
+        assert_eq!(t.unresolved_against(&labels).count(), 0);
     }
 
     #[test]

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -314,8 +314,11 @@ everything and the hand reader disagrees anywhere would reverse it.
 
 ## 8 · References
 
-An `@ref` whose identifier no `@id` declares is `XT1003`. The scope is the document root — its root file
-plus everything reached through `@import` — which matches LaTeX, where a label is document-wide.
+An `@ref` whose identifier neither an `@id` nor a completely inventoried source `\label` declares is
+`XT1003`. The symbol scope is the document root — its root file plus everything reached through `@import`.
+The label inventory additionally follows literal `\include` and `\input` paths in readable content, matching
+the assembly the author already wrote without changing emission. If any such file cannot be resolved, read or
+parsed through the end, the whole inventory is unavailable and `XT1003` is silent.
 
 Two `@id` constructs declaring the same identifier in one root is `XT1001`, blamed on the later one. The
 first declaration is not at fault for existing.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -305,15 +305,22 @@ imposing a project-wide one on separately emitted documents.
 `@id(sec:intro)` emits `\label{sec:intro}` at the annotation's source position, and nothing else — no
 wrapper, no support command.
 
-Before emission each root builds a **label inventory**. `\label` is a built-in known command with signature
+Before checking each root builds a **label inventory**. `\label` is a built-in known command with signature
 `m`, so its mandatory argument is selectable under §8 even though its bytes are otherwise opaque. A label
 enters the inventory only when it is tokenized as `\label` under default category codes, occurs outside every
 §8 exclusion region, has one balanced braced argument, and that argument is an `ident` after trimming ASCII
 whitespace.
 
+The inventory also follows literal `\include{…}` and `\input{…}` paths in readable content, transitively.
+An omitted extension resolves first to `.tex`, then to `.xtex`. These commands remain transported bytes: they
+do not become imports, add files to emission, or change page breaks. A command in a comment, verbatim region
+or macro definition is not an edge.
+
 The inventory is `Complete` or `Unavailable`. It becomes `Unavailable` when quarantine begins, a category-code
-change prevents reliable tokenization, or a candidate argument cannot be bounded. None of those is an error
-for an unannotated document.
+change prevents reliable tokenization, a candidate argument cannot be bounded, an inventory edge is computed,
+or any literal edge cannot be resolved and read completely. None of those is an error for an unannotated
+document, and no identifier may be reported absent from an unavailable inventory. A configured resource
+limit remains fatal rather than being treated as evidence about the document.
 
 When `Complete`, an `@id(x)` colliding with another `@id(x)` or with a source `\label{x}` is a hard error
 blamed on the `@id`; nothing is emitted. The source `\label{x}` is never itself an error.


### PR DESCRIPTION
Closes #68. Stacked on `#67`; review that first.

## The problem, measured on a real book

A Springer monograph — 20 `.tex` files, eight chapters held together by `\include`. **136 references live in the chapters, and 16 point to a `\label` in a different chapter.** Annotate one and check that chapter:

```
error[XT1003]: identifier `subsec:aggregation` is not declared
exit=1
```

The label is in `chapter2_stn_concept.tex`. Nothing is wrong with the book.

## What changed

The label inventory follows literal `\include` and `\input` paths, transitively, the way it already follows `@import`. **Emission is untouched** — those bytes are transported exactly as before, no page break appears or disappears, and the commands do not become imports.

Rewriting `\include` as `@import` was the obvious alternative and `docs/decisions/0004` §3 refuses it: LaTeX will not nest `\include` while `@import` nests by definition, and `\include` forces a page break we may not emit unasked.

## What it is not

Not a licence to scan inside opaque regions — `checking.md` §4 stands. Edges are read from *readable content* via `readable_for`, so a command inside a comment, a verbatim region or a macro body is not an edge. A literal path is taken from a recognised command, and the target file is then parsed structurally like any other file.

## Failure is total

A path that does not resolve, a file that cannot be read, or a file that quarantines makes the **whole** inventory unavailable, and no identifier may then be called absent. Same rule as the bibliography, same reason: an inventory built from four of five chapters looks complete and turns every label of the fifth into a false error against an author who did nothing wrong.

## Verification

Seven cases, each built so a wrong implementation gives the other answer:

| Case | Expected | Got |
|---|---|---|
| `\include` inside a comment | `XT1003`, exit 1 | ✓ |
| `\include` inside `verbatim` | `XT1003`, exit 1 | ✓ |
| `\include` inside a `\newcommand` body | `XT1003`, exit 1 | ✓ |
| the same edge, real | exit 0 | ✓ |
| path that does not resolve | silence, exit 0 | ✓ |
| path built by a macro | silence, exit 0 | ✓ |
| target file quarantines | silence, exit 0 | ✓ |

The first four share one fixture shape, so the difference between rows one to three and row four is the whole test.

| Check | Result |
|---|---|
| monograph, root unmodified: cross-chapter `@ref` | resolves, exit 0 |
| the same reference made wrong | `XT1003` with file, line and column |
| all 20 monograph files emitted | byte-identical |
| `~/Workspace` sweep | 251 files, **0** non-zero |
| cycle `a → b → a` | terminates |
| `fmt`, `clippy -D warnings`, `test --workspace` | clean, 197 tests |

The sweep improved by one. `tests/fixtures/emission/03-raw-and-import/emitted.tex` contains `\input{sections/model.tex}`, which does not resolve beside it, so its `@ref` can no longer be called missing. A false error that had been sitting in the sweep all along, removed by the rule rather than by a special case.

Both mutation checks land on the right test: following every `\include` regardless of exclusion fails only `excluded_includes_are_not_followed`, and dropping the unavailable marking on a failed edge fails only `unreadable_or_quarantined_edges_suppress_missing_reference_errors`.

## One disagreement, resolved toward the binding document

The issue's wording could have folded a resource-limit refusal into "cannot be read". `AGENTS.md` reserves resource limits as fatal, so an oversized file stays fatal and only ordinary resolution and read failures yield `Unavailable`.