### PR TITLE
Measure the compiler against LaTeX nobody here wrote

### DIFF
--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -832,6 +832,40 @@ fn blame(mut args: impl Iterator<Item = String>) -> ExitCode {
 }
 
 #[cfg(test)]
+mod cause_tests {
+    use super::cause_at;
+
+    #[test]
+    fn a_control_word_is_named_and_an_environment_is_named_with_it() {
+        // These are what a corpus groups by. `\\begin` alone would put
+        // `lstlisting` and `verbatim` in one bucket, and they are not one
+        // problem.
+        assert_eq!(cause_at(b"\\verb+unterminated", 0), "\\verb");
+        assert_eq!(cause_at(b"\\catcode`\\@=11", 0), "\\catcode");
+        assert_eq!(
+            cause_at(b"\\begin{lstlisting}\ncode", 0),
+            "\\begin{lstlisting}"
+        );
+        assert_eq!(cause_at(b"\\begin{verbatim}\nx", 0), "\\begin{verbatim}");
+    }
+
+    #[test]
+    fn without_a_control_word_the_bytes_are_shown_rather_than_a_cause_invented() {
+        // Naming a cause we cannot see would be worse than showing the bytes,
+        // because a corpus tally of invented causes reads exactly like a tally
+        // of real ones.
+        assert_eq!(cause_at(b"plain text here", 0), "bytes `plain text here`");
+        assert_eq!(cause_at(b"\\  spaced", 0), "bytes `\\  spaced`");
+    }
+
+    #[test]
+    fn an_offset_at_or_past_the_end_does_not_panic() {
+        assert_eq!(cause_at(b"abc", 3), "bytes ``");
+        assert_eq!(cause_at(b"", 99), "bytes ``");
+    }
+}
+
+#[cfg(test)]
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
@@ -1147,12 +1181,55 @@ fn confidence_command(args: &[String]) -> ExitCode {
             #[allow(clippy::cast_precision_loss)]
             let fraction = at as f64 / total as f64;
             println!("quarantine: {fraction:.6}");
+            println!("cause: {}", cause_at(source.bytes(), at));
         }
         _ => println!("quarantine: none"),
     }
     println!("bytes: {total}");
     println!("coverage: {:.6}", document.coverage());
     ExitCode::SUCCESS
+}
+
+/// What is at the byte where recognition stopped.
+///
+/// A quarantine figure says how much of a file was reachable. It does not say
+/// what to fix, and over a corpus that is the difference between a number and
+/// a list of work. Reported as the control word where there is one, because
+/// those group — a hundred files stopped by `\catcode` are one problem — and
+/// as a short excerpt otherwise, because inventing a cause is worse than
+/// showing the bytes.
+fn cause_at(bytes: &[u8], at: usize) -> String {
+    let rest = &bytes[at.min(bytes.len())..];
+    if rest.first() == Some(&b'\\') {
+        let name: Vec<u8> = rest[1..]
+            .iter()
+            .take_while(|byte| byte.is_ascii_alphabetic())
+            .copied()
+            .collect();
+        if !name.is_empty() {
+            let name = String::from_utf8_lossy(&name);
+            // `\begin{lstlisting}` and `\begin{verbatim}` are different
+            // problems and collapsing them into `\begin` would hide that.
+            if name == "begin" {
+                if let Some(open) = rest.get(6) {
+                    if *open == b'{' {
+                        let environment: Vec<u8> = rest[7..]
+                            .iter()
+                            .take_while(|byte| **byte != b'}')
+                            .copied()
+                            .collect();
+                        return format!("\\begin{{{}}}", String::from_utf8_lossy(&environment));
+                    }
+                }
+            }
+            return format!("\\{name}");
+        }
+    }
+    let excerpt: String = String::from_utf8_lossy(&rest[..rest.len().min(40)])
+        .chars()
+        .map(|c| if c.is_whitespace() { ' ' } else { c })
+        .collect();
+    format!("bytes `{}`", excerpt.trim())
 }
 
 /// Emits, runs the TeX engine, and reports what it said against the source.

--- a/tests/corpus/README.md
+++ b/tests/corpus/README.md
@@ -11,21 +11,53 @@ Real LaTeX, used to decide how the shallow parser behaves. Two halves with diffe
 
 ## Real documents are referenced, not vendored
 
-`manifest.toml` records, per file: where it came from, under what licence, and a SHA-256 of the exact bytes
-measured. It does not contain the file.
+Two files hold what a measurement needs, and neither holds a document.
 
-The reason is ordinary caution. A journal submission's copyright frequently sits with the publisher, and
-this repository is MIT. Recording a fingerprint claims nothing about the bytes except that they are the ones
-the number was computed from — which is the only claim a measurement needs.
+`provenance.json`, written by `fetch.py`, records where each document came from: its identifier, its field,
+its year, the licence arXiv or the repository states, its URL, and a SHA-256 per file.
+
+`manifest.json`, written by `measure.py`, records what was measured and **what measured it** — the binary's
+own SHA-256 and the commit it was built from.
+
+The reason nothing is vendored is ordinary caution. A journal submission's copyright frequently sits with
+the publisher, and this repository is MIT. Recording a fingerprint claims nothing about the bytes except
+that they are the ones the number was computed from — which is the only claim a measurement needs.
 
 It is also better evidence. Anyone can point the tooling at their own corpus and get a comparable number,
 and the fingerprint makes a stale result detectable rather than silently reused. That is the measurement
 rule in [`AGENTS.md`](../../AGENTS.md) §7 applied to our own inputs.
 
+The instrument is fingerprinted for a reason that is not theoretical. Measuring with a binary built from a
+different branch than the one being reasoned about went wrong three times in a single day here, and each
+time the numbers looked entirely reasonable.
+
 ```sh
-python3 tests/corpus/measure.py ~/Workspace          # measure a corpus
-python3 tests/corpus/measure.py --verify manifest.toml   # check the fingerprints still match
+python3 tests/corpus/fetch.py --out /tmp/corpus              # build a corpus
+python3 tests/corpus/measure.py /tmp/corpus \
+    --binary target/release/xtex --out manifest.json         # measure it
+python3 tests/corpus/measure.py --verify manifest.json       # are the bytes still the ones measured?
 ```
+
+---
+
+## What is measured, and over which files
+
+Three numbers, and the first two are the project's promises rather than diagnostics about it.
+
+| | |
+|---|---|
+| **checks clean** | `xtex check` exits 0 on the file, unmodified. Run in the file's own directory, so its includes and bibliography resolve the way they do for its author. |
+| **transports** | Emitting returns the input's bytes exactly. Property A. |
+| **available** | The fraction of the file reachable before `OpaqueToEof`, plus what was at the byte where recognition stopped. |
+
+**The first two apply only to unannotated files.** An annotated one is a different object: emitting it is
+*supposed* to change bytes, and a hard error inside an explicit construct is the compiler working rather
+than failing. Which is which is decided by the compiler's own coverage figure, not by a pattern matched
+here — a file with no constructs reports coverage `0`.
+
+Getting this wrong is not hypothetical either. Measured over a tree that included this repository's own
+hazard fixtures, the run reported 40 files failing to check and 59 failing to transport. Every one of them
+was a fixture written to do exactly that.
 
 ---
 

--- a/tests/corpus/RESULTS.md
+++ b/tests/corpus/RESULTS.md
@@ -1,0 +1,73 @@
+# The external corpus — first measurement
+
+Measured 2026-08-30, against the thresholds frozen in [`README.md`](README.md) before any corpus existed.
+Corpus built by [`fetch.py`](fetch.py): **95 documents, 992 `.tex` files** nobody in this project wrote —
+two papers per cell of an 8-year × 6-field grid (2005–2026; algebraic geometry, data structures, hep-th,
+astronomy, statistical mechanics, population biology), plus five multi-file books and lecture-note
+repositories pinned by commit. Provenance, licences and per-file SHA-256 in the corpus's
+`provenance.json`; the measurement's own instrument (binary hash, commit) in its manifest.
+
+## The verdict
+
+```
+992 files, 0 of them already annotated
+
+  the two promises, over the 992 unannotated files
+    check clean, unmodified              992/992
+    emit the input's bytes exactly       992/992
+
+  how much is reachable
+    median available before quarantine   1.000   (threshold >= 0.900)
+    quarantined before half their bytes  9.6%     (threshold <= 10%)
+    never quarantined                    881
+
+thresholds: met
+```
+
+**Both promises hold on every file of every year and field measured.** No unmodified document produces a
+hard error, and every one emits its own bytes exactly. This is the first evidence for either claim that does
+not come from this project's author's own writing.
+
+The quarantine thresholds are met, but the second one barely — 9.6% against a ceiling of 10% — and the
+margin is thin enough that the causes matter more than the pass.
+
+## What stopped recognition, grouped
+
+| Count | At the stopped byte | What it actually is |
+|---|---|---|
+| 102 | `\iftag` | OpenLogic's own conditional machinery — braced-argument conditionals across one book's files. Arguably correct quarantines of genuinely unscannable macros, but they are 92% of all quarantined files. |
+| 2 | `\iff` | **The kernel's ⟺ symbol**, not a conditional. No `\fi` exists or is needed. |
+| 2 | `\in` | **A half-open interval.** `X \in [A, B)` inside `\begin{equation}`: the `[` is read as an optional argument that never closes. |
+| 1 each | `\ifabstract`, `\ifhyper`, `\ifdraft` | Real author conditionals opened in preambles — correct quarantines. |
+| 1 | `\bigg` | Sized delimiter in display math, same family as `\in`. |
+| 1 | `\makeatletter` | Correct. |
+
+## The root cause behind the false quarantines
+
+Reduced to minimal cases, verified in both directions:
+
+```
+\begin{equation} X \in [A, B) \end{equation}     → quarantine at \in
+\begin{equation} X \in [A, B] \end{equation}     → none
+$X \in [A, B)$                                    → none
+\begin{align*} a &\iff b \end{align*}            → quarantine at \iff
+```
+
+Inline math is an exclusion region and behaves as one. **Display-math environments are promised as an
+exclusion region by `grammar.md` §8 — "for a display-math environment, the first byte after the header
+slot" — and the scanner implements no such set.** `equation`, `align`, and their family do not exist for
+it, so their bytes are scanned as command syntax: `\iff` matches the `\if…` conditional rule, and an
+unknown command followed by `[` opens an optional-argument scan that a half-open interval never closes.
+
+Separately, `\iff` in prose — outside any math — also quarantines, so the conditional rule needs the kernel
+symbol excepted regardless of the region fix.
+
+Issues filed from this measurement: the display-math environment set, and the `\if…` rule's exceptions.
+
+## Boundary
+
+One run, 95 documents, two per cell — enough to find defect families, not to estimate their rates. The
+per-cell sample is small and licence-filtered toward what arXiv exposes. The `\iftag` concentration shows a
+single macro-heavy project can dominate the quarantine tally; conclusions about the *rate* of quarantine in
+the wild need a corpus an order of magnitude larger, which belongs on arXiv's S3 bulk route rather than the
+polite crawl `fetch.py` uses.

--- a/tests/corpus/fetch.py
+++ b/tests/corpus/fetch.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Builds a corpus of LaTeX written by other people, across years and fields.
+
+Everything the compiler knows so far comes from one author. This fetches
+documents nobody here wrote, stratified two ways, because LaTeX practice varies
+along both axes and a corpus that varies along neither measures a style rather
+than a language.
+
+    python3 fetch.py --out <directory>
+    python3 fetch.py --out <directory> --per-cell 2
+
+Nothing is downloaded into the repository. `tests/corpus/README.md` records why:
+these documents' licences are not ours to grant, so the corpus lives outside and
+only its fingerprints come back. `provenance.json` is what makes a measurement
+taken from it re-checkable — identifier, field, year, licence, URL, and a
+SHA-256 of every file measured.
+
+arXiv's API terms of use ask for one request every three seconds over a single
+connection, and its bulk-access page lists crawling the export service as a
+sanctioned route for a subset of content. This makes one request at a time and
+sleeps between them. A larger corpus belongs on their S3 bulk data, not here.
+"""
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+import tarfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+# Eight cuts from the pdflatex era to now. LaTeX practice moved underneath them:
+# pdflatex gave way to xelatex and lualatex, natbib to biblatex, TikZ arrived,
+# and source files stopped being ASCII.
+YEARS = [2005, 2008, 2011, 2014, 2017, 2020, 2023, 2026]
+
+# Six fields that write LaTeX differently: theorem environments and private
+# macro layers in mathematics, algorithms and listings in computer science,
+# revtex and dense display maths in physics, aastex and wide tables in
+# astronomy. All six existed in 2005, so no cell of the grid is empty for a
+# reason that has nothing to do with the compiler.
+# `astro-ph*` rather than `astro-ph`: the archive was split into subcategories
+# in 2009, and the bare name matches nothing after that — a query that silently
+# returns an empty year rather than an error. Every pair below was checked at
+# both ends of the range before the corpus was built, and all twelve return
+# results.
+AREAS = ["math.AG", "cs.DS", "hep-th", "astro-ph*", "cond-mat.stat-mech", "q-bio.PE"]
+
+# Whole documents rather than papers: books and lecture notes, multi-file, held
+# together by \include. arXiv has almost none of that shape, and it is the shape
+# the label inventory crosses. Pinned by name and licence here rather than
+# discovered by search, so the selection can be audited rather than trusted.
+REPOSITORIES = [
+    ("OpenLogicProject/OpenLogic", "CC-BY-4.0"),
+    ("sysprog21/lkmpg", "OSL-3.0"),
+    ("dendibakh/perf-book", "CC0-1.0"),
+    ("MasatakaYm/Molecular-Simulation", "CC-BY-4.0"),
+    ("yegor256/ssd16", "MIT"),
+]
+
+SEED = 20260829
+DELAY = 3.0  # seconds between requests to arxiv.org, per their terms of use
+AGENT = "exacttex-corpus/0.1 (research measurement; camilochs@gmail.com)"
+
+_last_request = [0.0]
+
+
+def polite_get(url, params=None):
+    """One request at a time, never faster than the published rate."""
+    if params:
+        url = url + "?" + urllib.parse.urlencode(params)
+    waited = time.monotonic() - _last_request[0]
+    if waited < DELAY:
+        time.sleep(DELAY - waited)
+    request = urllib.request.Request(url, headers={"User-Agent": AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            body = response.read()
+    except (urllib.error.URLError, TimeoutError) as error:
+        _last_request[0] = time.monotonic()
+        return None, str(error)
+    _last_request[0] = time.monotonic()
+    return body, None
+
+
+def ids_for(area, year, want):
+    """Papers submitted to `area` during `year`, sampled reproducibly.
+
+    Returns each paper's own primary category alongside its identifier. A search
+    for a category matches papers cross-listed into it, so the field a paper was
+    drawn from is not necessarily the field it belongs to, and recording the
+    query instead of the answer would put a gr-qc paper in the astronomy row.
+    """
+    body, error = polite_get(
+        "https://export.arxiv.org/api/query",
+        {
+            "search_query": f"cat:{area} AND submittedDate:"
+            f"[{year}01010000 TO {year}12312359]",
+            "start": 0,
+            # Sampling from a pool rather than taking the first few: the API
+            # returns them in a fixed order, and the first few of any year are
+            # the first few days of January.
+            "max_results": 60,
+        },
+    )
+    if body is None:
+        print(f"  {area} {year}: search failed, {error}")
+        return []
+    pool = []
+    for entry in body.split(b"<entry>")[1:]:
+        identifier = re.search(rb"<id>http://arxiv\.org/abs/([^<]+?)v\d+</id>", entry)
+        primary = re.search(rb'primary_category[^/>]*term="([^"]*)"', entry)
+        if identifier:
+            pool.append(
+                (
+                    identifier.group(1).decode(),
+                    primary.group(1).decode() if primary else "unknown",
+                )
+            )
+    if not pool:
+        print(f"  {area} {year}: no results")
+        return []
+    if len(pool) <= want:
+        return pool
+    return random.Random(f"{SEED}-{area}-{year}").sample(pool, want)
+
+
+def licence_of(identifier):
+    """The licence arXiv records for a paper, transcribed rather than assumed."""
+    body, error = polite_get(
+        "https://export.arxiv.org/oai2",
+        {
+            "verb": "GetRecord",
+            "identifier": f"oai:arXiv.org:{identifier}",
+            "metadataPrefix": "arXiv",
+        },
+    )
+    if body is None:
+        return None, None, error
+    licence = re.search(rb"<license>([^<]*)</license>", body)
+    created = re.search(rb"<created>([^<]*)</created>", body)
+    return (
+        licence.group(1).decode() if licence else "arxiv-default",
+        created.group(1).decode() if created else None,
+        None,
+    )
+
+
+def tex_from_eprint(body):
+    """The `.tex` files in an e-print, whatever shape it arrived in.
+
+    A submission is a gzipped tar, a single gzipped file, or a PDF. The last is
+    a PDF-only submission with no source to measure, and is skipped rather than
+    counted as a failure of anything.
+    """
+    if body[:4] == b"%PDF":
+        return None, "pdf-only submission"
+    try:
+        plain = gzip.decompress(body)
+    except (OSError, EOFError) as error:
+        return None, f"not gzip: {error}"
+    try:
+        with tarfile.open(fileobj=io.BytesIO(plain)) as archive:
+            files = {}
+            for member in archive.getmembers():
+                if not member.isfile() or not member.name.endswith(".tex"):
+                    continue
+                # A tar member's name is attacker-controlled in general. These
+                # come from arXiv, but a path that escapes the directory is
+                # still a path we refuse to write.
+                if os.path.isabs(member.name) or ".." in member.name.split("/"):
+                    continue
+                handle = archive.extractfile(member)
+                if handle is not None:
+                    files[member.name] = handle.read()
+        if not files:
+            return None, "no .tex in the archive"
+        return files, None
+    except tarfile.TarError:
+        # Not a tar: a single-file submission, gzipped on its own.
+        return {"main.tex": plain}, None
+
+
+def fingerprint(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def fetch_arxiv(out, per_cell):
+    documents = []
+    skipped = []
+    for year in YEARS:
+        for area in AREAS:
+            print(f"{year} {area}")
+            for identifier, primary in ids_for(area, year, per_cell):
+                directory = os.path.join(out, "arxiv", str(year), area, identifier.replace("/", "_"))
+                if os.path.isdir(directory) and os.listdir(directory):
+                    print(f"  {identifier}: already here")
+                    continue
+                body, error = polite_get(f"https://arxiv.org/e-print/{identifier}")
+                if body is None:
+                    skipped.append((identifier, f"download failed: {error}"))
+                    print(f"  {identifier}: {error}")
+                    continue
+                files, reason = tex_from_eprint(body)
+                if files is None:
+                    skipped.append((identifier, reason))
+                    print(f"  {identifier}: {reason}")
+                    continue
+                licence, created, error = licence_of(identifier)
+                if error:
+                    skipped.append((identifier, f"licence unknown: {error}"))
+                    print(f"  {identifier}: licence unknown, not kept")
+                    continue
+
+                os.makedirs(directory, exist_ok=True)
+                recorded = []
+                for name, data in files.items():
+                    path = os.path.join(directory, name)
+                    os.makedirs(os.path.dirname(path), exist_ok=True)
+                    with open(path, "wb") as handle:
+                        handle.write(data)
+                    recorded.append(
+                        {
+                            "path": os.path.relpath(path, out),
+                            "bytes": len(data),
+                            "sha256": fingerprint(data),
+                        }
+                    )
+                documents.append(
+                    {
+                        "source": "arxiv",
+                        "id": identifier,
+                        "area": primary,
+                        "drawn_from": area,
+                        "year": year,
+                        "created": created,
+                        "licence": licence,
+                        "url": f"https://arxiv.org/abs/{identifier}",
+                        "files": recorded,
+                    }
+                )
+                print(f"  {identifier} [{primary}]: {len(recorded)} .tex, {licence}")
+    return documents, skipped
+
+
+def fetch_repositories(out):
+    documents = []
+    skipped = []
+    for name, licence in REPOSITORIES:
+        directory = os.path.join(out, "github", name.replace("/", "_"))
+        if not os.path.isdir(directory):
+            print(f"cloning {name}")
+            result = subprocess.run(
+                ["git", "clone", "--depth", "1", f"https://github.com/{name}.git", directory],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                skipped.append((name, result.stderr.strip().splitlines()[-1:]))
+                print(f"  {name}: clone failed")
+                continue
+        commit = subprocess.run(
+            ["git", "-C", directory, "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.strip()
+
+        recorded = []
+        for base, dirs, names in os.walk(directory):
+            dirs[:] = [d for d in dirs if d != ".git"]
+            for name_ in names:
+                if not name_.endswith(".tex"):
+                    continue
+                path = os.path.join(base, name_)
+                with open(path, "rb") as handle:
+                    data = handle.read()
+                recorded.append(
+                    {
+                        "path": os.path.relpath(path, out),
+                        "bytes": len(data),
+                        "sha256": fingerprint(data),
+                    }
+                )
+        documents.append(
+            {
+                "source": "github",
+                "id": name,
+                "area": "book",
+                "year": None,
+                "created": None,
+                "licence": licence,
+                "url": f"https://github.com/{name}/tree/{commit}",
+                "commit": commit,
+                "files": recorded,
+            }
+        )
+        print(f"  {name}: {len(recorded)} .tex at {commit[:8]}")
+    return documents, skipped
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--per-cell", type=int, default=2)
+    parser.add_argument("--skip-arxiv", action="store_true")
+    parser.add_argument("--skip-github", action="store_true")
+    args = parser.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    documents, skipped = [], []
+    if not args.skip_arxiv:
+        found, missed = fetch_arxiv(args.out, args.per_cell)
+        documents += found
+        skipped += missed
+    if not args.skip_github:
+        found, missed = fetch_repositories(args.out)
+        documents += found
+        skipped += missed
+
+    path = os.path.join(args.out, "provenance.json")
+    with open(path, "w") as handle:
+        json.dump(
+            {
+                "seed": SEED,
+                "years": YEARS,
+                "areas": AREAS,
+                "documents": documents,
+                "skipped": [{"id": i, "reason": str(r)} for i, r in skipped],
+            },
+            handle,
+            indent=2,
+        )
+
+    files = sum(len(d["files"]) for d in documents)
+    print(f"\n{len(documents)} documents, {files} .tex files")
+    print(f"  skipped {len(skipped)}")
+    print(f"  provenance written to {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/corpus/measure.py
+++ b/tests/corpus/measure.py
@@ -13,11 +13,14 @@ thresholds, and it records them from before any corpus was measured.
 """
 
 import argparse
+import collections
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 
 
 def tex_files(root):
@@ -44,18 +47,95 @@ def fingerprint(path):
         return hashlib.sha256(handle.read()).hexdigest()
 
 
-def quarantine_position(binary, path):
-    """Fraction of the file available before `OpaqueToEof`, or 1.0 if never."""
+def confidence(binary, path):
+    """Where recognition stopped, what was there, and how much is annotated."""
     result = subprocess.run(
         [binary, "confidence", path], capture_output=True, text=True, check=False
     )
     if result.returncode != 0:
-        return None
+        return None, None, 0.0
+    position, cause, coverage = None, None, 0.0
     for line in result.stdout.splitlines():
         if line.startswith("quarantine:"):
             value = line.split(":", 1)[1].strip()
-            return 1.0 if value == "none" else float(value)
-    return None
+            position = 1.0 if value == "none" else float(value)
+        elif line.startswith("cause:"):
+            cause = line.split(":", 1)[1].strip()
+        elif line.startswith("coverage:"):
+            coverage = float(line.split(":", 1)[1].strip())
+    return position, cause, coverage
+
+
+def checks_clean(binary, path):
+    """Whether unmodified LaTeX checks clean, which is the central promise.
+
+    Run where the file actually lives, because a document's imports, includes
+    and bibliography resolve relative to it. Checking a copy in a scratch
+    directory would measure a document that has been taken apart.
+    """
+    result = subprocess.run(
+        [binary, "check", os.path.basename(path)],
+        cwd=os.path.dirname(path) or ".",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0, result.stdout.strip().splitlines()[:1]
+
+
+def transports(binary, path):
+    """Whether emitting returns the input's bytes — property A.
+
+    The file is copied alone into a scratch directory under a `.xtex` name,
+    because emission is what the compiler writes for *this* file's bytes.
+    """
+    with tempfile.TemporaryDirectory() as directory:
+        name = os.path.splitext(os.path.basename(path))[0] + ".xtex"
+        copied = os.path.join(directory, name)
+        shutil.copyfile(path, copied)
+        result = subprocess.run(
+            [binary, name], cwd=directory, capture_output=True, text=True, check=False
+        )
+        emitted = os.path.join(
+            directory, "build", os.path.splitext(name)[0] + ".tex"
+        )
+        if result.returncode != 0 or not os.path.exists(emitted):
+            return False
+        with open(path, "rb") as left, open(emitted, "rb") as right:
+            return left.read() == right.read()
+
+
+def instrument(binary):
+    """What took the measurement.
+
+    A result file that does not say which code produced it can be picked up
+    later and read as current. This has already gone wrong here three times in
+    one day, each time by measuring with a binary built from a different branch
+    than the one being reasoned about, so the binary's own fingerprint and the
+    commit it was built from travel with every number.
+    """
+    with open(binary, "rb") as handle:
+        digest = hashlib.sha256(handle.read()).hexdigest()
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=os.path.dirname(os.path.abspath(binary)),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=os.path.dirname(os.path.abspath(binary)),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "binary": os.path.abspath(binary),
+        "sha256": digest,
+        "commit": commit.stdout.strip() or None,
+        "working_tree_clean": dirty.returncode == 0 and not dirty.stdout.strip(),
+    }
 
 
 def measure(root, binary):
@@ -64,17 +144,28 @@ def measure(root, binary):
         size = os.path.getsize(path)
         if size == 0:
             continue
-        position = quarantine_position(binary, path)
+        position, cause, coverage = confidence(binary, path)
         if position is None:
             continue
-        rows.append(
-            {
-                "path": os.path.relpath(path, root),
-                "sha256": fingerprint(path),
-                "bytes": size,
-                "available": position,
-            }
-        )
+        row = {
+            "path": os.path.relpath(path, root),
+            "sha256": fingerprint(path),
+            "bytes": size,
+            "available": position,
+            "cause": cause,
+            # Both promises are about LaTeX the author did not rewrite. An
+            # annotated file is a different object: emitting it is *supposed*
+            # to change bytes, and a hard error in it is the compiler working.
+            # The compiler's own coverage figure decides which this is, rather
+            # than a regular expression guessing at it here.
+            "annotated": coverage > 0.0,
+        }
+        if not row["annotated"]:
+            clean, first_line = checks_clean(binary, path)
+            row["checks_clean"] = clean
+            row["diagnostic"] = None if clean else (first_line[0] if first_line else "")
+            row["transports"] = transports(binary, path)
+        rows.append(row)
     return rows
 
 
@@ -86,19 +177,47 @@ def report(rows):
     median = available[len(available) // 2]
     early = sum(1 for value in available if value < 0.5) / len(available)
 
-    print(f"{len(rows)} files")
-    print(f"  median available before quarantine   {median:.3f}   (threshold >= 0.900)")
-    print(f"  quarantined before half their bytes  {early:.1%}     (threshold <= 10%)")
-    print(f"  never quarantined                    {sum(1 for v in available if v >= 1.0)}")
+    plain = [row for row in rows if not row["annotated"]]
+    dirty = [row for row in plain if not row["checks_clean"]]
+    lost = [row for row in plain if not row["transports"]]
 
-    failed = median < 0.90 or early > 0.10
+    print(f"{len(rows)} files, {len(rows) - len(plain)} of them already annotated")
+    print("\n  the two promises, over the " + f"{len(plain)} unannotated files")
+    print(f"    check clean, unmodified              {len(plain) - len(dirty)}/{len(plain)}")
+    print(f"    emit the input's bytes exactly       {len(plain) - len(lost)}/{len(plain)}")
+    print("\n  how much is reachable")
+    print(f"    median available before quarantine   {median:.3f}   (threshold >= 0.900)")
+    print(f"    quarantined before half their bytes  {early:.1%}     (threshold <= 10%)")
+    print(f"    never quarantined                    {sum(1 for v in available if v >= 1.0)}")
+
+    causes = collections.Counter(
+        row.get("cause") for row in rows if row["available"] < 1.0 and row.get("cause")
+    )
+    if causes:
+        print("\n  what stopped recognition, by count")
+        for cause, count in causes.most_common(12):
+            print(f"    {count:5}  {cause}")
+
+    # A file that fails a promise is a defect, whatever the quarantine figure
+    # says. Quarantine is a coverage signal; these two are the contract.
+    failed = median < 0.90 or early > 0.10 or dirty or lost
     print("\nthresholds: " + ("MISSED" if failed else "met"))
-    if failed:
-        print("  Which files, and why, before changing the numbers. The thresholds")
+
+    if dirty:
+        print(f"\n  {len(dirty)} files did not check clean. Unmodified LaTeX must.")
+        for row in dirty[:10]:
+            print(f"    {row['path']}")
+            print(f"      {row.get('diagnostic', '')}")
+    if lost:
+        print(f"\n  {len(lost)} files did not emit their own bytes. Transport must.")
+        for row in lost[:10]:
+            print(f"    {row['path']}")
+    if median < 0.90 or early > 0.10:
+        print("\n  Which files, and why, before changing the numbers. The thresholds")
         print("  were fixed before any corpus was measured; moving them now would")
         print("  make them a description of the result rather than a test of it.")
         for row in sorted(rows, key=lambda r: r["available"])[:10]:
-            print(f"    {row['available']:.3f}  {row['path']}")
+            print(f"    {row['available']:.3f}  {row.get('cause', '')}  {row['path']}")
     return 1 if failed else 0
 
 
@@ -138,10 +257,29 @@ def main():
     if args.verify:
         return verify(args.target)
 
-    rows = measure(args.target, args.binary)
+    # Resolved before use: two of the three measurements run with the working
+    # directory set to the document's own, so that its imports and bibliography
+    # resolve the way they do for its author. A relative binary path would stop
+    # existing there.
+    binary = os.path.abspath(args.binary)
+    if not os.path.exists(binary):
+        print(f"no binary at {binary}")
+        return 2
+    taken_by = instrument(binary)
+    print(f"measured by {taken_by['commit'] or 'unknown commit'}", end="")
+    print("" if taken_by["working_tree_clean"] else " (working tree dirty)")
+    rows = measure(args.target, binary)
     if args.out:
         with open(args.out, "w") as handle:
-            json.dump({"root": os.path.abspath(args.target), "files": rows}, handle, indent=2)
+            json.dump(
+                {
+                    "root": os.path.abspath(args.target),
+                    "measured_by": instrument(binary),
+                    "files": rows,
+                },
+                handle,
+                indent=2,
+            )
         print(f"manifest written to {args.out}\n")
     return report(rows)
 

--- a/tests/experiments/syntax-rewrite/README.md
+++ b/tests/experiments/syntax-rewrite/README.md
@@ -1,0 +1,50 @@
+# Phase 0a — rewriting a published paper, and what the language could not name
+
+Run 2026-08-30, on the author's published BRKGA+LLM paper (`sn-article.tex`, 1,865 lines, 14 figures,
+23 tables, 82 references, 62 citations). Every `\label`, `\ref` and `\cite` was converted mechanically to
+`@id`, `@ref` and `@cite` — 196 constructs — and the whole file checked and emitted.
+
+## The criterion, restated by the director before the numbers were read
+
+**"No queremos escribir menos, queremos ser más legible y más seguro."** The original gate counted
+delimiters and lines; that measured the wrong quantity, the same failure mode Gate 0b's threshold had. The
+numbers are recorded anyway, and they show why brevity was never the pillar: 196 constructs, −392 braces,
+−150 bytes — net writing effort is unchanged. TypeScript is the precedent: annotations *add* characters and
+won on the guarantee.
+
+What the rewrite measures under the corrected criterion is the **gap list** — everything the paper
+declares that the language cannot see — because every diagnostic names something the author declared, and
+what cannot be declared can never get a good error.
+
+## The gap list
+
+1. **Placement is unspeakable in a typed block.** `\figure(id){...}` emits `\begin{figure}` with no
+   `[ht]`. Measured over the author's corpus: **634 of 662** figure/table environments carry explicit
+   placement (96%) — `[t]` alone appears 247 times. A typed block that drops placement cannot express the
+   corpus's normal case, so annotated figures stay in the environment form and the block form goes unused.
+
+2. **A label declared as a package option is invisible.** `\begin{lstlisting}[label={lst:x}]` declares
+   `lst:x`; there is no `\label` to convert. An `@ref(lst:x)` is then a hard error against a correct
+   document. The paper has one; any listings-heavy paper has many.
+
+3. **A construct inside a known command's argument is silently inert.** `@ref(sec:s)` inside `\caption{}`,
+   `\footnote{}`, `\textbf{}` is ordinary bytes under `grammar.md` §8 ("Command argument" row) — *and is
+   emitted literally into the PDF, with exit 0 and no advisory*. The specified behaviour and the safe
+   behaviour disagree: a reader of the PDF sees `@ref(sec:s)` in a caption. The paper hit this once,
+   mechanically, on its first conversion. This is the highest-risk row of the list because it is silent in
+   exactly the place an author will not look.
+
+4. **Multi-key citation spacing is normalised.** `\cite{a, b}` → `@cite(a, b)` → `\cite{a,b}`. Renders
+   identically; byte-level transport of the *annotated* construct is not promised. Recorded, not a defect.
+
+## What held
+
+The converted paper checks clean (the two package-option labels excepted, per gap 2) and every reference
+and citation resolves against the real `.bib`. The conversion is mechanical — a regex, not judgement —
+which is itself evidence for the on-ramp: 196 constructs entered a real paper without reading it.
+
+## Boundary
+
+One paper, one author, mechanical conversion. The gap list is what this run surfaced, not a claim of
+completeness — the roadmap's own instruction for 0a ("record what the language does not let you name") is
+satisfied by the list existing and feeding grammar decisions, not by the list being finished.


### PR DESCRIPTION
The corpus instrument, the first external measurement, and the Phase 0a record. Issues #78 and #79 came out of it.

## The headline

**992 of 992 files** — two papers per cell of an 8-year × 6-field grid plus five multi-file books, none written by this project's author — **check clean unmodified and emit their own bytes exactly.** First evidence for either promise that does not come from the author's own corpus.

## What the corpus caught that ours could not

The quarantine ceiling passed at 9.6% against 10%, and the causes are the finding:

- **#78** — `grammar.md` §8 promises display-math environments as an exclusion region; the scanner implements no such set. `X \in [A, B)` — a half-open interval — inside `\begin{equation}` quarantines the file; the same bytes in `$…$` are fine. Cost a 2011 math paper 39% of its bytes, a cs.DS paper 59%, a hep-th draft 78%.
- **#79** — `\iff` is the kernel's ⟺, not a conditional; the `\if…` rule captures it even in prose.

## The instrument, hardened by its own failures

- The annotated/unannotated split is decided by the compiler's coverage figure. First run over a tree with our own fixtures reported 40+59 "failures" — every one a fixture written to fail.
- Every manifest records **what measured**: binary hash and commit. Measuring with a stale binary produced wrong conclusions three times in one day before this.
- `xtex confidence` now names what sat at the byte where recognition stopped, so 111 quarantines aggregate into 8 causes instead of 111 numbers.
- arXiv is crawled at its published rate, one request per three seconds, licence transcribed per paper from OAI-PMH.

## Phase 0a, run at last

Criterion as the director fixed it: **legibility and safety, not brevity** — the old delimiter-counting gate measured the wrong quantity, as Gate 0b's threshold did. 196 constructs entered a real published paper mechanically. The gap list:

1. **Placement is unspeakable in a typed block** — and 96% of 662 measured floats carry one.
2. **A label declared as a package option** (`lstlisting`'s `label={…}`) is invisible, so a correct `@ref` to it is a hard error.
3. **A construct inside a known command's argument is emitted literally into the PDF, with exit 0** — specified in §8, but silent in exactly the place an author will not look. The riskiest row.

Nothing here changes compiler behaviour; the two defect fixes are #78 and #79.