### PR TITLE
Bring the stacked deliveries into main

### DIFF
--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -1413,6 +1413,7 @@ mod bibliography_advisory_tests {
             },
             Unavailable::UnparsableEntry {
                 name: "refs.bib".to_owned(),
+                detail: "a value opened at line 3 is never closed".to_owned(),
             },
         ] {
             let message = bibliography_advisory(&table, &Bibliography::Unavailable(reason.clone()))

--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -282,7 +282,7 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
     // `\label` in an imported file declares its name for the root, exactly as
     // an `@id` there does.
     let mut labels: BTreeMap<String, xtex_core::source::Span> = BTreeMap::new();
-    let mut labels_available = true;
+    let mut labels_unavailable = None;
 
     while let Some(id) = pending.pop() {
         let name = sources
@@ -300,9 +300,16 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
             // One file that went dark makes the root's inventory a subset, and
             // a subset that looks complete turns every name it missed into a
             // false "not declared".
-            xtex_core::labels::Inventory::Unavailable(_) => labels_available = false,
+            xtex_core::labels::Inventory::Unavailable(reason) => labels_unavailable = Some(reason),
         }
         merge_declared(&mut declared, declared_in(&sources, id));
+        follow_latex_edges(
+            &loader,
+            id,
+            &mut sources,
+            &mut pending,
+            &mut labels_unavailable,
+        )?;
         let mut imports = Vec::new();
         document.walk(|node| {
             if let Node::Construct {
@@ -319,6 +326,7 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
             match loader.load(&path, Some(id), &mut sources) {
                 Ok(imported) => pending.push(imported),
                 Err(IoError::NotFound { .. } | IoError::Unresolvable { .. }) => {
+                    labels_unavailable = Some(xtex_core::labels::Unavailable::UnreadableEdge);
                     import_diagnostics.push(Diagnostic {
                         code: "XT1009",
                         entity: EntityClass::UnknownOpen,
@@ -342,7 +350,7 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
     // The author's own `\label` commands resolve `@ref` too, so annotating a
     // document one figure at a time does not report the unannotated ones as
     // missing. Merged across the root, like every other declaration.
-    let inventory = root_inventory(labels, labels_available);
+    let inventory = root_inventory(labels, labels_unavailable);
     let mut diagnostics = check_with_labels(&table, &bibliography, &inventory);
     diagnostics.extend(bibliography_advisory(&table, &bibliography));
     diagnostics.extend(check_documents(&sources, &documents, |source, name| {
@@ -353,30 +361,129 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
         base.join(name).is_file()
     }));
     diagnostics.extend(import_diagnostics);
-    let total_bytes: f64 = documents
-        .iter()
-        .filter_map(|document| sources.get(document.source()))
-        .map(|source| {
-            f64::from(u32::try_from(source.bytes().len()).expect("source exceeds u32 addressing"))
-        })
-        .sum();
-    let checked_bytes: f64 = documents
-        .iter()
-        .filter_map(|document| {
-            sources.get(document.source()).map(|source| {
-                document.coverage()
-                    * f64::from(
-                        u32::try_from(source.bytes().len()).expect("source exceeds u32 addressing"),
-                    )
-            })
-        })
-        .sum();
-    let coverage = if total_bytes == 0.0 {
-        1.0
-    } else {
-        checked_bytes / total_bytes
-    };
+    let coverage = root_coverage(&sources, &documents);
     Ok((sources, diagnostics, coverage, bibliography))
+}
+
+fn root_coverage(sources: &Sources, documents: &[xtex_core::document::Document]) -> f64 {
+    let mut total = 0.0;
+    let mut checked = 0.0;
+    for document in documents {
+        let Some(source) = sources.get(document.source()) else {
+            continue;
+        };
+        let bytes =
+            f64::from(u32::try_from(source.bytes().len()).expect("source exceeds u32 addressing"));
+        total += bytes;
+        checked += document.coverage() * bytes;
+    }
+    if total == 0.0 { 1.0 } else { checked / total }
+}
+
+fn follow_latex_edges(
+    loader: &impl SourceLoader,
+    id: SourceId,
+    sources: &mut Sources,
+    pending: &mut Vec<SourceId>,
+    unavailable: &mut Option<xtex_core::labels::Unavailable>,
+) -> Result<(), IoError> {
+    let (edges, computed) = sources
+        .get(id)
+        .map(|source| latex_inventory_edges(source.bytes()))
+        .unwrap_or_default();
+    if computed {
+        *unavailable = Some(xtex_core::labels::Unavailable::UnreadableEdge);
+    }
+    for path in edges {
+        match load_latex_edge(loader, &path, id, sources) {
+            Ok(included) => pending.push(included),
+            Err(error @ IoError::TooLarge { .. }) => return Err(error),
+            Err(_) => *unavailable = Some(xtex_core::labels::Unavailable::UnreadableEdge),
+        }
+    }
+    Ok(())
+}
+
+fn load_latex_edge(
+    loader: &impl SourceLoader,
+    path: &str,
+    relative_to: SourceId,
+    sources: &mut Sources,
+) -> Result<SourceId, IoError> {
+    if Path::new(path).extension().is_some() {
+        return loader.load(path, Some(relative_to), sources);
+    }
+    match loader.load(&format!("{path}.tex"), Some(relative_to), sources) {
+        Ok(id) => Ok(id),
+        Err(IoError::NotFound { .. }) => {
+            loader.load(&format!("{path}.xtex"), Some(relative_to), sources)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn latex_inventory_edges(bytes: &[u8]) -> (Vec<String>, bool) {
+    let mut edges = Vec::new();
+    let mut computed = false;
+    for span in xtex_core::scanner::readable_for(bytes, &["include", "input"]) {
+        let region = &bytes[span.start()..span.end()];
+        computed |= collect_latex_edges(region, &mut edges);
+    }
+    (edges, computed)
+}
+
+fn collect_latex_edges(mut region: &[u8], edges: &mut Vec<String>) -> bool {
+    let mut computed = false;
+    while let Some(at) = region.windows(2).position(|window| window == b"\\i") {
+        region = &region[at..];
+        let command_len = if region.starts_with(b"\\include") {
+            b"\\include".len()
+        } else if region.starts_with(b"\\input") {
+            b"\\input".len()
+        } else {
+            region = &region[2..];
+            continue;
+        };
+        if region
+            .get(command_len)
+            .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'@')
+        {
+            region = &region[command_len..];
+            continue;
+        }
+        let rest = &region[command_len..];
+        let whitespace = rest
+            .iter()
+            .position(|byte| !byte.is_ascii_whitespace())
+            .unwrap_or(rest.len());
+        let rest = &rest[whitespace..];
+        let Some(body) = rest.strip_prefix(b"{") else {
+            computed = true;
+            region = rest;
+            continue;
+        };
+        let Some(close) = body.iter().position(|byte| *byte == b'}') else {
+            return true;
+        };
+        let path = &body[..close];
+        if path
+            .iter()
+            .any(|byte| matches!(byte, b'\\' | b'{' | b'}' | b'#'))
+        {
+            computed = true;
+        } else if let Ok(path) = std::str::from_utf8(path) {
+            let path = path.trim();
+            if path.is_empty() {
+                computed = true;
+            } else {
+                edges.push(path.to_owned());
+            }
+        } else {
+            computed = true;
+        }
+        region = &body[close + 1..];
+    }
+    computed
 }
 
 fn literal_import(
@@ -1354,12 +1461,11 @@ fn report_record(
 /// whole inventory exists to prevent.
 fn root_inventory(
     labels: BTreeMap<String, xtex_core::source::Span>,
-    available: bool,
+    unavailable: Option<xtex_core::labels::Unavailable>,
 ) -> xtex_core::labels::Inventory {
-    if available {
-        xtex_core::labels::Inventory::Complete(labels)
-    } else {
-        xtex_core::labels::Inventory::Unavailable(xtex_core::labels::Unavailable::Quarantined)
+    match unavailable {
+        Some(reason) => xtex_core::labels::Inventory::Unavailable(reason),
+        None => xtex_core::labels::Inventory::Complete(labels),
     }
 }
 

--- a/crates/xtex-cli/tests/include_inventory.rs
+++ b/crates/xtex-cli/tests/include_inventory.rs
@@ -1,0 +1,175 @@
+//! Filesystem-level checks for LaTeX inventory edges.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT: AtomicU64 = AtomicU64::new(0);
+
+struct Case(PathBuf);
+
+impl Case {
+    fn new() -> Self {
+        let id = NEXT.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!("xtex-include-{}-{id}", std::process::id()));
+        fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+
+    fn write(&self, name: &str, text: &str) {
+        let path = self.0.join(name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, text).unwrap();
+    }
+
+    fn check(&self) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_xtex"))
+            .args(["check", "book.xtex"])
+            .current_dir(&self.0)
+            .output()
+            .unwrap()
+    }
+}
+
+impl Drop for Case {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn include_and_input_labels_share_the_root_inventory() {
+    let case = Case::new();
+    case.write(
+        "book.xtex",
+        "\\include{chapters/one}\n\\input{chapters/two}\n",
+    );
+    case.write("chapters/one.tex", "\\label{sec:one}\n");
+    case.write("chapters/two.xtex", "@ref(sec:one)\n@ref(sec:missing)\n");
+
+    let output = case.check();
+
+    assert_eq!(output.status.code(), Some(1));
+    let diagnostics = stdout(&output);
+    assert!(!diagnostics.contains("identifier `sec:one` is not declared"));
+    assert!(
+        diagnostics.contains("chapters/two.xtex:2:6"),
+        "{diagnostics}"
+    );
+    assert!(diagnostics.contains("identifier `sec:missing` is not declared"));
+}
+
+#[test]
+fn unreadable_or_quarantined_edges_suppress_missing_reference_errors() {
+    for root in [
+        "\\include{absent}\n@ref(sec:possibly-there)\n",
+        "\\include{dark}\n@ref(sec:possibly-there)\n",
+        "\\input{   }\n@ref(sec:possibly-there)\n",
+    ] {
+        let case = Case::new();
+        case.write("book.xtex", root);
+        case.write(
+            "dark.tex",
+            "\\catcode`\\@=11\n\\label{sec:possibly-there}\n",
+        );
+
+        let output = case.check();
+
+        assert!(output.status.success(), "{}", stderr(&output));
+        assert!(!stdout(&output).contains("XT1003"));
+    }
+}
+
+#[test]
+fn a_missing_import_reports_the_import_but_not_a_possibly_hidden_label() {
+    let case = Case::new();
+    case.write(
+        "book.xtex",
+        "@import(\"absent.xtex\")\n@ref(sec:possibly-there)\n",
+    );
+
+    let output = case.check();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout(&output).contains("XT1009"));
+    assert!(!stdout(&output).contains("XT1003"));
+}
+
+#[test]
+fn excluded_includes_are_not_followed() {
+    let case = Case::new();
+    case.write(
+        "book.xtex",
+        concat!(
+            "% \\include{comment}\n",
+            "\\begin{verbatim}\n\\include{verbatim}\n\\end{verbatim}\n",
+            "\\newcommand{\\loadit}{\\include{macro-body}}\n",
+            "@ref(sec:missing)\n",
+        ),
+    );
+
+    let output = case.check();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stdout(&output).contains("identifier `sec:missing` is not declared"));
+}
+
+#[test]
+fn a_computed_include_makes_the_inventory_unavailable_without_an_error() {
+    for root in [
+        "\\include{\\chaptername}\n@ref(sec:possibly-computed)\n",
+        "\\input\\othername\n@ref(sec:possibly-computed)\n",
+    ] {
+        let case = Case::new();
+        case.write("book.xtex", root);
+
+        let output = case.check();
+
+        assert!(output.status.success(), "{}", stderr(&output));
+        assert!(!stdout(&output).contains("XT1003"));
+    }
+}
+
+#[test]
+fn include_cycles_terminate() {
+    let case = Case::new();
+    case.write("book.xtex", "\\include{other}\n@ref(sec:other)\n");
+    case.write("other.tex", "\\input{book.xtex}\n\\label{sec:other}\n");
+
+    let output = case.check();
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert!(!stdout(&output).contains("XT1003"));
+}
+
+#[test]
+fn plain_latex_edges_do_not_change_emission() {
+    let case = Case::new();
+    let input = "before\\include{chapter}\nafter\n";
+    case.write("book.xtex", input);
+    case.write("chapter.tex", "chapter\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_xtex"))
+        .arg("book.xtex")
+        .current_dir(&case.0)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    assert_eq!(
+        fs::read(case.0.join("build/book.tex")).unwrap(),
+        input.as_bytes()
+    );
+    assert!(!Path::new(&case.0.join("build/chapter.tex")).exists());
+}

--- a/crates/xtex-core/src/bibliography.rs
+++ b/crates/xtex-core/src/bibliography.rs
@@ -48,6 +48,8 @@ pub enum Unavailable {
     UnparsableEntry {
         /// The resource the entry is in.
         name: String,
+        /// A location and description that can be printed without a source map.
+        detail: String,
     },
 }
 
@@ -64,8 +66,8 @@ impl Unavailable {
                 "the declared bibliography path is computed rather than literal".to_owned()
             }
             Self::Unreadable { name } => format!("`{name}` could not be read"),
-            Self::UnparsableEntry { name } => {
-                format!("an entry boundary in `{name}` could not be located")
+            Self::UnparsableEntry { name, detail } => {
+                format!("`{name}` did not parse — {detail}")
             }
         }
     }
@@ -287,11 +289,12 @@ pub fn assemble(
                 name: resource.name.clone(),
             });
         };
-        match keys_in_bib(&bytes) {
-            Some(found) => keys.extend(found),
-            None => {
+        match scan_bib(&bytes) {
+            Ok(found) => keys.extend(found),
+            Err(detail) => {
                 return Bibliography::Unavailable(Unavailable::UnparsableEntry {
                     name: resource.name.clone(),
+                    detail,
                 });
             }
         }
@@ -305,6 +308,10 @@ pub fn assemble(
 /// `@string` declare no citation key and are skipped.
 #[must_use]
 pub fn keys_in_bib(bytes: &[u8]) -> Option<BTreeSet<String>> {
+    scan_bib(bytes).ok()
+}
+
+fn scan_bib(bytes: &[u8]) -> Result<BTreeSet<String>, String> {
     let mut keys = BTreeSet::new();
     let mut at = 0usize;
     while at < bytes.len() {
@@ -320,32 +327,149 @@ pub fn keys_in_bib(bytes: &[u8]) -> Option<BTreeSet<String>> {
         let entry_type = bytes[type_start..cursor].to_ascii_lowercase();
         cursor = skip_space(bytes, cursor);
         let opener = match bytes.get(cursor) {
-            Some(b'{') => b'}',
-            Some(b'(') => b')',
+            Some(b'{') => (b'{', b'}'),
+            Some(b'(') => (b'(', b')'),
             _ => {
                 at = type_start;
                 continue;
             }
         };
+        let entry_line = line_at(bytes, cursor);
         cursor += 1;
-        if matches!(entry_type.as_slice(), b"comment" | b"preamble" | b"string") {
+        // `@comment` is the one entry type BibTeX does not read. It skips to the
+        // next `@` and resumes there, so an unbalanced brace inside a comment is
+        // not an error, and an entry a writer commented out by wrapping it is
+        // still a database entry. Measured against BibTeX 0.99e, both ways:
+        // `@comment{a stray { brace}` is accepted, and a `@book` inside a
+        // `@comment` still resolves when cited.
+        if entry_type == b"comment" {
             at = cursor;
             continue;
         }
+        let body_start = cursor;
+        let close = entry_end(
+            bytes,
+            cursor,
+            opener.0,
+            opener.1,
+            entry_line,
+            entry_type == b"preamble",
+        )?;
         let key_start = skip_space(bytes, cursor);
         let mut key_end = key_start;
-        while matches!(bytes.get(key_end), Some(b) if !b.is_ascii_whitespace() && *b != b',' && *b != opener)
+        while matches!(bytes.get(key_end), Some(b) if !b.is_ascii_whitespace() && *b != b',' && *b != opener.1)
         {
             key_end += 1;
         }
-        if key_end > key_start {
+        if !matches!(entry_type.as_slice(), b"preamble" | b"string") {
+            validate_field_separators(bytes, body_start, close)?;
+        }
+        if !matches!(entry_type.as_slice(), b"preamble" | b"string") && key_end > key_start {
             if let Ok(key) = std::str::from_utf8(&bytes[key_start..key_end]) {
                 keys.insert(key.to_owned());
             }
         }
-        at = key_end.max(cursor);
+        at = close + 1;
     }
-    Some(keys)
+    Ok(keys)
+}
+
+fn entry_end(
+    bytes: &[u8],
+    mut at: usize,
+    open: u8,
+    close: u8,
+    entry_line: usize,
+    mut value_position: bool,
+) -> Result<usize, String> {
+    let mut braces = Vec::new();
+    let mut quote = None;
+    while let Some(&byte) = bytes.get(at) {
+        if quote.is_some() && byte == b'"' && braces.is_empty() {
+            quote = None;
+        } else if quote.is_none() && value_position && byte == b'"' && braces.is_empty() {
+            quote = Some(line_at(bytes, at));
+            value_position = false;
+        } else if byte == b'{' {
+            braces.push(line_at(bytes, at));
+        } else if byte == b'}' && !braces.is_empty() {
+            braces.pop();
+        } else if byte == close && braces.is_empty() && quote.is_none() {
+            return Ok(at);
+        } else if braces.is_empty() && quote.is_none() {
+            if matches!(byte, b'=' | b'#') {
+                value_position = true;
+            } else if !byte.is_ascii_whitespace() {
+                value_position = false;
+            }
+        }
+        at += 1;
+    }
+    if let Some(line) = quote {
+        Err(format!(
+            "a quoted value opened at line {line} is never closed"
+        ))
+    } else if let Some(line) = braces.first() {
+        Err(format!("a value opened at line {line} is never closed"))
+    } else {
+        let delimiter = char::from(open);
+        Err(format!(
+            "an entry delimiter `{delimiter}` opened at line {entry_line} is never closed"
+        ))
+    }
+}
+
+fn validate_field_separators(bytes: &[u8], start: usize, end: usize) -> Result<(), String> {
+    let mut at = start;
+    let mut braces = 0usize;
+    let mut quoted = false;
+    while at < end {
+        match bytes[at] {
+            b'"' if braces == 0 => quoted = !quoted,
+            b'{' if !quoted => braces += 1,
+            b'}' if !quoted => braces = braces.saturating_sub(1),
+            _ => {}
+        }
+        if braces == 0
+            && !quoted
+            && matches!(bytes[at], b'}' | b'"' | b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z')
+        {
+            let mut next = at + 1;
+            while next < end && bytes[next].is_ascii_whitespace() {
+                next += 1;
+            }
+            let value_just_closed = matches!(bytes[at], b'}' | b'"');
+            if (value_just_closed || next > at + 1)
+                && bytes.get(next).is_some_and(u8::is_ascii_alphabetic)
+            {
+                let mut equals = next + 1;
+                while equals < end
+                    && (bytes[equals].is_ascii_alphanumeric() || bytes[equals] == b'_')
+                {
+                    equals += 1;
+                }
+                equals = skip_space(bytes, equals);
+                if bytes.get(equals) == Some(&b'=') {
+                    return Err(format!(
+                        "two fields at line {} have no comma between them",
+                        line_at(bytes, next)
+                    ));
+                }
+            }
+        }
+        at += 1;
+    }
+    Ok(())
+}
+
+fn line_at(bytes: &[u8], at: usize) -> usize {
+    let mut line = 1;
+    for &byte in &bytes[..at.min(bytes.len())] {
+        if byte == b'\n' {
+            line += 1;
+        }
+    }
+    line
 }
 
 fn find(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
@@ -546,6 +670,139 @@ mod tests {
     fn a_bib_entry_may_use_parentheses() {
         let keys = keys_in_bib(b"@article(paren_style, title = {T})").unwrap();
         assert!(keys.contains("paren_style"));
+    }
+
+    #[test]
+    fn validation_matches_bibtex_on_the_experiment_corpus() {
+        let rejected = [
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-01-unclosed-field.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-02-unclosed-entry.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-03-missing-comma.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-04-unclosed-quote.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-08-preamble-unbalanced.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-09-string-unbalanced.bib"
+            )
+            .as_slice(),
+            b"@article{k, title={A}year={2020}}",
+        ];
+        for bytes in rejected {
+            assert!(keys_in_bib(bytes).is_none());
+        }
+
+        let accepted = [
+            include_bytes!("../../../tests/experiments/bib-validator/corpus/bad-05-no-key.bib")
+                .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-06-stray-brace.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/bad-07-undefined-string.bib"
+            )
+            .as_slice(),
+            include_bytes!("../../../tests/experiments/bib-validator/corpus/ok-01-plain.bib")
+                .as_slice(),
+            include_bytes!("../../../tests/experiments/bib-validator/corpus/ok-02-quotes.bib")
+                .as_slice(),
+            include_bytes!("../../../tests/experiments/bib-validator/corpus/ok-03-strings.bib")
+                .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/ok-04-preamble-hash.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/ok-05-comment-and-junk.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/ok-06-nested-braces.bib"
+            )
+            .as_slice(),
+            include_bytes!("../../../tests/experiments/bib-validator/corpus/ok-07-concat.bib")
+                .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/ok-08-comment-unbalanced.bib"
+            )
+            .as_slice(),
+            include_bytes!(
+                "../../../tests/experiments/bib-validator/corpus/ok-09-comment-wraps-an-entry.bib"
+            )
+            .as_slice(),
+            b"@comment{\" is ordinary comment text}\n@book{k, title={T}}",
+            b"@article{k\"x, title={T}, year=2020}",
+        ];
+        for bytes in accepted {
+            assert!(keys_in_bib(bytes).is_some());
+        }
+    }
+
+    #[test]
+    fn a_comment_is_skipped_to_the_next_at_sign_the_way_bibtex_skips_it() {
+        // Both halves were settled by running the files through BibTeX 0.99e.
+        // It accepts an unbalanced brace inside `@comment`, because it never
+        // reads the body; and an entry a writer commented out by wrapping it
+        // still resolves when cited, because the skip stops at the next `@`.
+        // Validating the body would reject the first and lose the key in the
+        // second, and losing a key turns a correct `@cite` into `XT1005`.
+        let unbalanced = include_bytes!(
+            "../../../tests/experiments/bib-validator/corpus/ok-08-comment-unbalanced.bib"
+        );
+        assert_eq!(
+            keys_in_bib(unbalanced),
+            Some(BTreeSet::from(["k1".to_owned()]))
+        );
+
+        let wrapped = include_bytes!(
+            "../../../tests/experiments/bib-validator/corpus/ok-09-comment-wraps-an-entry.bib"
+        );
+        assert_eq!(
+            keys_in_bib(wrapped),
+            Some(BTreeSet::from([
+                "commented_out".to_owned(),
+                "k1".to_owned()
+            ]))
+        );
+    }
+
+    #[test]
+    fn an_invalid_file_makes_the_whole_bibliography_unavailable() {
+        let d = declared("\\bibliography{refs}");
+        let bibliography = assemble(&d, |_| Some(b"@book{k,\n title = {never closed\n".to_vec()));
+        assert_eq!(
+            bibliography,
+            Bibliography::Unavailable(Unavailable::UnparsableEntry {
+                name: "refs.bib".to_owned(),
+                detail: "a value opened at line 2 is never closed".to_owned(),
+            })
+        );
+        assert!(!bibliography.is_missing("anything"));
+
+        let mut sources = Sources::new();
+        let id = sources.add("main.xtex", b"@cite(anything)".to_vec());
+        let document = crate::parse(&sources, id);
+        let mut table = SymbolTable::new();
+        table.merge(&sources, &document);
+        assert!(
+            crate::check::check(&table, &bibliography)
+                .iter()
+                .all(|diagnostic| diagnostic.code != "XT1005")
+        );
     }
     /// The three outcomes issue #12 requires, driven through the real pipeline:
     /// parse, build the symbol table, assemble the bibliography, compare.

--- a/crates/xtex-core/src/labels.rs
+++ b/crates/xtex-core/src/labels.rs
@@ -33,6 +33,8 @@ pub enum Unavailable {
     /// A `\label` after that point cannot be seen, so the ones before it are a
     /// subset rather than a set.
     Quarantined,
+    /// A literal LaTeX project edge did not resolve or could not be read.
+    UnreadableEdge,
 }
 
 /// What a document's own `\label` commands amount to.

--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -344,7 +344,8 @@ impl SymbolTable {
         labels: &'a crate::labels::Inventory,
     ) -> impl Iterator<Item = (&'a str, &'a Reference)> {
         self.references.iter().filter_map(move |(name, reference)| {
-            (reference.kind == EntryToken::Ref
+            (matches!(labels, crate::labels::Inventory::Complete(_))
+                && reference.kind == EntryToken::Ref
                 && !self.declarations.contains_key(name)
                 && !labels.contains(name))
             .then_some((name.as_str(), reference))
@@ -589,6 +590,15 @@ mod tests {
         )]);
         let unresolved: Vec<_> = t.unresolved_references().map(|(n, _)| n).collect();
         assert_eq!(unresolved, ["missing"]);
+    }
+
+    #[test]
+    fn an_unavailable_label_inventory_reports_nothing_missing() {
+        let (_, t) = table(&[("a.xtex", "@ref(possibly-in-an-unread-file)")]);
+        let labels =
+            crate::labels::Inventory::Unavailable(crate::labels::Unavailable::UnreadableEdge);
+
+        assert_eq!(t.unresolved_against(&labels).count(), 0);
     }
 
     #[test]

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -232,7 +232,9 @@ diagnostic that survives is about the file, not about the citation.
 - **`ComputedPath`** — a declaration whose path is built by a macro rather than written literally. It cannot
   be resolved without running TeX, which the compiler does not do.
 - **`Unreadable`** — a declared resource was not found.
-- **`UnparsableEntry`** — an entry in a resource that was read has no locatable boundary.
+- **`UnparsableEntry`** — a resource was read and does not parse. Four shapes are detected, and they are the
+  four that BibTeX itself rejects: a field value whose `{` never closes, an entry whose delimiter never
+  closes, two fields with no comma between them, and a quoted value whose `"` never closes.
 
 When the document contains at least one `@cite`, an `Unavailable` bibliography is reported as advisory
 `XT2001` without being asked for. The construct requested a check; printing `coverage` and exiting `0`
@@ -288,8 +290,21 @@ crate would silence citation checking for that document entirely — trading a d
 a file that works.
 
 The key reader locates entry keys and nothing else. It does not read fields, resolve `@string` macros, or
-validate an entry, because none of that is needed to answer the only question asked: does this key exist.
+interpret a value, because none of that is needed to answer the only question asked: does this key exist.
 `@string`, `@comment` and `@preamble` declare no citation key and are skipped.
+
+Validating the file is a separate job from reading its keys, and separating them is what makes it cheap. The
+reader must be lenient and must never fail, because a failure silences citation checking for the whole
+document. The validator is strict, and because a failure only reaches the author as an advisory it can
+afford to be. Detecting a broken file does not require understanding a correct one, so no BibTeX parser is
+involved and no dependency was added.
+
+`@comment` is the one entry type BibTeX does not read: it skips to the next `@` and resumes there. So an
+unbalanced brace inside a comment is not an error, and an entry a writer commented out by wrapping it is
+still a database entry that resolves when cited. `@preamble` and `@string` are read, and BibTeX does reject
+an unbalanced brace in either. Reproduce all of it with
+[`tests/experiments/bib-validator`](../tests/experiments/bib-validator/), whose ground truth is BibTeX 0.99e
+rather than a reading of the grammar.
 
 Reproduce it with [`tests/experiments/bib-parser`](../tests/experiments/bib-parser/). The evidence above is
 a single run over one author's corpus, and it is what the decision rests on. A corpus where the crate parses

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -314,8 +314,11 @@ everything and the hand reader disagrees anywhere would reverse it.
 
 ## 8 · References
 
-An `@ref` whose identifier no `@id` declares is `XT1003`. The scope is the document root — its root file
-plus everything reached through `@import` — which matches LaTeX, where a label is document-wide.
+An `@ref` whose identifier neither an `@id` nor a completely inventoried source `\label` declares is
+`XT1003`. The symbol scope is the document root — its root file plus everything reached through `@import`.
+The label inventory additionally follows literal `\include` and `\input` paths in readable content, matching
+the assembly the author already wrote without changing emission. If any such file cannot be resolved, read or
+parsed through the end, the whole inventory is unavailable and `XT1003` is silent.
 
 Two `@id` constructs declaring the same identifier in one root is `XT1001`, blamed on the later one. The
 first declaration is not at fault for existing.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -305,15 +305,22 @@ imposing a project-wide one on separately emitted documents.
 `@id(sec:intro)` emits `\label{sec:intro}` at the annotation's source position, and nothing else — no
 wrapper, no support command.
 
-Before emission each root builds a **label inventory**. `\label` is a built-in known command with signature
+Before checking each root builds a **label inventory**. `\label` is a built-in known command with signature
 `m`, so its mandatory argument is selectable under §8 even though its bytes are otherwise opaque. A label
 enters the inventory only when it is tokenized as `\label` under default category codes, occurs outside every
 §8 exclusion region, has one balanced braced argument, and that argument is an `ident` after trimming ASCII
 whitespace.
 
+The inventory also follows literal `\include{…}` and `\input{…}` paths in readable content, transitively.
+An omitted extension resolves first to `.tex`, then to `.xtex`. These commands remain transported bytes: they
+do not become imports, add files to emission, or change page breaks. A command in a comment, verbatim region
+or macro definition is not an edge.
+
 The inventory is `Complete` or `Unavailable`. It becomes `Unavailable` when quarantine begins, a category-code
-change prevents reliable tokenization, or a candidate argument cannot be bounded. None of those is an error
-for an unannotated document.
+change prevents reliable tokenization, a candidate argument cannot be bounded, an inventory edge is computed,
+or any literal edge cannot be resolved and read completely. None of those is an error for an unannotated
+document, and no identifier may be reported absent from an unavailable inventory. A configured resource
+limit remains fatal rather than being treated as evidence about the document.
 
 When `Complete`, an `@id(x)` colliding with another `@id(x)` or with a source `\label{x}` is a hard error
 blamed on the `@id`; nothing is emitted. The source `\label{x}` is never itself an error.

--- a/tests/experiments/bib-validator/README.md
+++ b/tests/experiments/bib-validator/README.md
@@ -53,8 +53,33 @@ crates.io is MIT or MIT/Apache-2.0. Three other things are.
 all. It is not a candidate: it needs an `.aux` and a `.bst`, and using it would mean running the program,
 which the compiler does not do.
 
+## What the corpus decided
+
+The validator that came out of this is a detector, not a parser: it locates the four shapes BibTeX rejects
+and nothing else. Finding keys and validating syntax stay separate jobs, because the key reader must never
+fail — a failure silences citation checking for a whole document — while a validator only produces an
+advisory and so can afford to be strict.
+
+Two files in the corpus were added after the first attempt, because they refuted it.
+
+**`@comment` is the one entry type BibTeX does not read.** It skips to the next `@` and resumes there. A
+validator that checks the body instead rejects `ok-08`, which BibTeX accepts, and that is the expensive
+direction of error: a false rejection costs a document its citation checking.
+
+**A commented-out entry is still a database entry.** In `ok-09` a `@book` sits inside a `@comment{...}`
+wrapper. Because BibTeX's skip stops at the next `@`, it reads that entry and resolves it when cited —
+verified by citing `commented_out` and watching BibTeX not complain. A validator that skipped to the
+comment's closing brace would lose the key, and a lost key turns a correct `@cite` into `XT1005` against an
+author who did nothing wrong.
+
+`bad-08` and `bad-09` are the other side of the same question: BibTeX *does* check brace balance inside
+`@preamble` and `@string`, and rejects both. The three types are not interchangeable.
+
 ## Boundary
 
-One run. The seven malformed shapes were chosen by hand, and a different set could reorder the table. The 37
-real files are one author's corpus. What the numbers support is a decision about this codebase, not a claim
+One run. The malformed shapes were chosen by hand, and a different set could reorder the table. The 37 real
+files are one author's corpus. Eighteen further probes — CRLF endings, parenthesis-delimited entries, an `@`
+inside a value, a URL with `%` and `=`, non-ASCII names, `#` concatenation — agree with BibTeX, and one of
+them does not: BibTeX counts a backslash-escaped `\{` as an opening brace and rejects the file, where the
+validator accepts it. That is a shape it does not detect, not a file it wrongly rejects. What the numbers support is a decision about this codebase, not a claim
 about BibTeX parsers in general.

--- a/tests/experiments/bib-validator/README.md
+++ b/tests/experiments/bib-validator/README.md
@@ -1,0 +1,60 @@
+# What a broken `.bib` looks like, and who notices
+
+`#64` made the compiler say when it could not *read* a bibliography. It still says nothing when it reads one
+that is *broken*. This measures what it would take to notice, and what it would cost.
+
+## Ground truth is BibTeX, not judgement
+
+Whether a `.bib` file is "valid" is not a question about the BibTeX grammar in the abstract. It is a question
+about the program that consumes it. `groundtruth.py` runs each file through **BibTeX 0.99e** over a minimal
+`.aux` that cites everything, and records whether it reported an error.
+
+```sh
+python3 groundtruth.py corpus/*.bib
+```
+
+Result, BibTeX 0.99e (TeX Live 2026):
+
+| Files | Verdict |
+|---|---|
+| `bad-01` … `bad-04` | rejected — `Illegal end of database file`, `I was expecting a ',' or a '}'`, `Unbalanced braces` |
+| `bad-05` … `bad-07` | **accepted**, with warnings — an empty key, a stray brace, an undefined `@string` |
+| `ok-01` … `ok-07` | accepted |
+
+The three `bad-` files BibTeX accepts are in the corpus deliberately. A validator that rejects them is wrong,
+however reasonable the rejection looks.
+
+## What the candidates do
+
+The same 14 files, plus 37 real `.bib` files from the author's projects, through both crates and our own key
+reader. Measured 2026-08-29.
+
+| | Detects the 4 real errors | Falsely rejects a valid file | Message | New dependencies |
+|---|---|---|---|---|
+| our key reader | **0 of 4** | 0 | — | 0 |
+| `nom-bibtex` 0.6, MIT | 4 of 4 | 0 of 44 | unusable | +12 crates, two versions of `nom` |
+| `biblatex` 0.12, MIT OR Apache-2.0 | 4 of 4 | **3 of 44** | clear | +8 crates |
+
+Licence was the first thing checked and it turned out not to be the constraint: every serious candidate on
+crates.io is MIT or MIT/Apache-2.0. Three other things are.
+
+1. **`nom-bibtex`'s message names its own combinators.** For an unclosed brace on line 3 of a 5-line file:
+   `Parsing error. Reason: 0: at line 1, in IsNot: @book{knuth1984, ^`.
+2. **No parser locates the author's mistake for an unclosed delimiter.** `biblatex` reports byte 96 of a
+   96-byte file; BibTeX itself says `Illegal end of database file---line 5`. A delimiter that never closes is
+   only detectable at end of input, so "parsing stopped here" is the strongest honest claim available.
+3. **`biblatex`'s three false rejections include a real file.** `irace-package.bib`, shipped in the `irace` R
+   package, opens with an `@preamble` concatenating brace groups with `#`; the crate expects a quotation mark
+   and stops at byte 12. It also rejects an undefined `@string`, which BibTeX only warns about. Under
+   [`checking.md`](../../../docs/checking.md) §7 each of those silences citation checking for a whole
+   document.
+
+`tectonic_engine_bibtex` (MIT) is BibTeX itself as a crate, and is the reason ground truth was available at
+all. It is not a candidate: it needs an `.aux` and a `.bst`, and using it would mean running the program,
+which the compiler does not do.
+
+## Boundary
+
+One run. The seven malformed shapes were chosen by hand, and a different set could reorder the table. The 37
+real files are one author's corpus. What the numbers support is a decision about this codebase, not a claim
+about BibTeX parsers in general.

--- a/tests/experiments/bib-validator/corpus/bad-01-unclosed-field.bib
+++ b/tests/experiments/bib-validator/corpus/bad-01-unclosed-field.bib
@@ -1,0 +1,5 @@
+@book{knuth1984,
+  author = {Knuth, Donald E.},
+  title  = {The {\TeX}book,
+  year   = {1984}
+}

--- a/tests/experiments/bib-validator/corpus/bad-02-unclosed-entry.bib
+++ b/tests/experiments/bib-validator/corpus/bad-02-unclosed-entry.bib
@@ -1,0 +1,1 @@
+@book{k1, author = {A}, year = {1984}

--- a/tests/experiments/bib-validator/corpus/bad-03-missing-comma.bib
+++ b/tests/experiments/bib-validator/corpus/bad-03-missing-comma.bib
@@ -1,0 +1,1 @@
+@book{k1, author = {A} year = {1984}}

--- a/tests/experiments/bib-validator/corpus/bad-04-unclosed-quote.bib
+++ b/tests/experiments/bib-validator/corpus/bad-04-unclosed-quote.bib
@@ -1,0 +1,1 @@
+@article{k1, author = "Lamport, title = {T}, year = 1994}

--- a/tests/experiments/bib-validator/corpus/bad-05-no-key.bib
+++ b/tests/experiments/bib-validator/corpus/bad-05-no-key.bib
@@ -1,0 +1,1 @@
+@book{, author = {A}, year = {1984}}

--- a/tests/experiments/bib-validator/corpus/bad-06-stray-brace.bib
+++ b/tests/experiments/bib-validator/corpus/bad-06-stray-brace.bib
@@ -1,0 +1,1 @@
+@book{k1, author = {A}}, year = {1984}}

--- a/tests/experiments/bib-validator/corpus/bad-07-undefined-string.bib
+++ b/tests/experiments/bib-validator/corpus/bad-07-undefined-string.bib
@@ -1,0 +1,1 @@
+@article{k1, publisher = nosuchstring, title = {T}, year = 2000}

--- a/tests/experiments/bib-validator/corpus/bad-08-preamble-unbalanced.bib
+++ b/tests/experiments/bib-validator/corpus/bad-08-preamble-unbalanced.bib
@@ -1,0 +1,2 @@
+@preamble{ {\noop} { unbalanced }
+@book{k1, title = {T}}

--- a/tests/experiments/bib-validator/corpus/bad-09-string-unbalanced.bib
+++ b/tests/experiments/bib-validator/corpus/bad-09-string-unbalanced.bib
@@ -1,0 +1,2 @@
+@string{jj = {unbalanced { here}}
+@article{k1, journal = jj}

--- a/tests/experiments/bib-validator/corpus/ok-01-plain.bib
+++ b/tests/experiments/bib-validator/corpus/ok-01-plain.bib
@@ -1,0 +1,5 @@
+@book{knuth1984,
+  author = {Knuth, Donald E.},
+  title  = {The {\TeX}book},
+  year   = {1984}
+}

--- a/tests/experiments/bib-validator/corpus/ok-02-quotes.bib
+++ b/tests/experiments/bib-validator/corpus/ok-02-quotes.bib
@@ -1,0 +1,1 @@
+@article{lamport1994, author = "Lamport, Leslie", title = "LaTeX", year = "1994"}

--- a/tests/experiments/bib-validator/corpus/ok-03-strings.bib
+++ b/tests/experiments/bib-validator/corpus/ok-03-strings.bib
@@ -1,0 +1,2 @@
+@string{acm = {Association for Computing Machinery}}
+@inproceedings{a1, author = {A}, publisher = acm, year = 2020}

--- a/tests/experiments/bib-validator/corpus/ok-04-preamble-hash.bib
+++ b/tests/experiments/bib-validator/corpus/ok-04-preamble-hash.bib
@@ -1,0 +1,2 @@
+@preamble{ {\newcommand{\noopsort}[1]{}} # {\newcommand{\singleletter}[1]{#1}} }
+@book{irace1, author = {L{\'o}pez-Ib{\'a}{\~n}ez, Manuel}, title = {irace}, year = {2016}}

--- a/tests/experiments/bib-validator/corpus/ok-05-comment-and-junk.bib
+++ b/tests/experiments/bib-validator/corpus/ok-05-comment-and-junk.bib
@@ -1,0 +1,3 @@
+This text outside an entry is ignored by BibTeX.
+@comment{anything at all here}
+@misc{m1, title = {M}, year = {2021}}

--- a/tests/experiments/bib-validator/corpus/ok-06-nested-braces.bib
+++ b/tests/experiments/bib-validator/corpus/ok-06-nested-braces.bib
@@ -1,0 +1,1 @@
+@book{b1, title = {A {Nested {Deeply} Braced} Title}, year = {1999}}

--- a/tests/experiments/bib-validator/corpus/ok-07-concat.bib
+++ b/tests/experiments/bib-validator/corpus/ok-07-concat.bib
@@ -1,0 +1,2 @@
+@string{jan = "January"}
+@article{c1, month = jan # " 15", title = {T}, year = 2000}

--- a/tests/experiments/bib-validator/corpus/ok-08-comment-unbalanced.bib
+++ b/tests/experiments/bib-validator/corpus/ok-08-comment-unbalanced.bib
@@ -1,0 +1,2 @@
+@comment{a stray { brace}
+@book{k1, title = {T}}

--- a/tests/experiments/bib-validator/corpus/ok-09-comment-wraps-an-entry.bib
+++ b/tests/experiments/bib-validator/corpus/ok-09-comment-wraps-an-entry.bib
@@ -1,0 +1,4 @@
+@comment{
+@book{commented_out, title = {T}}
+}
+@book{k1, title = {T}}

--- a/tests/experiments/bib-validator/groundtruth.py
+++ b/tests/experiments/bib-validator/groundtruth.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Ground truth: what real BibTeX 0.99e does with a .bib file.
+
+Runs bibtex over a minimal .aux that cites everything, and records whether it
+reported an error. This is the reference the survey is measured against: the
+question is never "is this file good BibTeX" in the abstract, it is "does the
+program that consumes it accept it".
+"""
+import os, re, shutil, subprocess, sys, tempfile
+
+def run(bib):
+    d = tempfile.mkdtemp()
+    try:
+        shutil.copy(bib, os.path.join(d, "refs.bib"))
+        with open(os.path.join(d, "x.aux"), "w") as f:
+            f.write("\\relax\n\\citation{*}\n\\bibstyle{plain}\n\\bibdata{refs}\n")
+        r = subprocess.run(["bibtex", "x"], cwd=d, capture_output=True, text=True)
+        out = r.stdout + r.stderr
+        errors = [l for l in out.splitlines()
+                  if re.search(r"^(I was expecting|Sorry|Illegal|You're missing|Repeated entry"
+                               r"|A bad cross reference|I found no|Warning--|.*---line \d+)", l)
+                  or "error message" in l]
+        hard = [l for l in errors if not l.startswith("Warning--")]
+        return r.returncode, hard, out
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+for bib in sys.argv[1:]:
+    code, hard, out = run(bib)
+    verdict = "REJECT" if hard else "accept"
+    print(f"{verdict:7} exit={code}  {os.path.basename(bib)}")
+    for l in hard[:2]:
+        print(f"         {l.strip()[:100]}")


### PR DESCRIPTION
Process defect, found because a fixture started erroring again. **PRs #67 and #76 never reached main**: they were stacked, so their bases were other branches — #67 merged into `64-bibliography-advisory-by-default`, #76 into `66-bib-validator` — and merging them closed the PRs without touching main. Main today lacks the `.bib` validator (#66) and the `\include` inventory edges (#68), both reviewed and approved.

This PR is a single merge of `68-include-inventory-edges` (which contains the full stack) into current main. The merge was clean — no conflicts — because the later work (#77, #80, #84) touched different files.

## Verified on the merged result

| Check | Result |
|---|---|
| full test suite | 204 tests, 0 failures |
| `fmt`, `clippy -D warnings` | clean |
| external corpus, 992 files | both promises 992/992 |
| workspace sweep | 251 files, 0 non-zero — the fixture that exposed the gap is silent again |

## For next time

Stacked PRs need their base retargeted to main after the parent merges (`gh pr edit --base main`), or they close without landing. My mistake to set them up without saying that; the review flow itself caught it — the fixture regressed and the sweep noticed.