### PR TITLE
Let a typed block speak placement

### DIFF
--- a/crates/xtex-core/src/blocks.rs
+++ b/crates/xtex-core/src/blocks.rs
@@ -45,6 +45,10 @@ impl BlockKind {
             (Self::Figure | Self::Table, b"caption") | (Self::Table, b"body" | b"trailing") => {
                 Some(ValueKind::Braced)
             }
+            // Decided by the director, 2026-08-30 (issue #81), after Phase 0a
+            // measured that 96% of the corpus's floats carry explicit
+            // placement and the block could not say it.
+            (Self::Figure | Self::Table, b"placement") => Some(ValueKind::Placement),
             _ => None,
         }
     }
@@ -56,6 +60,7 @@ enum ValueKind {
     Str,
     LengthOrPercentage,
     Braced,
+    Placement,
 }
 
 /// A field's value, as it appears in the source.
@@ -70,6 +75,8 @@ pub enum Value {
     Percentage(Span),
     /// Balanced braces. The span covers them.
     Braced(Span),
+    /// A float placement specifier: bytes from `htbp!H`, unquoted.
+    Placement(Span),
 }
 
 impl Value {
@@ -77,7 +84,11 @@ impl Value {
     #[must_use]
     pub const fn span(self) -> Span {
         match self {
-            Self::Str(s) | Self::Length(s) | Self::Percentage(s) | Self::Braced(s) => s,
+            Self::Str(s)
+            | Self::Length(s)
+            | Self::Percentage(s)
+            | Self::Braced(s)
+            | Self::Placement(s) => s,
         }
     }
 }
@@ -135,6 +146,13 @@ pub enum BlockError {
     },
     /// A field has no `=`.
     MissingEquals(Span),
+    /// A placement letter LaTeX's float mechanism does not accept.
+    BadPlacementByte {
+        /// The offending byte's span, one byte long.
+        at: Span,
+        /// The byte itself, for the message.
+        byte: u8,
+    },
 }
 
 /// Whether a rejected field was removed from the specification, or never in it.
@@ -221,7 +239,8 @@ pub fn parse_block(
         if bytes.get(at) != Some(&b'=') {
             return Err(BlockError::MissingEquals(key));
         }
-        at = skip_whitespace(bytes, at + 1);
+        let after_equals = at + 1;
+        at = skip_whitespace(bytes, after_equals);
 
         let Some(expected) = kind.value_kind(&bytes[key.start()..key.end()]) else {
             return Err(BlockError::UnknownField {
@@ -230,12 +249,35 @@ pub fn parse_block(
             });
         };
 
+        // A bare value ends at its line, so a bare field whose line holds
+        // nothing is empty — not a licence to take the next line's key as the
+        // value. Writing the field and saying nothing is malformed; silence
+        // stays the author's explicit choice of omitting the field.
+        if expected == ValueKind::Placement
+            && bytes[after_equals..at.min(body_end)].contains(&b'\n')
+        {
+            return Err(BlockError::WrongValueKind {
+                key,
+                expected: describe(expected),
+            });
+        }
         let (value, next) = read_value(bytes, at, body_end, expected).ok_or({
             BlockError::WrongValueKind {
                 key,
                 expected: describe(expected),
             }
         })?;
+        if let Value::Placement(placement) = value {
+            for (offset, byte) in bytes[placement.start()..placement.end()].iter().enumerate() {
+                if !is_placement_byte(*byte) {
+                    let at = placement.start() + offset;
+                    return Err(BlockError::BadPlacementByte {
+                        at: span(at, at + 1),
+                        byte: *byte,
+                    });
+                }
+            }
+        }
         fields.push(Field { key, value });
         at = skip_whitespace(bytes, next);
     }
@@ -263,6 +305,9 @@ const fn describe(kind: ValueKind) -> &'static str {
             "a length such as 4cm or 0.8\\columnwidth, or a percentage such as 80%"
         }
         ValueKind::Braced => "a braced group, because it may span lines and contain LaTeX",
+        ValueKind::Placement => {
+            "one or more of the letters h, t, b, p, H and `!`, written without quotes"
+        }
     }
 }
 
@@ -328,7 +373,30 @@ fn read_value(
             let end = balanced_end(bytes, at)?;
             Some((Value::Braced(span(at, end)), end))
         }
+        ValueKind::Placement => {
+            let mut i = at;
+            while i < limit && !bytes[i].is_ascii_whitespace() && bytes[i] != b'}' {
+                i += 1;
+            }
+            // `placement =` followed by nothing is malformed, not "no
+            // brackets": silence must stay the author's explicit choice of
+            // omitting the field.
+            if i == at {
+                return None;
+            }
+            Some((Value::Placement(span(at, i)), i))
+        }
     }
+}
+
+/// The bytes LaTeX's float mechanism accepts in a placement specifier.
+///
+/// `h t b p !` are LaTeX's own; `H` is the `float` package's. Whether that
+/// package is loaded is a package fact and stays unvalidated, like every
+/// other package fact. The value is emitted verbatim — no reordering, no
+/// deduplication — because the compiler does not improve author intent.
+const fn is_placement_byte(byte: u8) -> bool {
+    matches!(byte, b'h' | b't' | b'b' | b'p' | b'!' | b'H')
 }
 
 fn is_identifier(bytes: &[u8]) -> bool {
@@ -382,6 +450,49 @@ mod tests {
             "\\figure(fig:r) {\n  src = \"r.pdf\"\n  width = 80%\n  caption = {A caption}\n}";
         assert_eq!(keys(input), ["src", "width", "caption"]);
         assert_eq!(parse(input).unwrap().kind, BlockKind::Figure);
+    }
+
+    #[test]
+    fn placement_reads_the_corpus_forms_and_stops_at_the_line() {
+        // The corpus's frequent forms, per issue #81. The value is bare and
+        // ends at its line.
+        for form in ["t", "h", "ht", "!htbp", "!ht", "b", "H"] {
+            let input = format!("\\figure(f) {{\n  placement = {form}\n  caption = {{x}}\n}}");
+            let block = parse_block(input.as_bytes(), BlockKind::Figure, 0, b"\\figure(".len())
+                .expect(form);
+            let field = &block.fields[0];
+            let Value::Placement(span) = field.value else {
+                panic!("{form} did not parse as a placement")
+            };
+            assert_eq!(&input.as_bytes()[span.start()..span.end()], form.as_bytes());
+            assert_eq!(block.fields.len(), 2, "{form} swallowed the caption");
+        }
+    }
+
+    #[test]
+    fn a_placement_byte_latex_would_reject_names_itself() {
+        let input = "\\table(t) {\n  placement = htq\n  caption = {x}\n}";
+        let error = parse_block(input.as_bytes(), BlockKind::Table, 0, b"\\table(".len())
+            .expect_err("q is not a placement letter");
+        let BlockError::BadPlacementByte { at, byte } = error else {
+            panic!("wrong error: {error:?}")
+        };
+        assert_eq!(byte, b'q');
+        assert_eq!(&input.as_bytes()[at.start()..at.end()], b"q");
+    }
+
+    #[test]
+    fn an_empty_placement_is_malformed_not_a_licence_to_read_the_next_line() {
+        // `placement =` followed by a line ending must not take the next
+        // line's key as its value. Writing the field and saying nothing is
+        // malformed; omitting the field is how silence is asked for.
+        let input = "\\figure(f) {\n  placement =\n  caption = {x}\n}";
+        let error = parse_block(input.as_bytes(), BlockKind::Figure, 0, b"\\figure(".len())
+            .expect_err("an empty placement is malformed");
+        assert!(
+            matches!(error, BlockError::WrongValueKind { .. }),
+            "wrong error: {error:?}"
+        );
     }
 
     #[test]

--- a/crates/xtex-core/src/check.rs
+++ b/crates/xtex-core/src/check.rs
@@ -336,6 +336,15 @@ fn block_error(source: SourceId, kind: BlockKind, error: BlockError, bytes: &[u8
             false,
             false,
         ),
+        BlockError::BadPlacementByte { at, byte } => (
+            at,
+            format!(
+                "`{}` is not a placement letter; LaTeX accepts h, t, b, p, `!` and the float package's H",
+                char::from(byte)
+            ),
+            false,
+            false,
+        ),
     };
     Diagnostic {
         code: if identifier_error {

--- a/crates/xtex-core/src/lib.rs
+++ b/crates/xtex-core/src/lib.rs
@@ -477,7 +477,15 @@ fn emit_block(token: EntryToken, bytes: &[u8], view: RevisionView, out: &mut Vec
 
     out.extend_from_slice(b"\\begin{");
     out.extend_from_slice(environment);
-    out.extend_from_slice(b"}\n");
+    out.push(b'}');
+    // Verbatim inside the brackets: no reordering, no deduplication. The
+    // compiler does not improve author intent. `decisions/0006`.
+    if let Some(placement) = field(b"placement") {
+        out.push(b'[');
+        copy_value(bytes, placement.value, false, out);
+        out.push(b']');
+    }
+    out.push(b'\n');
     if kind == BlockKind::Table || field(b"src").is_some() {
         out.extend_from_slice(b"  \\centering\n");
     }

--- a/docs/decisions/0006-placement.md
+++ b/docs/decisions/0006-placement.md
@@ -1,0 +1,38 @@
+# 0006 · A typed block speaks placement
+
+**Status:** accepted, 2026-08-30. Decided by the director.
+**Issue:** [#81](https://github.com/camilochs/exacttex/issues/81)
+
+Phase 0a rewrote a published paper into the syntax and measured the gap that forced this: **634 of 662
+figure and table environments in the author's corpus carry an explicit placement specifier (96%)** — `[t]`
+alone appears 247 times. A typed block that cannot say `[ht]` cannot hold the corpus's normal case, so the
+block form would go unused and the checked path with it.
+
+## The chosen form
+
+A `placement` field with a bare value:
+
+```
+\figure(fig:cd) {
+  placement = !htbp
+  ...
+}
+```
+
+Zero new grammar: one more row in the §5 field tables, using the `bare` value kind that already existed.
+
+## Rejected
+
+- **Brackets after the identifier** — `\figure(fig:cd)[!htbp] { … }`. Reads familiar, but adds a grammar
+  position to the block header, and the header is exactly what the §3 boundary rule keeps minimal.
+- **A quoted string** — `placement = "!htbp"`. Quote noise for a value that never holds a space.
+
+## Three rules that carry the semantics
+
+1. Valid bytes are `h t b p !` (LaTeX's own) and `H` (the `float` package's), in any order. Anything else
+   is a hard error naming the byte. Whether `float` is loaded is a package fact and stays unvalidated,
+   like every other package fact.
+2. The value is emitted verbatim inside `[ ]` — no reordering, no deduplication. The compiler does not
+   improve author intent.
+3. An empty field is malformed. Omitting the field is how no-brackets is asked for; writing the field and
+   saying nothing is an error, not a synonym.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -447,7 +447,14 @@ figure-fields:
   width     = length | percentage
   height    = length | percentage
   caption   = braced
+  placement = bare
 ```
+
+`placement` holds a float placement specifier — bytes from `h t b p !`, plus the `float` package's `H` — and
+emits verbatim inside `[ ]` after the environment header: `placement = !htbp` emits `\begin{figure}[!htbp]`.
+No reordering, no deduplication; the compiler does not improve author intent. An absent field emits no
+brackets. A present, empty field is malformed: silence is asked for by omission, never by an empty value.
+Any other byte is a hard error naming the byte. See [`decisions/0006`](decisions/0006-placement.md).
 
 ### Table fields
 
@@ -456,6 +463,7 @@ table-fields:
   caption   = braced
   body      = braced
   trailing  = braced
+  placement = bare
 ```
 
 `trailing` contains content placed inside the emitted `table` environment after the table body and before

--- a/tests/fixtures/emission/07-placement/emitted.tex
+++ b/tests/fixtures/emission/07-placement/emitted.tex
@@ -1,0 +1,17 @@
+BEFORE
+\begin{figure}[!htbp]
+  \centering
+  \includegraphics[width=\linewidth]{figures/cdplot.pdf}
+  \caption{A diagram.}
+  \label{fig:cd}
+\end{figure}
+MIDDLE
+\begin{table}[t]
+  \centering
+  \caption{Data}
+\begin{tabular}{ll}
+a & b \\
+\end{tabular}
+  \label{tab:t}
+\end{table}
+AFTER

--- a/tests/fixtures/emission/07-placement/expect.txt
+++ b/tests/fixtures/emission/07-placement/expect.txt
@@ -1,0 +1,3 @@
+transport: lowered
+scanner: figure table
+constructs: placement is emitted verbatim inside brackets, and its absence emits none

--- a/tests/fixtures/emission/07-placement/input.xtex
+++ b/tests/fixtures/emission/07-placement/input.xtex
@@ -1,0 +1,16 @@
+BEFORE
+\figure(fig:cd) {
+  placement = !htbp
+  src = "figures/cdplot.pdf"
+  width = \linewidth
+  caption = {A diagram.}
+}
+MIDDLE
+\table(tab:t) {
+  placement = t
+  caption = {Data}
+  body = {\begin{tabular}{ll}
+a & b \\
+\end{tabular}}
+}
+AFTER


### PR DESCRIPTION
Closes #81. The director's decision is recorded in `docs/decisions/0006-placement.md`.

## Why

Phase 0a measured it: **634 of 662** floats in the author's corpus carry explicit placement (96%). A typed block that cannot say `[ht]` cannot hold the corpus's normal case.

## The syntax

```
\figure(fig:cd) {
  placement = !htbp
  src = "figures/cdplot.pdf"
  width = \linewidth
  caption = {A diagram.}
}
```

emits `\begin{figure}[!htbp]`. Zero new grammar — one more row in the §5 field tables, using the `bare` value kind that already existed. Both `\figure` and `\table`.

## The three rules

- Valid bytes: `h t b p !` (LaTeX) and `H` (`float` package, unvalidated like every package fact). Anything else: **hard error naming the byte** — `` `q` is not a placement letter; LaTeX accepts h, t, b, p, `!` and the float package's H``.
- Emitted **verbatim** — no reordering, no dedup.
- An **empty field is malformed**, not a synonym for absence. And a bare value ends at its line — the first implementation happily read the next line's `caption` key as the placement value until the test existed; the fix and its test are both in.

## Verification

| Check | Result |
|---|---|
| corpus's six frequent forms (`t`, `h`, `ht`, `!htbp`, `!ht`, `b`) | round-trip |
| **Property B on the real Springer monograph** — one `[h]` figure converted to a block, whole book recompiled | **105 pages, 0 pixels differ** |
| block without the field | emission fixtures byte-identical |
| external corpus | 992/992 both promises |
| workspace sweep | clean |
| mutation: drop the brackets | emission fixture fails |
| mutation: accept any byte | the naming test fails |
| mutation: remove the line rule | the empty-field test fails |
| `fmt`, `clippy -D warnings`, `test --workspace` | clean |

One deviation from the issue text, stated: the error code is `XT1008` (block field present and malformed), not the `XT1007` family the issue guessed — `XT1007` is lengths, and `checking.md`'s own table puts a malformed field under `XT1008`.

Next in the queue: #82 (`label=` in listing headers), then #83 (constructs in text-bearing arguments).