### PR TITLE
Read label= from a lstlisting header, because listings makes it a \label

### DIFF
--- a/crates/xtex-core/src/labels.rs
+++ b/crates/xtex-core/src/labels.rs
@@ -33,6 +33,11 @@ pub enum Unavailable {
     /// A `\label` after that point cannot be seen, so the ones before it are a
     /// subset rather than a set.
     Quarantined,
+    /// A listing header's `label` option could not be read literally.
+    ///
+    /// A computed value, or an option list that never closes. What could not
+    /// be read might declare a label, so nothing may be called absent.
+    UnreadableLabelOption,
     /// A literal LaTeX project edge did not resolve or could not be read.
     UnreadableEdge,
 }
@@ -89,6 +94,16 @@ pub fn inventory(sources: &Sources, document: &Document, id: SourceId) -> Invent
     // separated those out.
     for span in crate::scanner::readable_content(bytes) {
         collect(&bytes[span.start()..span.end()], span.start(), &mut labels);
+    }
+    // A listing may declare its label as a package option in its header,
+    // with no `\label` anywhere. Grammar §4; decided in issue #82.
+    match crate::scanner::listing_header_labels(bytes) {
+        Ok(found) => {
+            for (name, span) in found {
+                labels.entry(name).or_insert(span);
+            }
+        }
+        Err(_) => return Inventory::Unavailable(Unavailable::UnreadableLabelOption),
     }
     Inventory::Complete(labels)
 }
@@ -150,6 +165,59 @@ mod tests {
         let id = sources.add("a.xtex", text.as_bytes().to_vec());
         let document = parse(&sources, id);
         inventory(&sources, &document, id)
+    }
+
+    #[test]
+    fn a_listing_header_label_is_a_declaration() {
+        // The Phase 0a paper's exact shape: options across three lines with a
+        // `%` comment inside, and the braced label form. No `\label` exists
+        // anywhere in this input.
+        let text = "\\begin{lstlisting}[language=Python, style=pythonstyle, % <-- estilo\n    caption=Python function.,\n    label={lst:runs_decomposition}]\nbody\n\\end{lstlisting}";
+        assert!(built(text).contains("lst:runs_decomposition"));
+
+        // The unbraced form occurs in the wild too.
+        assert!(
+            built("\\begin{lstlisting}[label=lst:plain]\nx\n\\end{lstlisting}")
+                .contains("lst:plain")
+        );
+    }
+
+    #[test]
+    fn a_computed_label_option_makes_the_inventory_unavailable() {
+        // What cannot be read might declare a label, so nothing may be called
+        // absent. The same all-or-nothing rule as the bibliography.
+        let found = built("\\begin{lstlisting}[label=\\jobname]\nx\n\\end{lstlisting}");
+        assert_eq!(
+            found,
+            Inventory::Unavailable(Unavailable::UnreadableLabelOption)
+        );
+    }
+
+    #[test]
+    fn a_label_in_a_listing_body_or_inside_another_value_declares_nothing() {
+        // The body is raw bytes; `label=` there is code being displayed. And
+        // `label` as a substring of another option's value is prose about the
+        // syntax, not a use of it. Both fixtures contain exactly the bytes a
+        // wrong implementation would read.
+        let body = built("\\begin{lstlisting}\nlabel={lst:in-body}\n\\end{lstlisting}");
+        assert!(!body.contains("lst:in-body"));
+
+        let value = built(
+            "\\begin{lstlisting}[caption={the label={lst:in-value} syntax}]\nx\n\\end{lstlisting}",
+        );
+        assert!(!value.contains("lst:in-value"));
+    }
+
+    #[test]
+    fn a_lstlisting_inside_a_comment_or_verbatim_body_is_not_a_header() {
+        // Only regions the scanner itself opened are read. Both inputs carry
+        // a well-formed header a scan of raw bytes would find.
+        let comment = built("% \\begin{lstlisting}[label={lst:commented}]\ntext\n");
+        assert!(!comment.contains("lst:commented"));
+
+        let nested =
+            built("\\begin{verbatim}\n\\begin{lstlisting}[label={lst:shown}]\n\\end{verbatim}\n");
+        assert!(!nested.contains("lst:shown"));
     }
 
     #[test]

--- a/crates/xtex-core/src/scanner.rs
+++ b/crates/xtex-core/src/scanner.rs
@@ -1447,6 +1447,157 @@ fn display_header_whitespace_end(bytes: &[u8], mut at: usize) -> usize {
     at
 }
 
+/// The `label` values declared in listing-environment header options.
+///
+/// `\begin{lstlisting}[…, label={lst:x}]` declares `lst:x` with no `\label`
+/// anywhere — the label is a package option, read here so a correct
+/// `@ref(lst:x)` is not a false hard error. The environments are only the
+/// ones whose `label` option *is* a reference target: `listings` runs
+/// `\label` internally for it. `fancyvrb`'s `Verbatim` also takes a `label`
+/// option, but there it titles the frame and declares nothing, and plain
+/// `verbatim` takes no options at all — reading a `[` from its body as an
+/// option list would misread a correct document.
+///
+/// Only headers the scanner itself opened are read: an excluded region that
+/// begins with the environment's `\begin` is one the scanner entered, so a
+/// `\begin{lstlisting}` inside a comment or another verbatim body never
+/// reaches this.
+///
+/// # Errors
+///
+/// A `label` value that is not literal — a control sequence, inner braces,
+/// non-ASCII — or an option list whose `]` cannot be found returns the span
+/// it stopped at. The caller makes the whole inventory unavailable: a
+/// half-read inventory turns correct references into false errors.
+pub fn listing_header_labels(bytes: &[u8]) -> Result<Vec<(String, Span)>, Span> {
+    const LABEL_OPTION_ENVIRONMENTS: &[&str] = &["lstlisting"];
+    let mut found = Vec::new();
+    for piece in scan(bytes) {
+        let Piece::Excluded(region) = piece else {
+            continue;
+        };
+        let start = region.start();
+        let slice = &bytes[start..region.end()];
+        let Some(rest) = slice.strip_prefix(b"\\begin{") else {
+            continue;
+        };
+        let Some(close) = rest.iter().position(|byte| *byte == b'}') else {
+            continue;
+        };
+        if !LABEL_OPTION_ENVIRONMENTS
+            .iter()
+            .any(|name| name.as_bytes() == &rest[..close])
+        {
+            continue;
+        }
+        let mut at = b"\\begin{".len() + close + 1;
+        // Spaces and tabs may precede the option list; a line ending means
+        // the body has begun and there are no options.
+        while matches!(slice.get(at), Some(b' ' | b'\t')) {
+            at += 1;
+        }
+        if slice.get(at) != Some(&b'[') {
+            continue;
+        }
+        at += 1;
+        let list_start = at;
+        // The option list is TeX tokens under default category codes, so a
+        // `%` opens a comment to the line ending — the measured header in
+        // the Phase 0a paper carries one — and braces nest.
+        let mut depth = 0usize;
+        let mut segment = list_start;
+        let mut closed = None;
+        while at < slice.len() {
+            match slice[at] {
+                b'%' if !is_escaped(slice, at) => {
+                    while at < slice.len() && slice[at] != b'\n' {
+                        at += 1;
+                    }
+                    continue;
+                }
+                b'{' => depth += 1,
+                b'}' => depth = depth.saturating_sub(1),
+                b',' | b']' if depth == 0 => {
+                    read_label_option(&slice[segment..at], start + segment, &mut found).map_err(
+                        |offset| {
+                            Span::new(
+                                u32::try_from(start + segment + offset).unwrap_or(u32::MAX),
+                                u32::try_from(start + at).unwrap_or(u32::MAX),
+                            )
+                        },
+                    )?;
+                    if slice[at] == b']' {
+                        closed = Some(at);
+                        break;
+                    }
+                    segment = at + 1;
+                }
+                _ => {}
+            }
+            at += 1;
+        }
+        if closed.is_none() {
+            // The list never closes. Its contents cannot be bounded, so
+            // nothing read from it may be trusted.
+            return Err(region);
+        }
+    }
+    Ok(found)
+}
+
+/// Reads one `key = value` option segment, keeping only a literal `label`.
+///
+/// Returns the offset of an unusable `label` value inside the segment.
+fn read_label_option(
+    segment: &[u8],
+    base: usize,
+    found: &mut Vec<(String, Span)>,
+) -> Result<(), usize> {
+    let equals = segment.iter().position(|byte| *byte == b'=');
+    let Some(equals) = equals else { return Ok(()) };
+    let key: Vec<u8> = segment[..equals]
+        .iter()
+        .copied()
+        .filter(|byte| !byte.is_ascii_whitespace())
+        .collect();
+    if key != b"label" {
+        return Ok(());
+    }
+    let raw = &segment[equals + 1..];
+    let lead = raw
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .unwrap_or(raw.len());
+    let trail = raw
+        .iter()
+        .rposition(|byte| !byte.is_ascii_whitespace())
+        .map_or(lead, |i| i + 1);
+    let mut value = &raw[lead..trail];
+    let mut offset = equals + 1 + lead;
+    // The braced and unbraced forms both occur; strip one balanced pair.
+    if value.first() == Some(&b'{') && value.last() == Some(&b'}') && value.len() >= 2 {
+        value = &value[1..value.len() - 1];
+        offset += 1;
+    }
+    let literal = !value.is_empty()
+        && value.iter().all(|byte| {
+            byte.is_ascii() && !byte.is_ascii_control() && !matches!(byte, b'\\' | b'{' | b'}')
+        });
+    if !literal {
+        return Err(offset);
+    }
+    if let Ok(name) = std::str::from_utf8(value) {
+        found.push((
+            name.trim().to_owned(),
+            Span::new(
+                u32::try_from(base + offset).unwrap_or(u32::MAX),
+                u32::try_from(base + offset + value.len()).unwrap_or(u32::MAX),
+            ),
+        ));
+    }
+    Ok(())
+}
+
 /// Control words beginning with `if` that are not conditionals.
 ///
 /// The name is everything after `\if`, and the comparison is against the

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -311,6 +311,12 @@ enters the inventory only when it is tokenized as `\label` under default categor
 §8 exclusion region, has one balanced braced argument, and that argument is an `ident` after trimming ASCII
 whitespace.
 
+The inventory also reads `label` from the header options of a `lstlisting` environment, because `listings`
+runs `\label` internally for it — `\begin{lstlisting}[…, label={lst:x}]` declares `lst:x` with no `\label`
+anywhere. Only literal values; a computed one, or an option list that never closes, makes the inventory
+`Unavailable`. Only `lstlisting`: `fancyvrb`'s `label` option titles a frame and declares nothing, and
+`verbatim` takes no options, so reading a `[` from its body would misread a correct document.
+
 The inventory also follows literal `\include{…}` and `\input{…}` paths in readable content, transitively.
 An omitted extension resolves first to `.tex`, then to `.xtex`. These commands remain transported bytes: they
 do not become imports, add files to emission, or change page breaks. A command in a comment, verbatim region


### PR DESCRIPTION
Closes #82. The director's decision (option 1 of three) is in the issue.

## The case, from the real paper

```latex
\begin{lstlisting}[language=Python, style=pythonstyle, % <-- Aplicar estilo aquí
    caption=Python function to decompose runs.,
    label={lst:runs_decomposition}]
```

No `\label` anywhere — and a correct `@ref(lst:runs_decomposition)` was `XT1003`. That exact header, three lines and an inner `%` comment included, is now the fixture: the option list is TeX under default category codes, so the comment is skipped and braces nest.

## The rules that carry it

- **Only headers the scanner opened.** An excluded region beginning with the environment's `\begin` is one the scanner entered — so a `\begin{lstlisting}` inside a comment or a verbatim body never reaches the reader. This is not a raw scan of bytes, and a mutation that turns it into one fails the test for it.
- **Only literal values.** `label=\jobname`, or an option list whose `]` never comes, makes the whole inventory `Unavailable` — the bibliography's all-or-nothing rule, same reason: a half-read inventory turns correct references into false errors.
- **The body stays raw.** `label={…}` inside the listing is code being displayed; `label` as a substring of another option's value is prose about the syntax. Both fixtures contain exactly the bytes a wrong implementation would read.
- Braced and unbraced value forms both read.

## One narrowing against the issue's wording, stated

The set is **`lstlisting` alone**, not the whole configured verbatim set. `fancyvrb`'s `Verbatim` also takes a `label` option — but there it *titles the frame* and declares no reference target, so reading it would invent labels. And plain `verbatim` takes no options at all: treating a `[` at the start of its body as an option list would misread a correct document. Widening the set later is one line plus its justification.

## Verification

| Check | Result |
|---|---|
| the Phase 0a paper (1,865 lines, 196 constructs) | its two false `XT1003`s are gone; **checks clean, exit 0** |
| `label=\jobname` | whole inventory off; silence, no error anywhere |
| body `label=`, substring `label` | declare nothing (`XT1003` correctly fires on refs to them) |
| unbraced form `label=lst:x` | reads |
| external corpus | 992/992 both promises |
| workspace sweep | clean |
| mutation: never read options / accept computed / raw-byte scan | each fails its own test |
| `fmt`, `clippy -D warnings`, `test --workspace` | clean |

Next: #83 (constructs in text-bearing arguments), the last of the Phase 0a gap list.