### PR TITLE
A construct inside a text-bearing argument is a construct

### DIFF
--- a/crates/xtex-core/src/rename.rs
+++ b/crates/xtex-core/src/rename.rs
@@ -251,6 +251,24 @@ fn name_spans(sources: &Sources, source: SourceId, construct: Span, kind: EntryT
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_construct_in_a_caption_is_a_real_occurrence_not_untouched() {
+        // Issue #83: a text-bearing argument is prose, so rename must reach
+        // it. Before, the caption's @ref sat in an Arguments piece and was
+        // reported untouched — an editor renaming 2 of 3 places silently.
+        let mut sources = Sources::new();
+        let text = "\\section{S}@id(sec:s)\nProsa @ref(sec:s).\n\\caption{Pie con @ref(sec:s).}\n";
+        let id = sources.add("r.xtex", text.as_bytes().to_vec());
+        let document = crate::parse(&sources, id);
+        let plan = plan(&sources, &[document], "sec:s", "sec:nuevo");
+        assert_eq!(plan.edits.len(), 3, "the caption occurrence is an edit");
+        assert!(
+            plan.untouched.is_empty(),
+            "nothing opaque holds this identifier: {:?}",
+            plan.untouched
+        );
+    }
     use crate::parse;
 
     fn renamed(text: &str, from: &str, to: &str) -> (String, usize) {

--- a/crates/xtex-core/src/scanner.rs
+++ b/crates/xtex-core/src/scanner.rs
@@ -340,6 +340,14 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
     let mut excluded_start = 0usize;
     let mut at = 0usize;
     let mut display_opening: Option<(usize, Vec<u8>)> = None;
+    // Text-bearing arguments being scanned as prose. Each entry is the byte
+    // where the argument's interior ends and the byte where the whole call
+    // ends; the tail between them is the closing delimiter, emitted as an
+    // `Arguments` piece when prose reaches it. A region that overruns the
+    // interior (an unbalanced `$` inside a caption) simply passes the
+    // boundary: the entry is dropped and whatever tail remains is still
+    // classified, so every byte stays covered exactly once.
+    let mut text_arguments: Vec<(usize, usize)> = Vec::new();
 
     /// Closes the run of ordinary bytes that ends here.
     macro_rules! flush {
@@ -367,6 +375,19 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
     while at < bytes.len() {
         match &region {
             Region::Prose => {
+                if let Some(&(interior_end, call_end)) = text_arguments.last() {
+                    if at >= interior_end {
+                        flush!(at.min(interior_end));
+                        text_arguments.pop();
+                        let tail = at.max(interior_end);
+                        if tail < call_end {
+                            pieces.push(Piece::Arguments(span(tail, call_end)));
+                            at = call_end;
+                        }
+                        text_start = at;
+                        continue;
+                    }
+                }
                 if let Some((start, name)) = display_opening.as_ref() {
                     if at == *start {
                         enter!(at);
@@ -474,6 +495,22 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                 if bytes[at] == b'\\' {
                     match command_extent(bytes, at) {
                         Extent::Through(end) => {
+                            // A caption is prose. The head of the call — the
+                            // command, its data arguments, the opening
+                            // delimiter — stays an exclusion region, and the
+                            // interior is scanned exactly as the prose
+                            // outside it, every inner region included.
+                            // Issue #83; grammar §8's composition rule.
+                            if let Some((interior_start, interior_end)) =
+                                text_argument_interior(bytes, at)
+                            {
+                                enter!(at);
+                                pieces.push(Piece::Arguments(span(at, interior_start)));
+                                text_arguments.push((interior_end, end));
+                                text_start = interior_start;
+                                at = interior_start;
+                                continue;
+                            }
                             // §8 makes a command's arguments an exclusion
                             // region, and `Piece::Excluded` is what tells a
                             // consumer searching the source not to look here.
@@ -1119,6 +1156,106 @@ enum Extent {
 /// a mandatory argument was expected means the signature does not describe this
 /// call. See `docs/grammar.md` §8.
 const ARGUMENT_OPENERS: &[u8] = b"[<(*";
+
+/// Known commands whose final mandatory argument is prose.
+///
+/// A caption is a sentence; treating it as data made `@ref(fig:x)` inside
+/// one emit literally into the PDF with exit 0 — Phase 0a's gap 3, decided
+/// as issue #83. Each entry is transcribed against its signature in the
+/// table above; a command absent from the signature table cannot be listed
+/// (`title` and `author` are not, and stay excluded — the conservative
+/// default the issue fixes for the unclassified).
+///
+/// `item` is not here because its prose lives in its *optional* argument;
+/// see [`TEXT_OPTIONAL_COMMANDS`].
+const TEXT_MANDATORY_COMMANDS: &[&[u8]] = &[
+    b"caption",
+    b"chapter",
+    b"emph",
+    b"footnote",
+    b"footnotetext",
+    b"mbox",
+    b"paragraph",
+    b"part",
+    b"section",
+    b"subparagraph",
+    b"subsection",
+    b"subsubsection",
+    b"textbf",
+    b"textit",
+    b"underline",
+];
+// `\texttt` is deliberately absent, against the issue's first list: it is
+// the code font, and `\texttt{@ref(x)}` is how prose *shows* the literal
+// token — fixture revisions/04 exists to hold exactly that. Converting it
+// would corrupt any document that documents ExactTeX.
+
+/// Known commands whose optional argument is prose.
+const TEXT_OPTIONAL_COMMANDS: &[&[u8]] = &[b"item"];
+
+/// The interior of a text-bearing argument, when this call has one.
+///
+/// Walks the same signature the command was consumed under and returns the
+/// byte range inside the prose argument's delimiters. `None` when the
+/// command bears no prose, when the argument is absent, or when it is not
+/// in delimited form — each of those keeps today's whole-argument
+/// exclusion, which is the safe direction.
+fn text_argument_interior(bytes: &[u8], at: usize) -> Option<(usize, usize)> {
+    let name_start = at + 1;
+    let mut name_end = name_start;
+    while matches!(bytes.get(name_end), Some(b) if b.is_ascii_alphabetic()) {
+        name_end += 1;
+    }
+    let name = &bytes[name_start..name_end];
+    let mandatory = TEXT_MANDATORY_COMMANDS.contains(&name);
+    let optional = TEXT_OPTIONAL_COMMANDS.contains(&name);
+    if !mandatory && !optional {
+        return None;
+    }
+    let signature = signature_of(name)?;
+    let mut cursor = name_end;
+    let mut last_mandatory = None;
+    let mut first_optional = None;
+    for argument in signature {
+        cursor = skip_ascii_whitespace(bytes, cursor);
+        match argument {
+            Argument::Star => {
+                if bytes.get(cursor) == Some(&b'*') {
+                    cursor += 1;
+                }
+            }
+            Argument::Optional => {
+                if bytes.get(cursor) == Some(&b'[') {
+                    let end = delimited_end(bytes, cursor, b'[', b']')?;
+                    if first_optional.is_none() {
+                        first_optional = Some((cursor + 1, end - 1));
+                    }
+                    cursor = end;
+                }
+            }
+            Argument::Mandatory => {
+                if bytes.get(cursor) == Some(&b'{') {
+                    let end = balanced_end(bytes, cursor)?;
+                    last_mandatory = Some((cursor + 1, end - 1));
+                    cursor = end;
+                } else {
+                    return None;
+                }
+            }
+            Argument::Delimited(open, close) => {
+                if bytes.get(cursor) == Some(&open) {
+                    cursor = delimited_end(bytes, cursor, open, close)?;
+                }
+            }
+        }
+    }
+    let interior = if mandatory {
+        last_mandatory
+    } else {
+        first_optional
+    }?;
+    (interior.0 < interior.1).then_some(interior)
+}
 
 fn command_extent(bytes: &[u8], at: usize) -> Extent {
     let name_start = at + 1;
@@ -1769,30 +1906,61 @@ mod tests {
 
     #[test]
     fn a_known_signature_excludes_exactly_its_arguments() {
-        // \section is `s o m`: an optional star, an optional bracketed
-        // argument, then one mandatory braced one.
+        // \section is `s o m`. Since issue #83 its *mandatory* argument is
+        // prose — a heading is a sentence — while the optional short title
+        // stays data, the conservative default for the unclassified.
         assert_eq!(
             constructs(b"\\section[@ref(short)]{@ref(long)} @ref(after)"),
-            [EntryToken::Ref]
+            [EntryToken::Ref, EntryToken::Ref]
         );
         assert_eq!(
             constructs(b"\\section*{@ref(a)} @ref(after)"),
-            [EntryToken::Ref]
+            [EntryToken::Ref, EntryToken::Ref]
         );
-        // \caption is `o m`; the token after its argument is prose again.
+        // A data-bearing command's arguments are still fully excluded.
         assert_eq!(
-            constructs(b"\\caption{@ref(inside)} @id(after)"),
+            constructs(b"\\includegraphics[width=@ref(x)]{@ref(path)} @id(after)"),
             [EntryToken::Id]
         );
     }
 
     #[test]
+    fn a_text_bearing_argument_is_prose_and_its_regions_compose() {
+        // Phase 0a's gap 3, decided as issue #83: a caption is prose, so a
+        // construct inside one is a construct — while every inner exclusion
+        // still excludes. Each hidden case here carries exactly the bytes a
+        // wrong implementation would convert.
+        assert_eq!(
+            constructs(b"\\caption{see @ref(fig:x)} @id(after)"),
+            [EntryToken::Ref, EntryToken::Id]
+        );
+        assert_eq!(
+            constructs(b"\\caption{a \\verb|@ref(v)| $@ref(m)$ % @ref(c)\nb @ref(real)}"),
+            [EntryToken::Ref]
+        );
+        // Nested text-bearing commands scan through.
+        assert_eq!(
+            constructs(b"\\caption{\\textbf{@ref(deep)}}"),
+            [EntryToken::Ref]
+        );
+        // A definition body is not prose, wherever a caption sits inside it.
+        assert_eq!(constructs(b"\\newcommand{\\x}{\\caption{@ref(w)}}"), []);
+        // `\item`'s prose is its optional argument.
+        assert_eq!(
+            constructs(b"\\item[see @ref(fig:x)] body"),
+            [EntryToken::Ref]
+        );
+    }
+
+    #[test]
     fn a_command_takes_only_the_arguments_its_signature_declares() {
-        // \emph is `m`. The second group is prose, not a second argument, so a
-        // construct inside it is recognised.
+        // \emph is `m`. The second group is prose, not a second argument —
+        // and since #83 the argument itself is prose too, so both refs are
+        // recognised and the boundary is proven by their count staying two,
+        // not three, when a third group follows nothing.
         assert_eq!(
             constructs(b"\\emph{@ref(arg)}{@ref(prose)}"),
-            [EntryToken::Ref]
+            [EntryToken::Ref, EntryToken::Ref]
         );
     }
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -777,8 +777,18 @@ entry token are ordinary bytes.
 | Listing | `\begin{lstlisting}` or a configured listing name | its line-exact terminator |
 | Internal-macro region | `\makeatletter` | `\makeatother` |
 | Raw escape | complete `latex` entry through its opening `{` | matching `}` |
-| Command argument | an argument start selected by a known signature | that argument's specified boundary |
+| Command argument | an argument start selected by a known signature — except a text-bearing argument, whose interior is prose (see below) | that argument's specified boundary |
 | Quarantine | a hazard listed below | end of file |
+
+**Text-bearing arguments are prose.** A caption is a sentence, so the final mandatory argument of
+`\caption`, `\footnote`, `\footnotetext`, `\emph`, `\textbf`, `\textit`, `\underline`, `\mbox` and the
+sectioning family, and `\item`'s optional argument, is scanned exactly as the prose around the call —
+constructs are constructs, and every inner exclusion region still excludes (a `\verb`, math or a comment
+inside a caption still hides its bytes). Everything else about the call — the command, its data arguments,
+the delimiters — remains an exclusion region. `\texttt` deliberately bears data, not text: it is the code
+font, and `\texttt{@ref(x)}` is how prose shows the literal token. A known command absent from the
+classification bears data, which is the conservative default. Decided in issue #83; found as Phase 0a's
+gap 3, where a construct in a caption was emitted literally into the PDF with exit 0.
 
 The default verbatim environment set is `verbatim`, `verbatimtab`, `Verbatim`, `listing` and `lstlisting`,
 extended by `xtex.toml`.

--- a/tests/fixtures/emission/06-constructs-in-block-fields/emitted.tex
+++ b/tests/fixtures/emission/06-constructs-in-block-fields/emitted.tex
@@ -8,7 +8,7 @@ BEFORE
 BETWEEN
 \begin{table}
   \centering
-  \caption{Results for \cite{knuth1984}; \textbf{@cite(hidden-command)}; \verb|@cite(hidden-verb)|; $@cite(hidden-math)$; % @cite(hidden-comment)
+  \caption{Results for \cite{knuth1984}; \textbf{\cite{hidden-command}}; \verb|@cite(hidden-verb)|; $@cite(hidden-math)$; % @cite(hidden-comment)
 continued}
 row for \ref{fig:a}
 tail \ref{tab:x}

--- a/tests/fixtures/emission/06-constructs-in-block-fields/expect.txt
+++ b/tests/fixtures/emission/06-constructs-in-block-fields/expect.txt
@@ -1,3 +1,3 @@
 transport: lowered
-scanner: figure cite table cite ref ref ref
-constructs: figure(fig:scalar) contains cite(figure-source), while its scalar src contains no construct; table(tab:x) contains cite(knuth1984), ref(fig:a), and ref(tab:x); ref(sec:after) remains after the block; tokens in a command argument, verbatim, math, and a comment remain ordinary text
+scanner: figure cite table cite cite ref ref ref
+constructs: figure(fig:scalar) contains cite(figure-source), while its scalar src contains no construct; table(tab:x) contains cite(knuth1984), cite(hidden-command) — a construct since #83, because \textbf bears text — ref(fig:a), and ref(tab:x); ref(sec:after) remains after the block; a token inside a text-bearing command's argument is a construct since #83, while verbatim, math, and a comment still hide theirs


### PR DESCRIPTION
Closes #83 — the last of Phase 0a's gap list.

## Before and after

```latex
\caption{Comparación con @ref(fig:base) y @cite(knuth1984).}
```

Before: emitted **literally into the PDF**, exit 0, nothing said. After: checks (`XT1003` with a line if `fig:base` is undeclared), resolves, and emits `\caption{Comparación con \ref{fig:base} y \cite{knuth1984}.}`. The `#64` advisory anchors on a footnote's `@cite` like any citation. `\url{https://x.org/@ref(x)/y}` is untouched.

## How

Flattened, not recursive: the call's head (command + data arguments + opening delimiter) stays an `Arguments` piece, the interior joins the main scan loop as prose, and a small stack emits the closing delimiter as the tail piece. Because the interior's pieces are ordinary top-level pieces, **the emitter, symbol table, rename and hover all see them with zero new code** — rename now counts a caption's `@ref` as an edit, not `untouched`, and there is a test pinning that.

Composition holds: `\verb`, math and comments inside a caption still hide their bytes (one fixture with all three plus a real construct), and a caption inside a `\newcommand` body is never reached — the definition consumes it whole.

## Two deviations from the issue's list, stated

- **`\texttt` bears data.** It is the code font, and `\texttt{@ref(x)}` is how prose *shows* the literal token — fixture `revisions/04` exists to hold exactly that, and converting it would corrupt any document that documents ExactTeX. The issue's first list included it; the fixture's argument won. Overrule by adding one line if you disagree.
- `\title`/`\author` are not in the signature table, so they stay excluded until someone adds them there.

## Verification

| Check | Result |
|---|---|
| caption/footnote constructs: check, resolve, lower | ✓ end to end |
| composition (`\verb` + `$…$` + `%` inside one caption) | only the real construct recognized |
| nested `\textbf` inside caption | scans through |
| definition body containing a caption | untouched |
| `\item[…]` optional-argument prose | recognized |
| rename | 3 edits, 0 untouched |
| external corpus | 992/992 both promises |
| workspace sweep | clean |
| mutation: empty the classification | 4 tests fail |
| mutation: inline math not opening inside interiors | the composition test fails |
| `fmt`, `clippy -D warnings`, `test --workspace` | clean |

Two fixtures documenting the old contract were updated to the new one, with `#83` cited in each.

With this, all three Phase 0a gaps are closed: #87 placement, #88 listing labels, and this.