### PR TITLE
Rename across a project through WebAssembly

### DIFF
--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -885,48 +885,13 @@ fn rename_command(args: &[String]) -> ExitCode {
     let loader = FileSystem {
         root: PathBuf::from("."),
     };
-    let mut sources = Sources::new();
-    let mut documents = Vec::new();
-    let mut names = Vec::new();
-    let mut pending = vec![(input.clone(), None)];
-    let mut seen = BTreeSet::new();
-    while let Some((name, parent)) = pending.pop() {
-        if !seen.insert(name.clone()) {
-            continue;
+    let (sources, documents, names) = match xtex_core::project::load_imports(&loader, input) {
+        Ok(project) => project,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return ExitCode::from(2);
         }
-        let id = match loader.load(&name, parent, &mut sources) {
-            Ok(id) => id,
-            Err(error) => {
-                eprintln!("error: {error}");
-                return ExitCode::from(2);
-            }
-        };
-        let document = parse(&sources, id);
-        let mut imports = Vec::new();
-        document.walk(|node| {
-            if let Node::Construct {
-                kind: EntryToken::Import,
-                span,
-                ..
-            } = node
-                && let Some(path) = xtex_core::project::literal_import(&sources, id, *span)
-            {
-                imports.push(path);
-            }
-        });
-        for path in imports {
-            pending.push((path, Some(id)));
-        }
-        // The source's own name, not the one it was asked for. An import is
-        // requested as `part.xtex` and stored as the path that actually
-        // resolved, and writing to the request would put the file wherever the
-        // process happens to be running.
-        let resolved = sources
-            .get(id)
-            .map_or_else(|| name.clone(), |source| source.name().to_owned());
-        names.push((id, resolved));
-        documents.push(document);
-    }
+    };
 
     let plan = xtex_core::rename::plan(&sources, &documents, from, to);
     if plan.is_empty() {

--- a/crates/xtex-core/src/project.rs
+++ b/crates/xtex-core/src/project.rs
@@ -312,6 +312,64 @@ fn root_inventory(
     }
 }
 
+/// Loads a root and its transitive `@import`s, keeping each parsed document.
+///
+/// This is the traversal `xtex rename` has always used — imports only, not
+/// the author's `\include` edges, because a rename rewrites `.xtex`
+/// constructs and transported LaTeX is never rewritten. Returns each
+/// source's resolved name beside its id, because a caller that writes files
+/// must write to the name that actually resolved, not the one requested.
+///
+/// # Errors
+///
+/// Returns [`IoError`] when the root or any import cannot be loaded.
+#[allow(clippy::type_complexity)]
+pub fn load_imports(
+    loader: &impl SourceLoader,
+    root: &str,
+) -> Result<
+    (
+        Sources,
+        Vec<crate::document::Document>,
+        Vec<(SourceId, String)>,
+    ),
+    IoError,
+> {
+    let mut sources = Sources::new();
+    let mut documents = Vec::new();
+    let mut names = Vec::new();
+    let mut pending = vec![(root.to_owned(), None)];
+    let mut seen = BTreeSet::new();
+    while let Some((name, parent)) = pending.pop() {
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+        let id = loader.load(&name, parent, &mut sources)?;
+        let document = parse(&sources, id);
+        let mut imports = Vec::new();
+        document.walk(|node| {
+            if let Node::Construct {
+                kind: EntryToken::Import,
+                span,
+                ..
+            } = node
+                && let Some(path) = literal_import(&sources, id, *span)
+            {
+                imports.push(path);
+            }
+        });
+        for path in imports {
+            pending.push((path, Some(id)));
+        }
+        let resolved = sources
+            .get(id)
+            .map_or_else(|| name.clone(), |source| source.name().to_owned());
+        names.push((id, resolved));
+        documents.push(document);
+    }
+    Ok((sources, documents, names))
+}
+
 #[cfg(test)]
 mod bibliography_advisory_tests {
     use super::*;

--- a/crates/xtex-core/src/rename.rs
+++ b/crates/xtex-core/src/rename.rs
@@ -248,6 +248,64 @@ fn name_spans(sources: &Sources, source: SourceId, construct: Span, kind: EntryT
     found
 }
 
+/// Renders a plan as JSON, one renderer for both hosts.
+///
+/// The honest half travels with the rest: `untouched` names every occurrence
+/// left alone because it sits in opaque text. An editor that silently renames
+/// 12 of 14 places is worse than one that renames none, so the places it did
+/// not touch are part of the answer, locatable, not a footnote.
+pub fn to_json(sources: &crate::source::Sources, plan: &Plan, out: &mut String) {
+    use std::fmt::Write as _;
+    fn entry(
+        sources: &crate::source::Sources,
+        source: crate::source::SourceId,
+        span: crate::source::Span,
+        out: &mut String,
+    ) {
+        let (name, line, column) = sources.get(source).map_or_else(
+            || (String::new(), 0, 0),
+            |s| {
+                let bytes = s.bytes();
+                let upto = &bytes[..span.start().min(bytes.len())];
+                // The dependency the lint suggests is a dependency; this
+                // repository holds none, as check.rs already records.
+                #[allow(clippy::naive_bytecount)]
+                let line = upto.iter().filter(|b| **b == b'\n').count() + 1;
+                let column =
+                    span.start() - upto.iter().rposition(|b| *b == b'\n').map_or(0, |i| i + 1) + 1;
+                (s.name().to_owned(), line, column)
+            },
+        );
+        out.push_str("{\"file\":\"");
+        out.push_str(&name.replace('\\', "\\\\").replace('"', "\\\""));
+        let _ = write!(
+            out,
+            "\",\"offset\":{},\"length\":{},\"line\":{line},\"column\":{column}",
+            span.start(),
+            span.len(),
+        );
+    }
+    out.push_str("{\"edits\":[");
+    for (index, edit) in plan.edits.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        entry(sources, edit.source, edit.span, out);
+        out.push_str(",\"replacement\":\"");
+        out.push_str(&edit.replacement.replace('\\', "\\\\").replace('"', "\\\""));
+        out.push_str("\"}");
+    }
+    out.push_str("],\"untouched\":[");
+    for (index, found) in plan.untouched.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        entry(sources, found.source, found.span, out);
+        out.push('}');
+    }
+    out.push_str("]}");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/xtex-wasm/src/lib.rs
+++ b/crates/xtex-wasm/src/lib.rs
@@ -219,6 +219,84 @@ pub unsafe extern "C" fn xtex_source_map(pointer: *const u8, len: usize) -> *mut
     }
 }
 
+/// Plans a rename across the bundle's project, honesty included.
+///
+/// Input: `u32 from_len · from · u32 to_len · to · bundle`. The answer is
+/// JSON with two lists: `edits`, each with file, position and replacement;
+/// and `untouched` — every occurrence left alone because it sits in opaque
+/// text. An editor that silently renames 12 of 14 places is worse than one
+/// that renames none, so the untouched places are part of the answer.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_rename_plan(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    let mut at = 0usize;
+    let Some(from) = take_text(&bytes, &mut at) else {
+        return result(&[]);
+    };
+    let Some(to) = take_text(&bytes, &mut at) else {
+        return result(&[]);
+    };
+    let Some(bundle) = decode_bundle(&bytes[at..]) else {
+        return result(&[]);
+    };
+    let Ok((sources, documents, _)) = xtex_core::project::load_imports(&bundle.store, &bundle.root)
+    else {
+        return result(&[]);
+    };
+    let plan = xtex_core::rename::plan(&sources, &documents, &from, &to);
+    let mut json = String::new();
+    xtex_core::rename::to_json(&sources, &plan, &mut json);
+    result(json.as_bytes())
+}
+
+/// Applies a rename to one file of the bundle and returns its new bytes.
+///
+/// Input: `u32 from_len · from · u32 to_len · to · u32 target_len · target ·
+/// bundle`. The plan is computed over the whole project — an edit's offsets
+/// are only meaningful against every reachable file — and applied to the one
+/// named file. A host rewrites its files one call at a time, the way
+/// `xtex rename` writes them one at a time. A rename that touches nothing
+/// returns the file unchanged, and a target the project does not reach
+/// returns the empty result.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_rename_apply(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    let mut at = 0usize;
+    let Some(from) = take_text(&bytes, &mut at) else {
+        return result(&[]);
+    };
+    let Some(to) = take_text(&bytes, &mut at) else {
+        return result(&[]);
+    };
+    let Some(target) = take_text(&bytes, &mut at) else {
+        return result(&[]);
+    };
+    let Some(bundle) = decode_bundle(&bytes[at..]) else {
+        return result(&[]);
+    };
+    let Ok((sources, documents, names)) =
+        xtex_core::project::load_imports(&bundle.store, &bundle.root)
+    else {
+        return result(&[]);
+    };
+    let Some((id, _)) = names.iter().find(|(_, name)| *name == target) else {
+        return result(&[]);
+    };
+    let plan = xtex_core::rename::plan(&sources, &documents, &from, &to);
+    let Some(original) = sources.get(*id).map(|source| source.bytes().to_vec()) else {
+        return result(&[]);
+    };
+    result(&xtex_core::rename::apply(&original, *id, &plan))
+}
+
 /// Reads one length-prefixed UTF-8 text from a buffer.
 fn take_text(bytes: &[u8], at: &mut usize) -> Option<String> {
     let end = at.checked_add(4)?;

--- a/crates/xtex-wasm/tests/parity.mjs
+++ b/crates/xtex-wasm/tests/parity.mjs
@@ -64,19 +64,31 @@ writeFileSync(`${outDir}/wasm.tex`, call("xtex_emit", project));
 writeFileSync(`${outDir}/wasm.json`, call("xtex_check_json", project));
 writeFileSync(`${outDir}/wasm.map`, call("xtex_source_map", project));
 
+// Helper: length-prefixed texts followed by the bundle.
+function framed(texts, bundleBytes) {
+  const enc = new TextEncoder();
+  const encoded = texts.map((t) => (t instanceof Uint8Array ? t : enc.encode(t)));
+  let size = bundleBytes.length;
+  for (const t of encoded) size += 4 + t.length;
+  const out = new Uint8Array(size);
+  const view = new DataView(out.buffer);
+  let at = 0;
+  for (const t of encoded) {
+    view.setUint32(at, t.length, true); at += 4;
+    out.set(t, at); at += t.length;
+  }
+  out.set(bundleBytes, at);
+  return out;
+}
+
+// Rename: plan JSON and the root's rewritten bytes.
+writeFileSync(`${outDir}/wasm.rename.json`, call("xtex_rename_plan", framed(["sec:model", "sec:modelo"], project)));
+writeFileSync(`${outDir}/wasm.renamed.root`, call("xtex_rename_apply", framed(["sec:model", "sec:modelo", rootName], project)));
+
 // Optional: a TeX log to translate. Two length-prefixed texts, then the bundle.
 const [, , , , , , stderrPath, logPath] = process.argv;
 if (stderrPath && logPath) {
-  const enc = new TextEncoder();
   const stderrBytes = readFileSync(stderrPath);
   const logBytes = readFileSync(logPath);
-  const framed = new Uint8Array(8 + stderrBytes.length + logBytes.length + project.length);
-  const view = new DataView(framed.buffer);
-  let at = 0;
-  view.setUint32(at, stderrBytes.length, true); at += 4;
-  framed.set(stderrBytes, at); at += stderrBytes.length;
-  view.setUint32(at, logBytes.length, true); at += 4;
-  framed.set(logBytes, at); at += logBytes.length;
-  framed.set(project, at);
-  writeFileSync(`${outDir}/wasm.blame.json`, call("xtex_blame", framed));
+  writeFileSync(`${outDir}/wasm.blame.json`, call("xtex_blame", framed([stderrBytes, logBytes], project)));
 }

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -229,6 +229,85 @@ fn a_multi_file_bundle_equals_the_cli_run_on_the_same_project_on_disk() {
 }
 
 #[test]
+fn a_rename_plans_and_applies_identically_and_reports_what_it_left_alone() {
+    let repo = repo();
+    let Some(module) = built_module(&repo) else {
+        return;
+    };
+    let project = repo.join("tests/fixtures/wasm/project");
+    let out = repo.join("target/wasm-parity/project");
+    run_module(&repo, &module, &project, "main.xtex", &out);
+
+    let store = memory_of(&project);
+    let (sources, documents, names) =
+        xtex_core::project::load_imports(&store, "main.xtex").expect("loads");
+    let plan = xtex_core::rename::plan(&sources, &documents, "sec:model", "sec:modelo");
+    let mut native_json = String::new();
+    xtex_core::rename::to_json(&sources, &plan, &mut native_json);
+    let wasm_json =
+        std::fs::read_to_string(out.join("wasm.rename.json")).expect("the module planned");
+    assert_eq!(
+        native_json, wasm_json,
+        "the two builds plan one rename differently"
+    );
+
+    // The fixture only proves what it exercises: an edit in the root, an edit
+    // in the imported file where the @id lives, and the \verb occurrence
+    // reported untouched with a location an editor can show.
+    assert!(
+        plan.edits.len() >= 2,
+        "cross-file edits are the point: {plan:?}"
+    );
+    assert_eq!(
+        plan.untouched.len(),
+        1,
+        "the verb occurrence is reported: {plan:?}"
+    );
+    assert!(
+        wasm_json.contains("\"untouched\":[{\"file\":\"main.xtex\""),
+        "{wasm_json}"
+    );
+
+    // Applying through the module leaves no stale reference: rewrite both
+    // files, re-check the rewritten project, and demand silence.
+    let renamed_root = std::fs::read(out.join("wasm.renamed.root")).expect("the module applied");
+    assert_ne!(
+        renamed_root,
+        std::fs::read(project.join("main.xtex")).unwrap()
+    );
+    let mut rewritten = xtex_core::io::Memory::new();
+    for (name, bytes) in [
+        ("main.xtex", renamed_root.clone()),
+        ("sections/model.xtex", {
+            let (id, _) = names
+                .iter()
+                .find(|(_, name)| name == "sections/model.xtex")
+                .expect("the imported file");
+            xtex_core::rename::apply(sources.get(*id).unwrap().bytes(), *id, &plan)
+        }),
+    ] {
+        rewritten = rewritten.with_input(name, bytes);
+    }
+    for name in ["appendix.tex", "refs.bib", "figures/plot.pdf"] {
+        rewritten = rewritten.with_input(
+            name,
+            std::fs::read(project.join(name)).expect("fixture file"),
+        );
+    }
+    let (sources2, diagnostics, _, _) = xtex_core::project::check_project(
+        &rewritten,
+        "main.xtex",
+        xtex_core::symbols::PrefixMap::default(),
+    )
+    .expect("checks");
+    let _ = sources2;
+    assert!(
+        diagnostics.is_empty(),
+        "a stale reference survived the rename: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn a_tex_log_translates_identically_in_both_builds_and_never_guesses_blame() {
     let repo = repo();
     let Some(module) = built_module(&repo) else {

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -57,6 +57,13 @@ file_count × ( u32 name_len   name (UTF-8)   u32 data_len   data )
 | `xtex_check_json(ptr, len)` | a bundle | the JSON `xtex check --json` prints, for the whole project |
 | `xtex_source_map(ptr, len)` | a bundle | the root's source map, as JSON |
 | `xtex_blame(ptr, len)` | two length-prefixed texts, then a bundle | the engine's records, translated |
+| `xtex_rename_plan(ptr, len)` | `from`, `to`, then a bundle | the plan, edits and untouched alike |
+| `xtex_rename_apply(ptr, len)` | `from`, `to`, `target`, then a bundle | the target file's rewritten bytes |
+
+A rename's plan is computed over the whole project and applied one file per call, the way `xtex rename`
+writes one file at a time. The plan's `untouched` list is the honest half: every occurrence left alone
+because it sits in opaque text, with a position an editor can show. An editor that silently renames 12 of
+14 places is worse than one that renames none.
 
 `xtex_blame`'s input is `u32 stderr_len · stderr · u32 log_len · log · bundle` — the engine's console
 output and its `.log` file, either of which may be empty. The answer carries, per record: the engine's own

--- a/tests/fixtures/wasm/project/main.xtex
+++ b/tests/fixtures/wasm/project/main.xtex
@@ -15,5 +15,7 @@ la figura~@ref(fig:plot) lo ilustra.
   caption = {Una figura con @ref(sec:intro) dentro del pie.}
 }
 
+El literal \verb|sec:model| queda como transporte.
+
 \bibliography{refs}
 \end{document}


### PR DESCRIPTION
Closes #71.

## The two exports

**`xtex_rename_plan`** — `from`, `to`, then a bundle. The answer:

```json
{"edits":[
  {"file":"main.xtex","offset":151,"length":9,"line":6,"column":22,"replacement":"sec:modelo"},
  {"file":"sections/model.xtex","offset":16,"length":9,"line":1,"column":17,"replacement":"sec:modelo"}],
 "untouched":[
  {"file":"main.xtex","offset":232,"length":9,"line":9,"column":18}]}
```

The `untouched` list is the honest half — every occurrence left alone because it sits in opaque text (`\verb`, verbatim, definition bodies), **located**, so an editor can show it before the author confirms. An editor that silently renames 12 of 14 places is worse than one that renames none.

**`xtex_rename_apply`** — `from`, `to`, `target`, then a bundle. Plan over the whole project, one file's rewritten bytes per call, the way `xtex rename` writes one file at a time.

## The structural half

The CLI rename's import traversal moved to `xtex_core::project::load_imports`; the CLI delegates, verified live — a cross-file rename through the binary still edits both files and still prints `left alone: main.xtex:2:24`.

## Verification

| Check | Result |
|---|---|
| plan parity: native vs module | byte for byte |
| plan exercises all three shapes (root edit, cross-file edit, untouched `\verb`) | pinned in the test |
| apply through the module, rewritten project re-checked | **zero diagnostics — no stale reference**, the Phase 3 criterion through this host |
| mutation: drop `untouched` from the JSON | test fails |
| mutation: apply ignores the plan | test fails |
| CLI rename, live | unchanged behaviour |
| external corpus | 992/992 both promises |
| workspace sweep | clean |
| `fmt`, `clippy -D warnings`, `test --workspace` | clean |

Queue: #72 (editor queries), #73 (revisions), #74 (full parity), #75 (versioned artefact).