### PR TITLE
Answer editor queries through WebAssembly, project-wide in both hosts

### DIFF
--- a/crates/xtex-core/src/editor.rs
+++ b/crates/xtex-core/src/editor.rs
@@ -248,8 +248,24 @@ pub fn definition(
     table: &SymbolTable,
     offset: usize,
 ) -> Option<Span> {
+    definition_site(sources, document, table, offset).map(|(_, span)| span)
+}
+
+/// As [`definition`], with the source the declaration lives in.
+///
+/// The span alone answered a single-file editor. A project-wide table can
+/// resolve a name declared in another file, and a location without its file
+/// sends the editor to the wrong buffer.
+#[must_use]
+pub fn definition_site(
+    sources: &Sources,
+    document: &Document,
+    table: &SymbolTable,
+    offset: usize,
+) -> Option<(crate::source::SourceId, Span)> {
     let located = construct_at(sources, document, offset)?;
-    Some(table.declaration(&located.name)?.construct)
+    let declaration = table.declaration(&located.name)?;
+    Some((declaration.payload.source, declaration.construct))
 }
 
 /// The text between a construct's parentheses.
@@ -282,6 +298,80 @@ fn payload_text_for(
     std::str::from_utf8(&bytes[open..close])
         .ok()
         .map(|text| text.trim().to_owned())
+}
+
+/// Renders a hover as JSON, one renderer for both hosts.
+pub fn hover_to_json(found: &Hover, out: &mut String) {
+    out.push_str("{\"text\":");
+    push_json_string(&found.text, out);
+    out.push('}');
+}
+
+/// Renders completions as JSON, one renderer for both hosts.
+pub fn completions_to_json(items: &[Completion], out: &mut String) {
+    out.push('[');
+    for (index, item) in items.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push_str("{\"label\":");
+        push_json_string(&item.label, out);
+        out.push_str(",\"class\":\"");
+        out.push_str(item.class.name());
+        out.push_str("\",\"detail\":");
+        match &item.detail {
+            Some(detail) => push_json_string(detail, out),
+            None => out.push_str("null"),
+        }
+        out.push('}');
+    }
+    out.push(']');
+}
+
+/// Renders a definition site as JSON, one renderer for both hosts.
+pub fn definition_to_json(sources: &Sources, source: SourceId, span: Span, out: &mut String) {
+    use std::fmt::Write as _;
+    let (name, line, column) = sources.get(source).map_or_else(
+        || (String::new(), 0, 0),
+        |s| {
+            let bytes = s.bytes();
+            let upto = &bytes[..span.start().min(bytes.len())];
+            // The dependency the lint suggests is a dependency; this
+            // repository holds none.
+            #[allow(clippy::naive_bytecount)]
+            let line = upto.iter().filter(|b| **b == b'\n').count() + 1;
+            let column =
+                span.start() - upto.iter().rposition(|b| *b == b'\n').map_or(0, |i| i + 1) + 1;
+            (s.name().to_owned(), line, column)
+        },
+    );
+    out.push_str("{\"file\":");
+    push_json_string(&name, out);
+    let _ = write!(
+        out,
+        ",\"offset\":{},\"length\":{},\"line\":{line},\"column\":{column}}}",
+        span.start(),
+        span.len(),
+    );
+}
+
+fn push_json_string(text: &str, out: &mut String) {
+    use std::fmt::Write as _;
+    out.push('"');
+    for ch in text.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
 }
 
 #[cfg(test)]

--- a/crates/xtex-core/src/project.rs
+++ b/crates/xtex-core/src/project.rs
@@ -370,6 +370,38 @@ pub fn load_imports(
     Ok((sources, documents, names))
 }
 
+/// A project loaded for positional queries: hover, completion, definition.
+pub struct Analysed {
+    /// Every reachable source.
+    pub sources: Sources,
+    /// Every parsed document, root first.
+    pub documents: Vec<crate::document::Document>,
+    /// Resolved name beside each id, in traversal order, root first.
+    pub names: Vec<(SourceId, String)>,
+    /// One table merged across the whole project, because a name declared in
+    /// an imported file answers a query made in the root.
+    pub table: SymbolTable,
+}
+
+/// Loads a root and its imports and merges one symbol table over them.
+///
+/// # Errors
+///
+/// Returns [`IoError`] when the root or any import cannot be loaded.
+pub fn analyse(loader: &impl SourceLoader, root: &str) -> Result<Analysed, IoError> {
+    let (sources, documents, names) = load_imports(loader, root)?;
+    let mut table = SymbolTable::new();
+    for document in &documents {
+        table.merge(&sources, document);
+    }
+    Ok(Analysed {
+        sources,
+        documents,
+        names,
+        table,
+    })
+}
+
 #[cfg(test)]
 mod bibliography_advisory_tests {
     use super::*;

--- a/crates/xtex-lsp/src/main.rs
+++ b/crates/xtex-lsp/src/main.rs
@@ -81,7 +81,7 @@ fn handle(message: &rpc::Message, open: &mut Open) -> Vec<String> {
 fn reply_with(
     message: &rpc::Message,
     open: &Open,
-    answer: impl Fn(&str, Position) -> Option<String>,
+    answer: impl Fn(&str, &str, Position) -> Option<String>,
 ) -> Vec<String> {
     let Some(id) = message.id else {
         return Vec::new();
@@ -92,7 +92,7 @@ fn reply_with(
     let Some(text) = open.get(&uri) else {
         return vec![rpc::reply(id, "null")];
     };
-    let body = answer(text, position).unwrap_or_else(|| "null".to_owned());
+    let body = answer(&uri, text, position).unwrap_or_else(|| "null".to_owned());
     vec![rpc::reply(id, &body)]
 }
 
@@ -162,8 +162,8 @@ fn diagnose(uri: &str, text: &str) -> String {
     rpc::notify("textDocument/publishDiagnostics", &params)
 }
 
-fn on_hover(text: &str, position: Position) -> Option<String> {
-    let (sources, document, table) = analyse(text);
+fn on_hover(uri: &str, text: &str, position: Position) -> Option<String> {
+    let (sources, document, table) = analyse(uri, text);
     let offset = offset_at(text.as_bytes(), position)?;
     let found = hover(&sources, &document, &table, offset)?;
     let mut body = String::from(r#"{"contents":{"kind":"plaintext","value":"#);
@@ -172,8 +172,8 @@ fn on_hover(text: &str, position: Position) -> Option<String> {
     Some(body)
 }
 
-fn on_completion(text: &str, position: Position) -> Option<String> {
-    let (sources, document, table) = analyse(text);
+fn on_completion(uri: &str, text: &str, position: Position) -> Option<String> {
+    let (sources, document, table) = analyse(uri, text);
     let offset = offset_at(text.as_bytes(), position)?;
     let items = completions(&sources, &document, &table, offset);
     let mut body = String::from("[");
@@ -194,8 +194,8 @@ fn on_completion(text: &str, position: Position) -> Option<String> {
     Some(body)
 }
 
-fn on_definition(text: &str, position: Position) -> Option<String> {
-    let (sources, document, table) = analyse(text);
+fn on_definition(uri: &str, text: &str, position: Position) -> Option<String> {
+    let (sources, document, table) = analyse(uri, text);
     let offset = offset_at(text.as_bytes(), position)?;
     let span = definition(&sources, &document, &table, offset)?;
     let (line, column) = line_column(text.as_bytes(), span.start());
@@ -207,13 +207,87 @@ fn on_definition(text: &str, position: Position) -> Option<String> {
 
 /// Parses the document and builds its table, which is what every positional
 /// handler needs and none of them should assemble itself.
-fn analyse(text: &str) -> (Sources, Document, SymbolTable) {
+///
+/// The buffer is the root and the project is loaded around it: imports are
+/// read from disk beside the URI's file, and the table is merged across
+/// everything reached, because a name declared in an imported file answers a
+/// query made in the root — the same project-wide path the WebAssembly build
+/// uses, so the two hosts cannot diverge. A URI that is not a file, or an
+/// import that cannot be read, falls back to the buffer alone: a worse answer
+/// beats no answer while the author is mid-keystroke.
+fn analyse(uri: &str, text: &str) -> (Sources, Document, SymbolTable) {
+    if let Some(path) = uri.strip_prefix("file://") {
+        let path = std::path::Path::new(path);
+        if let (Some(dir), Some(name)) = (path.parent(), path.file_name()) {
+            let overlay = Overlay {
+                dir: dir.to_path_buf(),
+                root: name.to_string_lossy().into_owned(),
+                text: text.to_owned(),
+            };
+            if let Ok(analysed) = xtex_core::project::analyse(&overlay, &overlay.root) {
+                let mut documents = analysed.documents;
+                if !documents.is_empty() {
+                    return (analysed.sources, documents.remove(0), analysed.table);
+                }
+            }
+        }
+    }
     let mut sources = Sources::new();
     let id = sources.add("document.xtex", text.as_bytes().to_vec());
     let document = parse(&sources, id);
     let mut table = SymbolTable::new();
     table.merge(&sources, &document);
     (sources, document, table)
+}
+
+/// The open buffer over the filesystem around it.
+///
+/// The root answers from the editor's buffer — what the author sees, not what
+/// is on disk — and every other name reads from disk relative to the root's
+/// directory.
+struct Overlay {
+    dir: std::path::PathBuf,
+    root: String,
+    text: String,
+}
+
+impl xtex_core::io::SourceLoader for Overlay {
+    fn load(
+        &self,
+        name: &str,
+        relative_to: Option<xtex_core::source::SourceId>,
+        sources: &mut Sources,
+    ) -> Result<xtex_core::source::SourceId, xtex_core::io::IoError> {
+        let base = relative_to.and_then(|id| sources.get(id).map(|s| s.name().to_owned()));
+        let resolved = match base.as_deref().and_then(|b| {
+            std::path::Path::new(b)
+                .parent()
+                .map(|d| d.join(name).to_string_lossy().into_owned())
+        }) {
+            Some(joined) => joined,
+            None => name.to_owned(),
+        };
+        if resolved == self.root {
+            return Ok(sources.add(resolved, self.text.as_bytes().to_vec()));
+        }
+        let bytes = std::fs::read(self.dir.join(&resolved)).map_err(|_| {
+            xtex_core::io::IoError::NotFound {
+                name: resolved.clone(),
+            }
+        })?;
+        Ok(sources.add(resolved, bytes))
+    }
+
+    fn read_aux(&self, beside: &str, name: &str) -> Option<Vec<u8>> {
+        let base = std::path::Path::new(beside).parent()?;
+        std::fs::read(self.dir.join(base).join(name)).ok()
+    }
+
+    fn file_exists(&self, relative_to: &str, name: &str) -> bool {
+        std::path::Path::new(relative_to)
+            .parent()
+            .is_some_and(|base| self.dir.join(base).join(name).is_file())
+    }
 }
 
 /// The URI and position a positional request names.
@@ -246,8 +320,8 @@ fn line_column(bytes: &[u8], offset: usize) -> (usize, usize) {
 ///
 /// Answering `null` is how an editor is told not to open its rename box at
 /// all, which is better than opening one whose result would be refused.
-fn on_prepare_rename(text: &str, position: Position) -> Option<String> {
-    let (sources, document, _) = analyse(text);
+fn on_prepare_rename(uri: &str, text: &str, position: Position) -> Option<String> {
+    let (sources, document, _) = analyse(uri, text);
     let offset = offset_at(text.as_bytes(), position)?;
     let located = construct_at(&sources, &document, offset)?;
     if located.kind == EntryToken::Cite {
@@ -280,7 +354,7 @@ fn on_rename(message: &rpc::Message, open: &Open) -> Vec<String> {
         return vec![rpc::reply(id, "null")];
     };
 
-    let (sources, document, _) = analyse(text);
+    let (sources, document, _) = analyse(&uri, text);
     let Some(offset) = offset_at(text.as_bytes(), position) else {
         return vec![rpc::reply(id, "null")];
     };

--- a/crates/xtex-lsp/tests/protocol.rs
+++ b/crates/xtex-lsp/tests/protocol.rs
@@ -216,3 +216,38 @@ fn prepare_rename_offers_the_construct_under_the_cursor() {
     let reply = frames.last().expect("a reply");
     assert!(reply.contains(r#""line":2"#), "{reply}");
 }
+
+#[test]
+fn hover_resolves_a_name_declared_in_an_imported_file_on_disk() {
+    // The buffer is the root and the project loads around it — the same
+    // project-wide path the WebAssembly build uses, so the two hosts cannot
+    // diverge. The imported file exists only on disk, so a file-local server
+    // would answer "not declared in this document root".
+    let dir = std::env::temp_dir().join(format!("xtex-lsp-cross-{}", std::process::id()));
+    std::fs::create_dir_all(dir.join("sections")).expect("a project dir");
+    std::fs::write(
+        dir.join("sections/model.xtex"),
+        "\\section{M}@id(sec:model)\n",
+    )
+    .expect("the import");
+    let root = dir.join("main.xtex");
+    std::fs::write(&root, "").expect("the root exists for the uri");
+
+    let text = "@import(\"sections/model.xtex\")\nVer @ref(sec:model).\n";
+    let uri = format!("file://{}", root.display());
+    let mut escaped = String::new();
+    xtex_lsp_escape(text, &mut escaped);
+    let open = format!(
+        r#"{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{uri}","text":{escaped}}}}}}}"#
+    );
+    let hover = format!(
+        r#"{{"jsonrpc":"2.0","id":9,"method":"textDocument/hover","params":{{"textDocument":{{"uri":"{uri}"}},"position":{{"line":1,"character":9}}}}}}"#
+    );
+    let frames = talk(&[open, hover, EXIT.to_owned()]);
+    let reply = frames.last().expect("a reply");
+    assert!(
+        reply.contains("declared as: section"),
+        "the declaration lives only on disk; a file-local analysis cannot see it: {reply}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/crates/xtex-wasm/src/lib.rs
+++ b/crates/xtex-wasm/src/lib.rs
@@ -297,6 +297,105 @@ pub unsafe extern "C" fn xtex_rename_apply(pointer: *const u8, len: usize) -> *m
     result(&xtex_core::rename::apply(&original, *id, &plan))
 }
 
+/// Answers a positional query over the bundle's project.
+///
+/// The three query exports share one input: `u32 target_len · target ·
+/// u32 offset · bundle`, where `offset` is a byte offset into the named
+/// file. The table is merged across the whole project, so a name declared in
+/// an imported file answers a query made in the root — completions are
+/// project-wide, and a definition can land in another file, which is why the
+/// answer carries the file. A position past the end of the file, or a target
+/// the project does not reach, returns the empty result; a position inside
+/// an opaque region returns the empty result rather than a guess.
+fn positional_query(
+    bytes: &[u8],
+    answer: impl Fn(
+        &xtex_core::project::Analysed,
+        &xtex_core::document::Document,
+        usize,
+    ) -> Option<String>,
+) -> Vec<u8> {
+    let mut at = 0usize;
+    let Some(target) = take_text(bytes, &mut at) else {
+        return Vec::new();
+    };
+    let Some(end) = at.checked_add(4) else {
+        return Vec::new();
+    };
+    let Some(field) = bytes.get(at..end) else {
+        return Vec::new();
+    };
+    let offset = u32::from_le_bytes([field[0], field[1], field[2], field[3]]) as usize;
+    let Some(bundle) = decode_bundle(&bytes[end..]) else {
+        return Vec::new();
+    };
+    let Ok(analysed) = xtex_core::project::analyse(&bundle.store, &bundle.root) else {
+        return Vec::new();
+    };
+    let Some(position) = analysed.names.iter().position(|(_, name)| *name == target) else {
+        return Vec::new();
+    };
+    let document = &analysed.documents[position];
+    answer(&analysed, document, offset).map_or_else(Vec::new, String::into_bytes)
+}
+
+/// Hover text for a position. See [`positional_query`] for the input.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_hover(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    result(&positional_query(&bytes, |analysed, document, offset| {
+        let found = xtex_core::editor::hover(&analysed.sources, document, &analysed.table, offset)?;
+        let mut json = String::new();
+        xtex_core::editor::hover_to_json(&found, &mut json);
+        Some(json)
+    }))
+}
+
+/// Completions at a position. See [`positional_query`] for the input.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_completions(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    result(&positional_query(&bytes, |analysed, document, offset| {
+        let items =
+            xtex_core::editor::completions(&analysed.sources, document, &analysed.table, offset);
+        if items.is_empty() {
+            return None;
+        }
+        let mut json = String::new();
+        xtex_core::editor::completions_to_json(&items, &mut json);
+        Some(json)
+    }))
+}
+
+/// The declaration a position refers to. See [`positional_query`].
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_definition(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    result(&positional_query(&bytes, |analysed, document, offset| {
+        let (source, span) = xtex_core::editor::definition_site(
+            &analysed.sources,
+            document,
+            &analysed.table,
+            offset,
+        )?;
+        let mut json = String::new();
+        xtex_core::editor::definition_to_json(&analysed.sources, source, span, &mut json);
+        Some(json)
+    }))
+}
+
 /// Reads one length-prefixed UTF-8 text from a buffer.
 fn take_text(bytes: &[u8], at: &mut usize) -> Option<String> {
     let end = at.checked_add(4)?;

--- a/crates/xtex-wasm/tests/parity.mjs
+++ b/crates/xtex-wasm/tests/parity.mjs
@@ -85,6 +85,29 @@ function framed(texts, bundleBytes) {
 writeFileSync(`${outDir}/wasm.rename.json`, call("xtex_rename_plan", framed(["sec:model", "sec:modelo"], project)));
 writeFileSync(`${outDir}/wasm.renamed.root`, call("xtex_rename_apply", framed(["sec:model", "sec:modelo", rootName], project)));
 
+// Positional queries: target file, u32 byte offset, then the bundle.
+function positional(target, offset, bundleBytes) {
+  const enc = new TextEncoder();
+  const t = enc.encode(target);
+  const out = new Uint8Array(4 + t.length + 4 + bundleBytes.length);
+  const view = new DataView(out.buffer);
+  let at = 0;
+  view.setUint32(at, t.length, true); at += 4;
+  out.set(t, at); at += t.length;
+  view.setUint32(at, offset, true); at += 4;
+  out.set(bundleBytes, at);
+  return out;
+}
+const rootText = readFileSync(join(projectDir, rootName), "utf8");
+const refAt = rootText.indexOf("@ref(sec:model)") + 6;
+const citeAt = rootText.indexOf("@cite(knuth1984)") + 7;
+writeFileSync(`${outDir}/wasm.hover.json`, call("xtex_hover", positional(rootName, refAt, project)));
+writeFileSync(`${outDir}/wasm.completions.json`, call("xtex_completions", positional(rootName, refAt, project)));
+writeFileSync(`${outDir}/wasm.definition.json`, call("xtex_definition", positional(rootName, refAt, project)));
+writeFileSync(`${outDir}/wasm.hover.opaque.json`, call("xtex_hover", positional(rootName, rootText.indexOf("verb|sec:model") + 6, project)));
+writeFileSync(`${outDir}/wasm.hover.pastend.json`, call("xtex_hover", positional(rootName, 10_000_000, project)));
+writeFileSync(`${outDir}/wasm.hover.cite.json`, call("xtex_hover", positional(rootName, citeAt, project)));
+
 // Optional: a TeX log to translate. Two length-prefixed texts, then the bundle.
 const [, , , , , , stderrPath, logPath] = process.argv;
 if (stderrPath && logPath) {

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -229,6 +229,84 @@ fn a_multi_file_bundle_equals_the_cli_run_on_the_same_project_on_disk() {
 }
 
 #[test]
+fn editor_queries_answer_project_wide_and_identically_in_both_builds() {
+    let repo = repo();
+    let Some(module) = built_module(&repo) else {
+        return;
+    };
+    let project = repo.join("tests/fixtures/wasm/project");
+    let out = repo.join("target/wasm-parity/project");
+    run_module(&repo, &module, &project, "main.xtex", &out);
+
+    let store = memory_of(&project);
+    let analysed = xtex_core::project::analyse(&store, "main.xtex").expect("loads");
+    let document = &analysed.documents[0];
+    let root_text = std::fs::read_to_string(project.join("main.xtex")).expect("the root");
+    let ref_at = root_text.find("@ref(sec:model)").expect("the ref") + 6;
+
+    // Hover, over a name declared in the IMPORTED file — the project-wide
+    // half is the claim, so the assertion demands the declaration was seen.
+    let found = xtex_core::editor::hover(&analysed.sources, document, &analysed.table, ref_at)
+        .expect("hover");
+    let mut native = String::new();
+    xtex_core::editor::hover_to_json(&found, &mut native);
+    let wasm = std::fs::read_to_string(out.join("wasm.hover.json")).expect("the module hovered");
+    assert_eq!(native, wasm);
+    assert!(
+        wasm.contains("declared as: section"),
+        "the cross-file declaration must be visible, or the table is file-local: {wasm}"
+    );
+
+    // Completions, which must include identifiers from every file.
+    let items =
+        xtex_core::editor::completions(&analysed.sources, document, &analysed.table, ref_at);
+    let mut native = String::new();
+    xtex_core::editor::completions_to_json(&items, &mut native);
+    let wasm =
+        std::fs::read_to_string(out.join("wasm.completions.json")).expect("the module completed");
+    assert_eq!(native, wasm);
+    // `sec:model` is declared in the imported file, so its presence is the
+    // project-wide claim. `fig:plot` must be ABSENT: the position is inside
+    // `@ref(sec:…)`, whose prefix demands a section (`decisions/0003`), and
+    // offering a figure there would be the compiler ignoring its own rule.
+    assert!(
+        wasm.contains("sec:model") && wasm.contains("sec:intro"),
+        "completions must span the project: {wasm}"
+    );
+    assert!(
+        !wasm.contains("fig:plot"),
+        "the sec: prefix demands a section; a figure offered here breaks decisions/0003: {wasm}"
+    );
+
+    // Definition, landing in the imported file — the answer carries the file.
+    let (source, span) =
+        xtex_core::editor::definition_site(&analysed.sources, document, &analysed.table, ref_at)
+            .expect("definition");
+    let mut native = String::new();
+    xtex_core::editor::definition_to_json(&analysed.sources, source, span, &mut native);
+    let wasm =
+        std::fs::read_to_string(out.join("wasm.definition.json")).expect("the module defined");
+    assert_eq!(native, wasm);
+    assert!(
+        wasm.contains("\"file\":\"sections/model.xtex\""),
+        "a definition in another file must say which: {wasm}"
+    );
+
+    // A position inside opaque text answers nothing rather than a guess, and
+    // a position past the end answers nothing rather than trusting it.
+    let opaque = std::fs::read(out.join("wasm.hover.opaque.json")).expect("ran");
+    assert!(opaque.is_empty(), "opaque text must answer nothing");
+    let past = std::fs::read(out.join("wasm.hover.pastend.json")).expect("ran");
+    assert!(past.is_empty(), "past the end must answer nothing");
+
+    // And a construct that is not a reference still answers — the control
+    // that keeps the two empties above from passing because everything is
+    // empty.
+    let cite = std::fs::read_to_string(out.join("wasm.hover.cite.json")).expect("ran");
+    assert!(cite.contains("citation key"), "{cite}");
+}
+
+#[test]
 fn a_rename_plans_and_applies_identically_and_reports_what_it_left_alone() {
     let repo = repo();
     let Some(module) = built_module(&repo) else {

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -59,6 +59,16 @@ file_count × ( u32 name_len   name (UTF-8)   u32 data_len   data )
 | `xtex_blame(ptr, len)` | two length-prefixed texts, then a bundle | the engine's records, translated |
 | `xtex_rename_plan(ptr, len)` | `from`, `to`, then a bundle | the plan, edits and untouched alike |
 | `xtex_rename_apply(ptr, len)` | `from`, `to`, `target`, then a bundle | the target file's rewritten bytes |
+| `xtex_hover(ptr, len)` | `target`, `u32 offset`, then a bundle | hover text |
+| `xtex_completions(ptr, len)` | `target`, `u32 offset`, then a bundle | completion items |
+| `xtex_definition(ptr, len)` | `target`, `u32 offset`, then a bundle | the declaration, file included |
+
+The three query exports share one input shape: the target file's name, a byte offset into it, then the
+bundle. The table is merged across the whole project, so a name declared in an imported file answers a
+query made in the root — and a definition can land in another file, which is why the answer carries the
+file. The language server answers from the same core functions over the same project-wide load (the open
+buffer overlays the file on disk; imports read from beside it), so the browser and a desktop editor cannot
+disagree about one project.
 
 A rename's plan is computed over the whole project and applied one file per call, the way `xtex rename`
 writes one file at a time. The plan's `untouched` list is the honest half: every occurrence left alone


### PR DESCRIPTION
Closes #72.

## The three exports

One input shape — `target`, `u32 offset`, bundle — and three answers, rendered by shared core renderers so the builds cannot drift:

- `xtex_hover` → `{"text":"@ref(sec:model)\nrequires: section\ndeclared as: section"}` — the declaration lives in the **imported** file; seeing it is the project-wide claim, asserted.
- `xtex_completions` → project-wide items, **filtered by the prefix's demand**: at `@ref(sec:…)` a figure is not offered, per `decisions/0003`, and the test asserts its absence.
- `xtex_definition` → `{"file":"sections/model.xtex",…}` — a definition can land in another file, so `definition_site` now carries the source and the answer names it.

Nothing guessed: past-the-end, unreachable target, or a position in opaque text answer empty — with a control case (`@cite` hover) proving the empties don't pass vacuously.

## The LSP half — the divergence that was waiting

The server analysed the open buffer alone; the module analyses the project. Same project, two answers. The server now loads the project **around the buffer** — the buffer overlays its file on disk, imports read from beside it — through the same `xtex_core::project::analyse`, falling back to buffer-only for non-file URIs. A protocol test opens a project whose declaration exists **only on disk** and demands the hover see it; forcing the fallback fails it.

This is also the alignment that matters for the web UI: browser (wasm) and desktop editor (LSP) are two renderings of one core answer, like the CLI already is for `check`.

## A self-correction recorded

The first draft of the completions assertion demanded `fig:plot` appear and was wrong about the compiler's own rule — the `sec:` prefix demands a section. The corrected assertion pins both: cross-file names present, wrong-class names absent.

## Verification

| Check | Result |
|---|---|
| hover / completions / definition parity, native vs module | byte for byte |
| cross-file: declaration in the import visible; definition names its file | pinned |
| prefix demand respected in completions | pinned, both directions |
| opaque / past-end / unreachable | empty, with a non-empty control |
| LSP cross-file protocol test | passes; fallback mutation fails it |
| wasm mutations: file-local table; answering in opaque text | each fails its test |
| `fmt`, `clippy -D warnings`, full suite | clean |

Next two PRs coming in parallel-mergeable form: #73 (revisions, stacked on this branch — merge this first), #75 (release artefact, independent off main).