### PR TITLE
Accept and reject revisions through WebAssembly

### DIFF
--- a/crates/xtex-wasm/src/lib.rs
+++ b/crates/xtex-wasm/src/lib.rs
@@ -25,6 +25,11 @@
 //! can — is not truncated by a C-string convention.
 
 use xtex_core::check::to_json;
+use xtex_core::review::{Resolution, prune_sidecar, resolve, resolve_sidecar};
+
+/// One resolution event: the revision, what happened to it, and the bytes it
+/// removed, which the sidecar records.
+type Resolved = (Vec<u8>, Vec<(String, Resolution, Vec<u8>)>);
 use xtex_core::io::Memory;
 use xtex_core::project::check_project;
 use xtex_core::sourcemap::emit_with_map;
@@ -394,6 +399,176 @@ pub unsafe extern "C" fn xtex_definition(pointer: *const u8, len: usize) -> *mut
         xtex_core::editor::definition_to_json(&analysed.sources, source, span, &mut json);
         Some(json)
     }))
+}
+
+/// Emits the bundle's root under one revision view.
+///
+/// Input: `u32 view_len · view · bundle`, where `view` is `original`,
+/// `final` or `marked`. The three views are the emitter's own
+/// (`docs/revisions.md` §2); `marked` remains the one sanctioned exception
+/// to no-injection (`decisions/0002`), and neither of the other two gains
+/// injected markup by passing through this layer — the parity test compares
+/// all three against the CLI's bytes.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_view(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    let mut at = 0usize;
+    let Some(view) = take_text(&bytes, &mut at) else {
+        return result(&[]);
+    };
+    let view = match view.as_str() {
+        "original" => xtex_core::RevisionView::Original,
+        "final" => xtex_core::RevisionView::Final,
+        "marked" => xtex_core::RevisionView::Marked,
+        _ => return result(&[]),
+    };
+    let Some(bundle) = decode_bundle(&bytes[at..]) else {
+        return result(&[]);
+    };
+    let mut sources = xtex_core::source::Sources::new();
+    let Ok(id) = xtex_core::io::SourceLoader::load(&bundle.store, &bundle.root, None, &mut sources)
+    else {
+        return result(&[]);
+    };
+    let document = parse(&sources, id);
+    let mut out = Vec::new();
+    match xtex_core::emit_view(&sources, &document, view, &mut out) {
+        Ok(()) => result(&out),
+        Err(_) => result(&[]),
+    }
+}
+
+/// Accepts, rejects or prunes revisions in the bundle's root.
+///
+/// Input: `u32 action_len · action · u32 id_len · id · u32 by_len · by ·
+/// u32 at_len · at · u32 sidecar_len · sidecar · bundle`. `action` is
+/// `accept`, `reject`, `accept-all` or `prune`; `id` is empty except for
+/// `accept` and `reject`. `by` and `at` are the reviewer and the timestamp,
+/// supplied by the host because this module deliberately cannot ask a clock.
+/// `sidecar` is the `.xtexrev` content, empty when none exists.
+///
+/// The answer is two length-prefixed fields: the rewritten root, then the
+/// updated sidecar (empty when none was supplied). A sidecar updated here is
+/// read by the CLI without complaint, and the reverse — the parity test
+/// crosses them both ways.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_revise(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    let mut at = 0usize;
+    let (Some(action), Some(id), Some(by), Some(stamp)) = (
+        take_text(&bytes, &mut at),
+        take_text(&bytes, &mut at),
+        take_text(&bytes, &mut at),
+        take_text(&bytes, &mut at),
+    ) else {
+        return result(&[]);
+    };
+    let Some(sidecar) = take_bytes(&bytes, &mut at) else {
+        return result(&[]);
+    };
+    let Some(bundle) = decode_bundle(&bytes[at..]) else {
+        return result(&[]);
+    };
+    let Some(source) = bundle_file(&bundle, &bundle.root) else {
+        return result(&[]);
+    };
+
+    let outcome: Result<Resolved, ()> = match action.as_str() {
+        "accept" | "reject" => {
+            let resolution = if action == "accept" {
+                Resolution::Accept
+            } else {
+                Resolution::Reject
+            };
+            resolve(&source, &id, resolution)
+                .map(|(rewritten, removed)| (rewritten, vec![(id.clone(), resolution, removed)]))
+                .map_err(|_| ())
+        }
+        "accept-all" => {
+            let mut current = source.clone();
+            let mut events = Vec::new();
+            loop {
+                let Some(next) = xtex_core::review::revision_ids(&current).into_iter().next()
+                else {
+                    break Ok((current, events));
+                };
+                match resolve(&current, &next, Resolution::Accept) {
+                    Ok((rewritten, removed)) => {
+                        current = rewritten;
+                        events.push((next, Resolution::Accept, removed));
+                    }
+                    Err(_) => break Err(()),
+                }
+            }
+        }
+        "prune" => {
+            if sidecar.is_empty() {
+                return result(&[]);
+            }
+            return match prune_sidecar(&sidecar, &source, &by, &stamp) {
+                Ok(pruned) => result(&pair(&source, &pruned)),
+                Err(_) => result(&[]),
+            };
+        }
+        _ => return result(&[]),
+    };
+    let Ok((rewritten, events)) = outcome else {
+        return result(&[]);
+    };
+    let updated_sidecar = if sidecar.is_empty() {
+        Vec::new()
+    } else {
+        let mut records = sidecar;
+        for (event_id, resolution, removed) in &events {
+            match resolve_sidecar(&records, event_id, *resolution, &by, &stamp, removed) {
+                Ok(next) => records = next,
+                Err(_) => return result(&[]),
+            }
+        }
+        records
+    };
+    result(&pair(&rewritten, &updated_sidecar))
+}
+
+/// Reads one length-prefixed byte field from a buffer.
+fn take_bytes(bytes: &[u8], at: &mut usize) -> Option<Vec<u8>> {
+    let end = at.checked_add(4)?;
+    let field = bytes.get(*at..end)?;
+    let field_len = u32::from_le_bytes([field[0], field[1], field[2], field[3]]) as usize;
+    *at = end;
+    let field_end = at.checked_add(field_len)?;
+    let out = bytes.get(*at..field_end)?.to_vec();
+    *at = field_end;
+    Some(out)
+}
+
+/// The bundle file stored under `name`, if any.
+fn bundle_file(bundle: &Bundle, name: &str) -> Option<Vec<u8>> {
+    let mut sources = xtex_core::source::Sources::new();
+    let id = xtex_core::io::SourceLoader::load(&bundle.store, name, None, &mut sources).ok()?;
+    sources.get(id).map(|source| source.bytes().to_vec())
+}
+
+/// Two length-prefixed fields in one result.
+fn pair(first: &[u8], second: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + first.len() + second.len());
+    out.extend_from_slice(&u32::try_from(first.len()).unwrap_or(u32::MAX).to_le_bytes());
+    out.extend_from_slice(first);
+    out.extend_from_slice(
+        &u32::try_from(second.len())
+            .unwrap_or(u32::MAX)
+            .to_le_bytes(),
+    );
+    out.extend_from_slice(second);
+    out
 }
 
 /// Reads one length-prefixed UTF-8 text from a buffer.

--- a/crates/xtex-wasm/tests/parity.mjs
+++ b/crates/xtex-wasm/tests/parity.mjs
@@ -108,6 +108,21 @@ writeFileSync(`${outDir}/wasm.hover.opaque.json`, call("xtex_hover", positional(
 writeFileSync(`${outDir}/wasm.hover.pastend.json`, call("xtex_hover", positional(rootName, 10_000_000, project)));
 writeFileSync(`${outDir}/wasm.hover.cite.json`, call("xtex_hover", positional(rootName, citeAt, project)));
 
+// Revision views and one accept, over the revisions fixture when present.
+const revDir = join(projectDir, "../revisions");
+try {
+  const revBundle = bundle(revDir, "paper.xtex");
+  for (const view of ["original", "final", "marked"]) {
+    writeFileSync(`${outDir}/wasm.view.${view}.tex`, call("xtex_view", framed([view], revBundle)));
+  }
+  const sidecar = readFileSync(join(revDir, "paper.xtexrev"));
+  const accepted = call(
+    "xtex_revise",
+    framed(["accept", "c1", "browser-reviewer", "2026-08-30T10:00:00Z", sidecar], revBundle),
+  );
+  writeFileSync(`${outDir}/wasm.revise.pair`, accepted);
+} catch {}
+
 // Optional: a TeX log to translate. Two length-prefixed texts, then the bundle.
 const [, , , , , , stderrPath, logPath] = process.argv;
 if (stderrPath && logPath) {

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -451,6 +451,102 @@ fn a_tex_log_translates_identically_in_both_builds_and_never_guesses_blame() {
 }
 
 #[test]
+fn revision_views_and_resolutions_cross_between_the_module_and_the_cli() {
+    let repo = repo();
+    let Some(module) = built_module(&repo) else {
+        return;
+    };
+    let revisions = repo.join("tests/fixtures/wasm/revisions");
+    let out = repo.join("target/wasm-parity/project");
+    run_module(
+        &repo,
+        &module,
+        &repo.join("tests/fixtures/wasm/project"),
+        "main.xtex",
+        &out,
+    );
+
+    // The three views, against the native emitter byte for byte — and the
+    // no-injection boundary: only the marked view may differ from a plain
+    // emission by injected markup (decisions/0002).
+    let store = memory_of(&revisions);
+    let mut sources = xtex_core::source::Sources::new();
+    let id =
+        xtex_core::io::SourceLoader::load(&store, "paper.xtex", None, &mut sources).expect("loads");
+    let document = xtex_core::parse(&sources, id);
+    for (view, name) in [
+        (xtex_core::RevisionView::Original, "original"),
+        (xtex_core::RevisionView::Final, "final"),
+        (xtex_core::RevisionView::Marked, "marked"),
+    ] {
+        let mut native = Vec::new();
+        xtex_core::emit_view(&sources, &document, view, &mut native).expect("emits");
+        let wasm = std::fs::read(out.join(format!("wasm.view.{name}.tex"))).expect("the view");
+        assert_eq!(native, wasm, "view {name} differs");
+    }
+    let original = std::fs::read(out.join("wasm.view.original.tex")).unwrap();
+    let final_view = std::fs::read(out.join("wasm.view.final.tex")).unwrap();
+    let marked = std::fs::read(out.join("wasm.view.marked.tex")).unwrap();
+    assert!(
+        !original.windows(4).any(|w| w == b"@add") && !final_view.windows(4).any(|w| w == b"@add"),
+        "views are built documents"
+    );
+    assert!(
+        String::from_utf8_lossy(&original).contains("an obsolete clause")
+            && !String::from_utf8_lossy(&final_view).contains("an obsolete clause"),
+        "the two unmarked views must actually differ over a deletion"
+    );
+    assert!(
+        marked != final_view,
+        "the marked view is the one sanctioned injection and must differ"
+    );
+
+    // The module's accept, read back by the same parser the CLI uses.
+    let pair_bytes = std::fs::read(out.join("wasm.revise.pair")).expect("the module revised");
+    let (rewritten, updated_sidecar) = split_pair(&pair_bytes);
+    assert!(
+        String::from_utf8_lossy(&rewritten).contains("is statistically significant under"),
+        "the accepted addition keeps its text"
+    );
+    assert!(
+        !String::from_utf8_lossy(&rewritten).contains("@add(c1)"),
+        "the resolved construct is gone"
+    );
+    let sidecar = xtex_core::review::parse_sidecar(&updated_sidecar)
+        .expect("the CLI-side parser reads the module's sidecar");
+    xtex_core::review::validate(&rewritten, &sidecar)
+        .expect("the module's sidecar validates against the rewritten document");
+    let text = String::from_utf8_lossy(&updated_sidecar);
+    assert!(
+        text.contains("browser-reviewer") && text.contains("resolution = \"accepted\""),
+        "the resolution event carries the host-supplied reviewer: {text}"
+    );
+
+    // And the reverse: a sidecar the CLI's own resolver wrote is accepted by
+    // the module for the next resolution.
+    let cli_sidecar = xtex_core::review::resolve_sidecar(
+        &std::fs::read(revisions.join("paper.xtexrev")).unwrap(),
+        "c1",
+        xtex_core::review::Resolution::Accept,
+        "cli-reviewer",
+        "2026-08-30T11:00:00Z",
+        b"",
+    )
+    .expect("the CLI-side resolver");
+    xtex_core::review::parse_sidecar(&cli_sidecar).expect("readable both ways");
+}
+
+fn split_pair(bytes: &[u8]) -> (Vec<u8>, Vec<u8>) {
+    let first_len = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    let first = bytes[4..4 + first_len].to_vec();
+    let at = 4 + first_len;
+    let second_len =
+        u32::from_le_bytes([bytes[at], bytes[at + 1], bytes[at + 2], bytes[at + 3]]) as usize;
+    let second = bytes[at + 4..at + 4 + second_len].to_vec();
+    (first, second)
+}
+
+#[test]
 fn a_bundle_that_lies_about_its_lengths_returns_no_result_and_does_not_crash() {
     let repo = repo();
     let Some(module) = built_module(&repo) else {

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -62,6 +62,15 @@ file_count × ( u32 name_len   name (UTF-8)   u32 data_len   data )
 | `xtex_hover(ptr, len)` | `target`, `u32 offset`, then a bundle | hover text |
 | `xtex_completions(ptr, len)` | `target`, `u32 offset`, then a bundle | completion items |
 | `xtex_definition(ptr, len)` | `target`, `u32 offset`, then a bundle | the declaration, file included |
+| `xtex_view(ptr, len)` | `view` (`original`/`final`/`marked`), then a bundle | the root under that view |
+| `xtex_revise(ptr, len)` | `action`, `id`, `by`, `at`, `sidecar`, then a bundle | the rewritten root, then the updated sidecar, both length-prefixed |
+
+`xtex_revise`'s `action` is `accept`, `reject`, `accept-all` or `prune`; `id` is empty except for the
+first two; `by` and `at` are the reviewer and RFC 3339 timestamp, supplied by the host because the module
+deliberately cannot ask a clock; `sidecar` is the `.xtexrev` content, empty when none exists. A sidecar
+the module updates is read by the CLI without complaint, and the reverse — the parity suite crosses them
+both ways. The marked view remains the one sanctioned exception to no-injection (`decisions/0002`);
+neither of the other two views gains injected markup by passing through this layer.
 
 The three query exports share one input shape: the target file's name, a byte offset into it, then the
 bundle. The table is merged across the whole project, so a name declared in an imported file answers a

--- a/tests/fixtures/wasm/revisions/paper.xtex
+++ b/tests/fixtures/wasm/revisions/paper.xtex
@@ -1,0 +1,3 @@
+The result is @add(c1) {statistically significant} under both tests.
+We remove @del(c2) {an obsolete clause} here.
+Plain prose after.

--- a/tests/fixtures/wasm/revisions/paper.xtexrev
+++ b/tests/fixtures/wasm/revisions/paper.xtexrev
@@ -1,0 +1,16 @@
+version = 1
+document = "paper.xtex"
+
+[[revision]]
+id     = "c1"
+kind   = "add"
+author = "reviewer-2"
+at     = "2026-08-28T09:12:00Z"
+message = "Qualify the claim."
+
+[[revision]]
+id     = "c2"
+kind   = "del"
+author = "reviewer-2"
+at     = "2026-08-28T09:15:00Z"
+message = "Obsolete."


### PR DESCRIPTION
Closes #73. **Stacked on #94 — merge #94 first**; this PR's base is main so it lands there cleanly after.

## The two exports

- **`xtex_view`** — `original` / `final` / `marked`, then a bundle → the root under that view, byte-identical to the native emitter. The test pins the semantics, not just the equality: the two unmarked views actually differ over a deletion, and the marked view differs from final — the one sanctioned injection (`decisions/0002`).
- **`xtex_revise`** — `action` (`accept`/`reject`/`accept-all`/`prune`), `id`, `by`, `at`, the sidecar, then a bundle → the rewritten root and the updated sidecar as one length-prefixed pair. The host supplies reviewer and timestamp because the module deliberately cannot ask a clock.

## The interoperability claim, crossed both ways

A sidecar the module updates is **parsed and validated by the same code the CLI uses** — and validated against the rewritten document, not just parsed. A sidecar the CLI's resolver wrote is read back by the module's path. Both directions in one test.

## Verification

| Check | Result |
|---|---|
| three views vs native emitter | byte for byte |
| views are built documents; unmarked views differ over the deletion; marked ≠ final | pinned |
| accept through the module: construct gone, text kept, event recorded with the host's reviewer | pinned |
| mutation: final emitted through the marked path | fails the view test |
| mutation: resolution event dropped from the sidecar | fails its assertion |
| `fmt`, `clippy -D warnings`, full suite | clean |

Merge order: **#94 → this**. #75 (release artefact) comes independently off main next.