### PR TITLE
Publish the WebAssembly module as a versioned artefact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: release
+
+# A tag `wasm-v*` publishes the WebAssembly artefact a separate repository
+# depends on. The tag is the version the consumer pins; the manifest inside
+# the artefact carries the ABI version, the commit and the module's SHA-256,
+# so what is being held is checkable without trusting the file name.
+on:
+  push:
+    tags: ["wasm-v*"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  wasm-artefact:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - run: bash scripts/release-wasm.sh target/xtex-wasm-release
+      - run: |
+          cd target/xtex-wasm-release
+          tar czf "../xtex-wasm-${GITHUB_REF_NAME}.tar.gz" .
+      - run: gh release create "$GITHUB_REF_NAME" "target/xtex-wasm-${GITHUB_REF_NAME}.tar.gz" --title "$GITHUB_REF_NAME" --notes "See manifest.json inside the artefact for the ABI version, commit and SHA-256."
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -1,5 +1,13 @@
 # The WebAssembly build
 
+## ABI version 1
+
+The version names the calling convention and the input framings below, not the compiler's behaviour. It
+changes when a consumer pinned to the previous one would stop working: an export removed or renamed, a
+framing reordered, the bundle format changed. New exports do not change it. The release manifest carries
+this number beside the commit and the module's SHA-256, so a consumer can tell what it is holding without
+trusting a file name.
+
 The same compiler, as a `.wasm` file the browser runs. No compile server, and no
 `wasm-bindgen`.
 

--- a/scripts/release-wasm.sh
+++ b/scripts/release-wasm.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Builds the WebAssembly artefact a separate repository can depend on.
+#
+# One command, and everything a consumer cannot reconstruct travels inside:
+# the ABI version, the commit the module was built from, and the reference
+# host. The output directory is self-contained; nothing in it needs this
+# repository.
+set -eu
+
+here="$(cd "$(dirname "$0")/.." && pwd)"
+out="${1:-$here/target/xtex-wasm-release}"
+
+commit="$(git -C "$here" rev-parse HEAD)"
+if [ -n "$(git -C "$here" status --porcelain)" ]; then
+    echo "refusing to release a dirty working tree: the manifest would name a commit the bytes are not from" >&2
+    exit 1
+fi
+abi="$(grep -m1 '^## ABI version' "$here/docs/wasm.md" | sed 's/.*version //')"
+if [ -z "$abi" ]; then
+    echo "docs/wasm.md carries no ABI version heading" >&2
+    exit 1
+fi
+
+cargo build --quiet -p xtex-wasm --target wasm32-unknown-unknown --release
+
+rm -rf "$out"
+mkdir -p "$out"
+cp "$here/target/wasm32-unknown-unknown/release/xtex_wasm.wasm" "$out/xtex.wasm"
+# The reference host: the same file the parity suite runs, copied verbatim so
+# the artefact documents itself with code that is tested rather than prose
+# that is not.
+cp "$here/crates/xtex-wasm/tests/parity.mjs" "$out/reference-host.mjs"
+cp "$here/docs/wasm.md" "$out/wasm.md"
+
+hash="$(shasum -a 256 "$out/xtex.wasm" 2>/dev/null | cut -d' ' -f1 || sha256sum "$out/xtex.wasm" | cut -d' ' -f1)"
+cat > "$out/manifest.json" <<MANIFEST
+{
+  "abi": "$abi",
+  "commit": "$commit",
+  "sha256": "$hash",
+  "module": "xtex.wasm"
+}
+MANIFEST
+
+echo "released ABI $abi from $commit"
+echo "  $out/xtex.wasm ($(wc -c < "$out/xtex.wasm" | tr -d ' ') bytes)"


### PR DESCRIPTION
Closes #75. **Independent of #94/#95** — merge in any order; it touches only `scripts/`, `.github/workflows/` and the `wasm.md` header.

## What a consumer gets

`bash scripts/release-wasm.sh` → one self-contained directory:

| File | What it is |
|---|---|
| `xtex.wasm` | the module (334 KB today) |
| `manifest.json` | `{"abi":"1","commit":"…","sha256":"…"}` — what you are holding, checkable without trusting a file name |
| `wasm.md` | the ABI documentation, version header included |
| `reference-host.mjs` | **the same file the parity suite runs, copied verbatim** — the artefact documents itself with code that is tested, not prose that is not |

Verified live: the artefact was built and the reference host ran against it from a scratch directory, producing check/emit/map/rename outputs with nothing from this repository.

## The two rules that carry it

- **A dirty working tree refuses to release** — a manifest naming a commit the bytes are not from is the measurement-provenance failure this repository keeps finding elsewhere. Proven live: the first run refused until the work was committed.
- **The ABI version names the calling convention, not behaviour.** It changes when a pinned consumer would stop working (export removed, framing reordered, bundle format changed); a new export does not change it. It lives in `docs/wasm.md` and the script transcribes it into the manifest — no second copy to drift.

## CI

A tag `wasm-v*` builds the artefact and publishes the tarball as a GitHub release. The tag is the consumer's pin; the manifest is the proof of contents.

## The known cost, restated from the issue

The ABI freezes before its first consumer finishes shaping it, and the web repo will force lockstep releases early. Accepted deliberately: the alternative was mixing an AGPL engine into an MIT history, which no later payment undoes.

With #94 and #95 merged, a `wasm-v1` tag hands the web repository everything Phase 6 built. #74 (full-surface parity in CI) is the remaining issue of the phase.