### PR TITLE
Prove the two builds answer alike across the whole surface, in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
+      # The parity suite skips, loudly, when node or the wasm target are
+      # absent — which meant CI had been green while never running it. Node
+      # ships on the runner; the target is installed above; and the guard
+      # after the tests turns any skip line into a failure, so the suite
+      # cannot fall silent again without CI saying so.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
       - uses: Swatinem/rust-cache@v2
 
       - name: format
@@ -28,4 +37,7 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: test
-        run: cargo test --workspace
+        run: cargo test --workspace -- --nocapture 2>&1 | tee test-output.log
+
+      - name: the parity suite ran rather than skipped
+        run: '! grep -q "^skipped:" test-output.log'

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -561,3 +561,90 @@ fn a_bundle_that_lies_about_its_lengths_returns_no_result_and_does_not_crash() {
         .expect("node runs");
     assert!(ran.success(), "a malformed bundle crashed the module");
 }
+
+#[test]
+fn every_export_the_module_declares_is_exercised_by_the_suite() {
+    // Coverage by construction: a new export that no parity case touches
+    // fails here, so the suite cannot quietly fall behind the surface. The
+    // export list is read from the source rather than maintained by hand,
+    // because a hand-kept list is the thing that drifts.
+    let repo = repo();
+    let source = std::fs::read_to_string(repo.join("crates/xtex-wasm/src/lib.rs"))
+        .expect("the module's source");
+    let mut exports: Vec<&str> = source
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let rest = line
+                .strip_prefix("pub unsafe extern \"C\" fn ")
+                .or_else(|| line.strip_prefix("pub extern \"C\" fn "))?;
+            rest.split('(').next()
+        })
+        .collect();
+    exports.sort_unstable();
+    assert!(!exports.is_empty(), "no exports found; the parser broke");
+
+    let drivers = [
+        std::fs::read_to_string(repo.join("crates/xtex-wasm/tests/parity.mjs")).unwrap(),
+        std::fs::read_to_string(repo.join("crates/xtex-wasm/tests/malformed.mjs")).unwrap(),
+    ];
+    let uncovered: Vec<&&str> = exports
+        .iter()
+        .filter(|name| !drivers.iter().any(|driver| driver.contains(**name)))
+        .collect();
+    assert!(
+        uncovered.is_empty(),
+        "exports with no parity case: {uncovered:?}"
+    );
+}
+
+#[test]
+fn failure_paths_fail_identically_in_both_builds() {
+    // The builds must agree about failure, not only success: an unreadable
+    // bibliography's advisory and a quarantined file's silence are answers
+    // too, and a divergence there is found by an author, not by us.
+    let repo = repo();
+    let Some(module) = built_module(&repo) else {
+        return;
+    };
+
+    let broken = repo.join("target/wasm-parity/broken-src");
+    std::fs::create_dir_all(&broken).expect("a scratch project");
+    // An unreadable bibliography: cited, declared, and absent from the
+    // bundle. A quarantined import: a \verb that never closes.
+    std::fs::write(
+        broken.join("main.xtex"),
+        "Ver @cite(clave) y @ref(sec:x).\n@import(\"dark.xtex\")\n\\bibliography{ausente}\n",
+    )
+    .expect("writes");
+    std::fs::write(broken.join("dark.xtex"), "\\verb+sin cierre\n\\label{sec:x}\n")
+        .expect("writes");
+
+    let out = repo.join("target/wasm-parity/broken");
+    run_module(&repo, &module, &broken, "main.xtex", &out);
+    let wasm_json = std::fs::read_to_string(out.join("wasm.json")).expect("the module checked");
+
+    let store = memory_of(&broken);
+    let (sources, diagnostics, coverage, _) = xtex_core::project::check_project(
+        &store,
+        "main.xtex",
+        xtex_core::symbols::PrefixMap::default(),
+    )
+    .expect("checks");
+    let mut native_json = String::new();
+    xtex_core::check::to_json(&sources, &diagnostics, coverage, &mut native_json);
+    assert_eq!(native_json, wasm_json, "the builds disagree about failure");
+
+    // And the failure is the RIGHT failure: the advisory names the missing
+    // bibliography, and the quarantined import silences XT1003 rather than
+    // blaming the author for a label we could not read.
+    assert!(
+        wasm_json.contains("XT2001") && wasm_json.contains("ausente"),
+        "the advisory must name the file: {wasm_json}"
+    );
+    assert!(
+        !wasm_json.contains("XT1003"),
+        "a quarantined file must silence the inventory: {wasm_json}"
+    );
+}
+

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -617,8 +617,11 @@ fn failure_paths_fail_identically_in_both_builds() {
         "Ver @cite(clave) y @ref(sec:x).\n@import(\"dark.xtex\")\n\\bibliography{ausente}\n",
     )
     .expect("writes");
-    std::fs::write(broken.join("dark.xtex"), "\\verb+sin cierre\n\\label{sec:x}\n")
-        .expect("writes");
+    std::fs::write(
+        broken.join("dark.xtex"),
+        "\\verb+sin cierre\n\\label{sec:x}\n",
+    )
+    .expect("writes");
 
     let out = repo.join("target/wasm-parity/broken");
     run_module(&repo, &module, &broken, "main.xtex", &out);
@@ -647,4 +650,3 @@ fn failure_paths_fail_identically_in_both_builds() {
         "a quarantined file must silence the inventory: {wasm_json}"
     );
 }
-


### PR DESCRIPTION
Closes #74 — the last issue of Phase 6. Independent of #96; merge in any order.

## The embarrassing finding first

The parity suite skips, loudly, when node or the wasm target are absent. **CI installs neither, so every green run to date ran none of it** — the exact "silent skip" failure the suite's own doc comment warns about, one layer up. The workflow now installs both, and a post-test guard greps the output for `skipped:` and fails on any hit. The suite cannot fall silent again without CI saying so.

## Coverage by construction

`every_export_the_module_declares_is_exercised_by_the_suite` reads the export list **from the module's source** and demands each name appear in a driver. A hand-kept list is the thing that drifts; this one cannot. Adding a probe export with no case fails the suite — done, verified, removed.

## Failure paths, pinned

The builds must agree about failure too — a divergence there is found by an author, not by us. A project with an unreadable bibliography and a quarantined import goes through both builds: byte-identical JSON, and the content pinned — `XT2001` names the missing file, and **no `XT1003`** blames the author for a label behind the quarantine. A build that quietly dropped the advisory fails the case.

## Verification

| Check | Result |
|---|---|
| 9 parity tests, whole surface (check/emit/map, blame, rename, queries, views/revise, malformed, failure paths) | pass |
| mutation: uncovered export | fails, naming it |
| mutation: advisory dropped in one build | fails |
| `fmt`, `clippy -D warnings`, full suite | clean |

With this and #96, Phase 6 is complete: the module is an API, proven equal to the CLI across its whole surface, published as a versioned artefact — everything the web repository needs to start.