### PR TITLE
Render a related entry as JSON, not almost-JSON

### DIFF
--- a/crates/xtex-core/src/check.rs
+++ b/crates/xtex-core/src/check.rs
@@ -596,11 +596,15 @@ pub fn to_json(sources: &Sources, diagnostics: &[Diagnostic], coverage: f64, out
             if related_index > 0 {
                 out.push(',');
             }
-            out.push('{');
-            // A related note has a span and a message and no code of its own.
-            write_span(sources, related.source, related.span, out);
-            out.push_str(",\"message\":");
+            // A related note has a message and a span and no code of its
+            // own. The message comes first because `write_span` writes a
+            // leading comma on the assumption that a field precedes it — the
+            // assumption this loop broke, emitting `{,\"span\":` and handing
+            // every consumer of a related-carrying diagnostic malformed
+            // JSON. Found by the first real document the web UI checked.
+            out.push_str("{\"message\":");
             write_json_string(&related.message, out);
+            write_span(sources, related.source, related.span, out);
             out.push('}');
         }
         out.push_str("]}");

--- a/crates/xtex-wasm/tests/parity.mjs
+++ b/crates/xtex-wasm/tests/parity.mjs
@@ -61,7 +61,11 @@ function bundle(dir, root) {
 
 const project = bundle(projectDir, rootName);
 writeFileSync(`${outDir}/wasm.tex`, call("xtex_emit", project));
-writeFileSync(`${outDir}/wasm.json`, call("xtex_check_json", project));
+const checkJson = call("xtex_check_json", project);
+// Byte-equality between builds is satisfied by two equally malformed
+// answers; parsing is what proves the JSON is JSON.
+JSON.parse(new TextDecoder().decode(checkJson));
+writeFileSync(`${outDir}/wasm.json`, checkJson);
 writeFileSync(`${outDir}/wasm.map`, call("xtex_source_map", project));
 
 // Helper: length-prefixed texts followed by the bundle.

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -612,9 +612,12 @@ fn failure_paths_fail_identically_in_both_builds() {
     std::fs::create_dir_all(&broken).expect("a scratch project");
     // An unreadable bibliography: cited, declared, and absent from the
     // bundle. A quarantined import: a \verb that never closes.
+    // The duplicate @id makes XT1001 fire, whose diagnostic carries a
+    // `related` entry — the shape whose JSON rendering shipped malformed
+    // (`{,"span"`) until the first real document met it.
     std::fs::write(
         broken.join("main.xtex"),
-        "Ver @cite(clave) y @ref(sec:x).\n@import(\"dark.xtex\")\n\\bibliography{ausente}\n",
+        "@id(dup:x) y @id(dup:x).\nVer @cite(clave) y @ref(sec:x).\n@import(\"dark.xtex\")\n\\bibliography{ausente}\n",
     )
     .expect("writes");
     std::fs::write(
@@ -648,5 +651,9 @@ fn failure_paths_fail_identically_in_both_builds() {
     assert!(
         !wasm_json.contains("XT1003"),
         "a quarantined file must silence the inventory: {wasm_json}"
+    );
+    assert!(
+        wasm_json.contains("XT1001") && wasm_json.contains("first declared here"),
+        "the duplicate must carry its related entry: {wasm_json}"
     );
 }


### PR DESCRIPTION
Closes nothing by number — found by the first real document the web UI checked.

## The defect

A diagnostic carrying a `related` entry — a duplicate identifier's "first declared here" — rendered as:

```json
"related":[{,"span":{"file":"sections/metodo.xtex",...
```

Malformed JSON; every consumer falls over. Root cause: `write_span` writes a **leading comma** on the documented assumption that a field precedes it, and the related-entry loop opened a brace and called it bare.

## Why nothing caught it

- No parity fixture had a related-carrying diagnostic.
- Byte-equality between builds is satisfied by **two equally malformed answers**.

## The fix, and the hardening

- The message now precedes the span inside a related entry, so `write_span`'s assumption holds.
- The parity driver **`JSON.parse`s** the check output instead of only comparing it.
- The failure-path fixture gained a duplicate `@id`, so a related-carrying diagnostic crosses the ABI in CI on every run.

## Verification

| Check | Result |
|---|---|
| hello-world project (the document that found it) | JSON parses, diagnostics correct |
| mutation: reintroduce the bare `write_span` call | run fails with `SyntaxError` from `JSON.parse` |
| `fmt`, `clippy -D warnings`, full suite | clean |

## After merge

Tag `wasm-v1.1`, so the web repository pins a module whose JSON parses — its lock updates in its own commit.