### PR TITLE
XT1014: unterminated inline constructs are hard errors at their entry token

### DIFF
--- a/crates/xtex-core/src/check.rs
+++ b/crates/xtex-core/src/check.rs
@@ -215,6 +215,27 @@ pub fn check_documents(
                 Node::Opaque { .. } => return,
             };
             let Some(block_kind) = block_kind(kind) else {
+                // An explicit inline construct that never closed: the scanner
+                // reported it at its entry token, and the grammar makes that a
+                // hard error (grammar.md §inline). Dropping it here was the
+                // hole that let `@id(x` fail only at its references.
+                if malformed {
+                    if let Some(entry) = inline_entry(kind) {
+                        diagnostics.push(Diagnostic {
+                            code: "XT1014",
+                            entity: EntityClass::UnknownOpen,
+                            name: None,
+                            source,
+                            span,
+                            message: format!(
+                                "`{entry}` never closes before the end of its line — expected `)`"
+                            ),
+                            related: Vec::new(),
+                            severity: Severity::Error,
+                            blame: Blame::XtexConstruct,
+                        });
+                    }
+                }
                 return;
             };
             let Some(bytes) = sources.get(source).map(crate::source::Source::bytes) else {
@@ -241,6 +262,16 @@ pub fn check_documents(
         });
     }
     diagnostics
+}
+
+fn inline_entry(kind: EntryToken) -> Option<&'static str> {
+    match kind {
+        EntryToken::Id => Some("@id"),
+        EntryToken::Ref => Some("@ref"),
+        EntryToken::Cite => Some("@cite"),
+        EntryToken::Import => Some("@import"),
+        _ => None,
+    }
 }
 
 fn block_kind(kind: EntryToken) -> Option<BlockKind> {
@@ -525,6 +556,20 @@ mod tests {
             }),
         );
         assert!(found.is_empty());
+    }
+
+    #[test]
+    fn an_unterminated_inline_construct_is_a_hard_error_at_its_entry_token() {
+        let mut sources = Sources::new();
+        let id = sources.add("main.xtex", b"hola @id(x:one\nSee @ref(x:one).".to_vec());
+        let document = parse(&sources, id);
+        let found = check_documents(&sources, std::slice::from_ref(&document), |_, _| true);
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert_eq!(found[0].code, "XT1014");
+        assert!(found[0].message.contains("`@id`"));
+        // At the entry token on the FIRST line — where the fix belongs —
+        // not at the reference that fails as a consequence.
+        assert_eq!(found[0].span.start(), 5);
     }
 
     #[test]

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -113,6 +113,7 @@ error.
 | `XT1011` | A sidecar record's `kind` disagrees with its construct | any |
 | `XT1012` | A sidecar record whose revision construct no longer exists | any |
 | `XT1013` | A sidecar that cannot be read, or that names a different document | any |
+| `XT1014` | An explicit inline construct (`@id`, `@ref`, `@cite`, `@import`) whose closing `)` is not found before line end | any |
 
 Two properties hold across the whole table and are tested as properties, not as examples:
 


### PR DESCRIPTION
## Problem

`grammar.md` §inline says of an inline construct that never closes on its line: *"the explicit construct produces a hard error at its entry token"*. The checker did not implement it, and the closed error table in `checking.md` never received the row.

Observed (director's report, from the web editor): delete one `)` from `@id(sec:hello` and the only error is `XT1003` at the `@ref` — the reference site, not the fix site. Minimal case: `hola @ref(x:one` alone checks **clean, exit 0**.

The scanner was already right — it produces `Piece::Malformed` spanning the entry token. The hole is in `check_documents`: `Node::Malformed` was only handled when `block_kind()` matched (`\figure`/`\table`); malformed inline nodes fell through the `else` and were dropped.

## What changed

| File | Change |
|---|---|
| `crates/xtex-core/src/check.rs` | Malformed inline nodes (`@id`, `@ref`, `@cite`, `@import`) emit `XT1014` at the entry token: `` `@id` never closes before the end of its line — expected `)` `` |
| `docs/checking.md` | Table row for `XT1014` |
| `crates/xtex-core/src/check.rs` (tests) | `an_unterminated_inline_construct_is_a_hard_error_at_its_entry_token` — asserts the code, the message, and that the span sits at the entry token on line 1, not at the downstream reference |

Both closed-table properties hold: the row requires an explicit construct (ordinary LaTeX cannot reach it), and no uncertainty is involved — the construct is explicit and unclosed by observation.

## Evidence

The director's case now reports both sides, consequence and cause:

```
error[XT1003]: identifier `sec:hello` is not declared
  --> broken.xtex:5:18
error[XT1014]: `@id` never closes before the end of its line — expected `)`
  --> broken.xtex:3:16
```

## Exit criteria

- [x] `cargo test --workspace` — all green (170 core tests incl. the new one)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Release binary re-run on the reproducing document: `XT1014` at 3:16 alongside `XT1003`

## After merge

Tag `wasm-v1.2` and repin the web repo's `artifacts.lock.json` so the editor underlines the broken `@id(` line itself.