### PR TITLE
Marked view: inject the preamble only into documents, never fragments

### DIFF
--- a/crates/xtex-core/src/lib.rs
+++ b/crates/xtex-core/src/lib.rs
@@ -235,7 +235,15 @@ pub fn emit_view(
     if view == RevisionView::Marked {
         let mut body = Vec::new();
         emit_nodes(sources, document, view, &mut body)?;
-        let insertion = documentclass_end(&body).unwrap_or(0);
+        // Only a document with a preamble receives the marked packages. A
+        // fragment — an imported file emitted with itself as the root, the
+        // documented host pattern — must not: injecting at byte 0 lands
+        // \usepackage inside the parent's body, where LaTeX refuses it.
+        // The root document's own injection covers its children.
+        let Some(insertion) = documentclass_end(&body) else {
+            out.extend_from_slice(&body);
+            return Ok(());
+        };
         out.extend_from_slice(&body[..insertion]);
         out.extend_from_slice(b"\\usepackage{xcolor}\n\\usepackage[normalem]{ulem}\n");
         out.extend_from_slice(&body[insertion..]);
@@ -663,6 +671,40 @@ pub fn transport(
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn a_fragment_marked_view_gains_no_preamble() {
+        let mut sources = source::Sources::new();
+        let id = sources.add(
+            "part.xtex",
+            b"gain is @sub(c) {dramatic -> consistent} here".to_vec(),
+        );
+        let document = parse(&sources, id);
+        let mut out = Vec::new();
+        emit_view(&sources, &document, RevisionView::Marked, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            !text.contains("usepackage"),
+            "a fragment must not receive the marked preamble: {text}"
+        );
+        assert!(text.contains("dramatic"), "{text}");
+    }
+
+    #[test]
+    fn a_document_marked_view_gains_the_preamble_after_documentclass() {
+        let mut sources = source::Sources::new();
+        let id = sources.add(
+            "paper.xtex",
+            b"\\documentclass{article}\ngain is @sub(c) {a -> b} here".to_vec(),
+        );
+        let document = parse(&sources, id);
+        let mut out = Vec::new();
+        emit_view(&sources, &document, RevisionView::Marked, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        let class = text.find("documentclass").unwrap();
+        let package = text.find("usepackage{xcolor}").unwrap();
+        assert!(package > class, "{text}");
+    }
     use super::*;
     use io::Memory;
     use source::Span;


### PR DESCRIPTION
## Problem

`emit_view` under `RevisionView::Marked` inserts `\usepackage{xcolor}` + `\usepackage[normalem]{ulem}` at `documentclass_end(&body).unwrap_or(0)`. For a **fragment** — a file with no `\documentclass`, which is exactly what an imported file looks like when emitted with itself as the root, the documented host pattern — the fallback `0` puts the packages at the top of the fragment. `\input` into the parent, they land mid-body and LaTeX halts: `Can be used only in preamble`.

Found by the web editor's first Marked compile of the multi-file demo (root + two imported sections).

## What changed

| File | Change |
|---|---|
| `crates/xtex-core/src/lib.rs` | No `\documentclass` in the emitted body → the marked body is emitted untouched; the root document's own injection covers its children |
| tests | `a_fragment_marked_view_gains_no_preamble` (marked `@sub` survives, no `usepackage`); `a_document_marked_view_gains_the_preamble_after_documentclass` (injection sits after `\documentclass`) |

## Evidence

- Both new tests fail on the previous code and pass now; 172 core tests green.
- The web editor carries a host-side strip of this exact injection as a stopgap (`web` commit "Two demo projects…"); after this merges and the artefact repins, that strip becomes dead and will be removed.

## Exit criteria

- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean