### PR TITLE
xtex_inventory export + bibliography state in check's two output forms

### DIFF
--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -256,13 +256,13 @@ fn check_command(args: &[String]) -> ExitCode {
     }
 
     match run_check(inputs[0]) {
-        Ok((sources, diagnostics, coverage, _bibliography)) => {
+        Ok((sources, diagnostics, coverage, bibliography)) => {
             if json {
                 {
                     // One renderer, shared with the WebAssembly build, so the two
                     // cannot drift.
                     let mut json = String::new();
-                    to_json(&sources, &diagnostics, coverage, &mut json);
+                    to_json(&sources, &diagnostics, coverage, &bibliography, &mut json);
                     println!("{json}");
                 }
             } else {
@@ -270,6 +270,14 @@ fn check_command(args: &[String]) -> ExitCode {
                     print_human(&sources, diagnostic);
                 }
                 println!("coverage: {:.1}%", coverage * 100.0);
+                match &bibliography {
+                    xtex_core::bibliography::Bibliography::Complete(keys) => {
+                        println!("bibliography: complete ({} entries)", keys.len());
+                    }
+                    xtex_core::bibliography::Bibliography::Unavailable(unavailable) => {
+                        println!("bibliography: unavailable — {}", unavailable.reason());
+                    }
+                }
             }
             if diagnostics
                 .iter()

--- a/crates/xtex-core/src/check.rs
+++ b/crates/xtex-core/src/check.rs
@@ -589,6 +589,31 @@ mod json_tests {
 
     /// The JSON was unrendered by any test until the WebAssembly build needed
     /// it. A scripted refactor scrambled the field order and every test still
+    #[test]
+    fn the_inventory_names_every_declaration_with_its_uses() {
+        let mut sources = Sources::new();
+        let id = sources.add(
+            "j.xtex",
+            b"\\section{A}@id(sec:a) then @ref(sec:a) and @ref(sec:a) and @id(fig:b)\n".to_vec(),
+        );
+        let document = parse(&sources, id);
+        let mut table = SymbolTable::new();
+        table.merge(&sources, &document);
+        let mut json = String::new();
+        crate::editor::inventory_to_json(&sources, &table, &mut json);
+        assert!(json.starts_with("[{") && json.ends_with("}]"), "{json}");
+        // Sorted by name: fig:b before sec:a; counts and class exact.
+        let fig = json.find("\"name\":\"fig:b\"").expect("fig:b listed");
+        let sec = json.find("\"name\":\"sec:a\"").expect("sec:a listed");
+        assert!(fig < sec, "{json}");
+        assert!(
+            json.contains("\"name\":\"sec:a\",\"class\":\"section\",\"references\":2"),
+            "{json}"
+        );
+        assert!(json.contains("\"references\":0"), "{json}");
+        assert!(json.contains("\"span\":{\"file\":\"j.xtex\""), "{json}");
+    }
+
     /// passed, which is how this one came to exist.
     #[test]
     fn the_json_is_well_formed_and_carries_every_field() {
@@ -597,15 +622,23 @@ mod json_tests {
         let document = parse(&sources, id);
         let mut table = SymbolTable::new();
         table.merge(&sources, &document);
-        let diagnostics = check(
-            &table,
-            &Bibliography::Unavailable(Unavailable::NoneDeclared),
-        );
+        let bibliography = Bibliography::Unavailable(Unavailable::NoneDeclared);
+        let diagnostics = check(&table, &bibliography);
 
         let mut json = String::new();
-        to_json(&sources, &diagnostics, document.coverage(), &mut json);
+        to_json(
+            &sources,
+            &diagnostics,
+            document.coverage(),
+            &bibliography,
+            &mut json,
+        );
 
         assert!(json.starts_with("{\"coverage\":"), "{json}");
+        assert!(
+            json.contains("\"bibliography\":{\"state\":\"unavailable\",\"reason\":"),
+            "{json}"
+        );
         assert!(json.ends_with("]}"), "{json}");
         for field in [
             "\"code\":\"XT1003\"",
@@ -789,13 +822,30 @@ fn location(
 /// has no stdout and the exit criterion of #18 is that its JSON equals the
 /// native tool's byte for byte. One implementation makes that true by
 /// construction; two would make it a coincidence to be re-checked.
-pub fn to_json(sources: &Sources, diagnostics: &[Diagnostic], coverage: f64, out: &mut String) {
+pub fn to_json(
+    sources: &Sources,
+    diagnostics: &[Diagnostic],
+    coverage: f64,
+    bibliography: &Bibliography,
+    out: &mut String,
+) {
     // Six decimals, not the sixteen an f64 prints. The extra digits are false
     // precision on a ratio of byte counts, and they are not reproducible: the
     // WebAssembly build computes `1.0 - opaque/total` on 32-bit `usize` and
     // lands one bit away from the native build, which made the two outputs
     // differ at the sixteenth digit and nowhere else.
-    let _ = write!(out, "{{\"coverage\":{coverage:.6},\"diagnostics\":[");
+    let _ = write!(out, "{{\"coverage\":{coverage:.6},\"bibliography\":");
+    match bibliography {
+        Bibliography::Complete(keys) => {
+            let _ = write!(out, "{{\"state\":\"complete\",\"entries\":{}}}", keys.len());
+        }
+        Bibliography::Unavailable(unavailable) => {
+            out.push_str("{\"state\":\"unavailable\",\"reason\":");
+            write_json_string(&unavailable.reason(), out);
+            out.push('}');
+        }
+    }
+    out.push_str(",\"diagnostics\":[");
     for (index, diagnostic) in diagnostics.iter().enumerate() {
         if index > 0 {
             out.push(',');
@@ -838,7 +888,12 @@ pub fn to_json(sources: &Sources, diagnostics: &[Diagnostic], coverage: f64, out
 
 /// Appends `,"span":{...}` for one span. The leading comma is included because
 /// every caller has already written a field before it.
-fn write_span(sources: &Sources, source: SourceId, span: crate::source::Span, out: &mut String) {
+pub(crate) fn write_span(
+    sources: &Sources,
+    source: SourceId,
+    span: crate::source::Span,
+    out: &mut String,
+) {
     let (file, line, column) = location(sources, source, span);
     out.push_str(",\"span\":{\"file\":");
     write_json_string(file, out);
@@ -851,7 +906,7 @@ fn write_span(sources: &Sources, source: SourceId, span: crate::source::Span, ou
 }
 
 /// Appends `value` as a quoted JSON string.
-fn write_json_string(value: &str, out: &mut String) {
+pub(crate) fn write_json_string(value: &str, out: &mut String) {
     out.push('"');
     for character in value.chars() {
         match character {

--- a/crates/xtex-core/src/editor.rs
+++ b/crates/xtex-core/src/editor.rs
@@ -307,6 +307,33 @@ pub fn hover_to_json(found: &Hover, out: &mut String) {
     out.push('}');
 }
 
+/// Renders the whole identity inventory: every declaration, sorted by name,
+/// with its class, its declaration site, and its reference count.
+pub fn inventory_to_json(sources: &Sources, table: &SymbolTable, out: &mut String) {
+    out.push('[');
+    for (index, (name, declaration)) in table.declarations().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push_str("{\"name\":");
+        crate::check::write_json_string(name, out);
+        let _ = write!(
+            out,
+            ",\"class\":\"{}\",\"references\":{}",
+            declaration.class.name(),
+            table.reference_count(name)
+        );
+        crate::check::write_span(
+            sources,
+            declaration.payload.source,
+            declaration.payload.span,
+            out,
+        );
+        out.push('}');
+    }
+    out.push(']');
+}
+
 /// Renders completions as JSON, one renderer for both hosts.
 pub fn completions_to_json(items: &[Completion], out: &mut String) {
     out.push('[');

--- a/crates/xtex-core/src/project.rs
+++ b/crates/xtex-core/src/project.rs
@@ -435,7 +435,7 @@ mod bibliography_advisory_tests {
         assert_eq!(advisory.blame, Blame::Unresolved);
         assert_eq!(advisory.name, None, "the advisory is not about a key");
         let mut json = String::new();
-        to_json(&sources, &[advisory], 1.0, &mut json);
+        to_json(&sources, &[advisory], 1.0, &bibliography, &mut json);
         assert!(json.contains("\"severity\":\"advisory\""), "{json}");
         assert!(
             json.contains("citation checking unavailable: `refs.bib` could not be read"),

--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -311,6 +311,22 @@ impl SymbolTable {
         self.declarations.keys().map(String::as_str)
     }
 
+    /// Every declaration with its name, sorted by name.
+    pub fn declarations(&self) -> impl Iterator<Item = (&str, &Declaration)> {
+        self.declarations
+            .iter()
+            .map(|(name, declaration)| (name.as_str(), declaration))
+    }
+
+    /// How many references demand `name`.
+    #[must_use]
+    pub fn reference_count(&self, name: &str) -> usize {
+        self.references
+            .iter()
+            .filter(|(reference, _)| reference == name)
+            .count()
+    }
+
     /// Class demanded by `name` under this table's project prefix map.
     #[must_use]
     pub fn demand_of(&self, name: &str) -> EntityClass {

--- a/crates/xtex-wasm/src/lib.rs
+++ b/crates/xtex-wasm/src/lib.rs
@@ -189,7 +189,7 @@ pub unsafe extern "C" fn xtex_check_json(pointer: *const u8, len: usize) -> *mut
     };
     // No `xtex.toml` reaches a browser yet; the default prefixes apply, as
     // they do for a project on disk that carries none.
-    let Ok((sources, diagnostics, coverage, _)) = check_project(
+    let Ok((sources, diagnostics, coverage, bibliography)) = check_project(
         &bundle.store,
         &bundle.root,
         xtex_core::symbols::PrefixMap::default(),
@@ -197,7 +197,29 @@ pub unsafe extern "C" fn xtex_check_json(pointer: *const u8, len: usize) -> *mut
         return result(&[]);
     };
     let mut json = String::new();
-    to_json(&sources, &diagnostics, coverage, &mut json);
+    to_json(&sources, &diagnostics, coverage, &bibliography, &mut json);
+    result(json.as_bytes())
+}
+
+/// The project's identity inventory: every declaration with its class, its
+/// site, and how many references demand it. One JSON array, sorted by name —
+/// what an editor needs to draw the typed world and to say "3 references"
+/// above an `@id` without guessing.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_inventory(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    let Some(bundle) = decode_bundle(&bytes) else {
+        return result(&[]);
+    };
+    let Ok(analysed) = xtex_core::project::analyse(&bundle.store, &bundle.root) else {
+        return result(&[]);
+    };
+    let mut json = String::new();
+    xtex_core::editor::inventory_to_json(&analysed.sources, &analysed.table, &mut json);
     result(json.as_bytes())
 }
 

--- a/crates/xtex-wasm/tests/parity.mjs
+++ b/crates/xtex-wasm/tests/parity.mjs
@@ -107,6 +107,7 @@ const refAt = rootText.indexOf("@ref(sec:model)") + 6;
 const citeAt = rootText.indexOf("@cite(knuth1984)") + 7;
 writeFileSync(`${outDir}/wasm.hover.json`, call("xtex_hover", positional(rootName, refAt, project)));
 writeFileSync(`${outDir}/wasm.completions.json`, call("xtex_completions", positional(rootName, refAt, project)));
+writeFileSync(`${outDir}/wasm.inventory.json`, call("xtex_inventory", project));
 writeFileSync(`${outDir}/wasm.definition.json`, call("xtex_definition", positional(rootName, refAt, project)));
 writeFileSync(`${outDir}/wasm.hover.opaque.json`, call("xtex_hover", positional(rootName, rootText.indexOf("verb|sec:model") + 6, project)));
 writeFileSync(`${outDir}/wasm.hover.pastend.json`, call("xtex_hover", positional(rootName, 10_000_000, project)));

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -148,14 +148,20 @@ fn a_single_file_bundle_equals_the_native_library_byte_for_byte() {
         "emitted bytes differ; the Latin-1 byte or the 0xFF did not survive"
     );
 
-    let (sources, diagnostics, coverage, _) = xtex_core::project::check_project(
+    let (sources, diagnostics, coverage, bibliography) = xtex_core::project::check_project(
         &store,
         "awkward.xtex",
         xtex_core::symbols::PrefixMap::default(),
     )
     .expect("checks");
     let mut native_json = String::new();
-    xtex_core::check::to_json(&sources, &diagnostics, coverage, &mut native_json);
+    xtex_core::check::to_json(
+        &sources,
+        &diagnostics,
+        coverage,
+        &bibliography,
+        &mut native_json,
+    );
     let wasm_json = std::fs::read_to_string(out.join("wasm.json")).expect("the module checked");
     assert_eq!(
         native_json, wasm_json,
@@ -255,6 +261,18 @@ fn editor_queries_answer_project_wide_and_identically_in_both_builds() {
     assert!(
         wasm.contains("declared as: section"),
         "the cross-file declaration must be visible, or the table is file-local: {wasm}"
+    );
+
+    // The inventory: every declaration with class, site and use count, and
+    // the module's answer byte-identical to the native library's.
+    let mut native_inventory = String::new();
+    xtex_core::editor::inventory_to_json(&analysed.sources, &analysed.table, &mut native_inventory);
+    let wasm_inventory =
+        std::fs::read_to_string(out.join("wasm.inventory.json")).expect("the module inventoried");
+    assert_eq!(native_inventory, wasm_inventory);
+    assert!(
+        wasm_inventory.contains("\"references\":"),
+        "counts must be present: {wasm_inventory}"
     );
 
     // Completions, which must include identifiers from every file.
@@ -631,14 +649,20 @@ fn failure_paths_fail_identically_in_both_builds() {
     let wasm_json = std::fs::read_to_string(out.join("wasm.json")).expect("the module checked");
 
     let store = memory_of(&broken);
-    let (sources, diagnostics, coverage, _) = xtex_core::project::check_project(
+    let (sources, diagnostics, coverage, bibliography) = xtex_core::project::check_project(
         &store,
         "main.xtex",
         xtex_core::symbols::PrefixMap::default(),
     )
     .expect("checks");
     let mut native_json = String::new();
-    xtex_core::check::to_json(&sources, &diagnostics, coverage, &mut native_json);
+    xtex_core::check::to_json(
+        &sources,
+        &diagnostics,
+        coverage,
+        &bibliography,
+        &mut native_json,
+    );
     assert_eq!(native_json, wasm_json, "the builds disagree about failure");
 
     // And the failure is the RIGHT failure: the advisory names the missing

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -369,6 +369,11 @@ The fields:
 | `message` | One sentence, no trailing period, naming the thing rather than the rule. |
 | `related` | Zero or more spans that explain the first, each with its own message. |
 
+Beside the diagnostics, both forms carry two run-level facts: `coverage`, and `bibliography` — `complete`
+with its entry count, or `unavailable` with the same reason §7 gives the advisory. A tool that wants to say
+"your citations are actually being checked" reads it here instead of inferring it from the absence of
+`XT2001`.
+
 Human form:
 
 ```

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -82,6 +82,7 @@ file_count × ( u32 name_len   name (UTF-8)   u32 data_len   data )
 | `xtex_rename_apply(ptr, len)` | `from`, `to`, `target`, then a bundle | the target file's rewritten bytes |
 | `xtex_hover(ptr, len)` | `target`, `u32 offset`, then a bundle | hover text |
 | `xtex_completions(ptr, len)` | `target`, `u32 offset`, then a bundle | completion items |
+| `xtex_inventory(ptr, len)` | a bundle | every declaration — name, class, declaration site, reference count — sorted by name |
 | `xtex_definition(ptr, len)` | `target`, `u32 offset`, then a bundle | the declaration, file included |
 | `xtex_view(ptr, len)` | `view` (`original`/`final`/`marked`), then a bundle | the root under that view |
 | `xtex_revise(ptr, len)` | `action`, `id`, `by`, `at`, `sidecar`, then a bundle | the rewritten root, then the updated sidecar, both length-prefixed |


### PR DESCRIPTION
## What this adds

Two compiler-side foundations for the editor's next visual features (director's request: coverage bar, bibliography semaphore, identity inventory, reference counts).

| Piece | What it answers |
|---|---|
| `xtex_inventory(bundle)` (wasm export №16) | Every declaration — name, class, declaration site, reference count — one sorted JSON array, from the same project-merged `SymbolTable` the editor queries use |
| `bibliography` field in `check --json` AND the human form | `{"state":"complete","entries":N}` or `{"state":"unavailable","reason":…}` — the same reason §7 gives XT2001; human form prints `bibliography: complete (3 entries)` per checking.md §10's rule that a field added to one form is added to both in the same change |

Supporting API: `SymbolTable::declarations()` and `SymbolTable::reference_count()`; `write_span`/`write_json_string` open to the crate.

## Honesty notes

- A bare `@id` attached to nothing inventories as `unknown-open` — the class comes from what the declaration attached to, not from the prefix; the first test draft assumed otherwise and the compiler corrected me.
- No CLI `inventory` subcommand yet: editor exports hold parity against the native library (as hover/completions do), which the new parity assertion covers byte-for-byte.

## Evidence

- New core test: sorted entries, exact counts (`sec:a` referenced twice, `fig:b` zero), span carried.
- Parity test extended: `wasm.inventory.json` byte-identical to the native renderer.
- The JSON well-formedness test now also demands the bibliography field.

## Exit criteria

- [x] `cargo test --workspace` — 234 tests green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (read, not assumed)
- [x] `cargo fmt --all --check` clean
- [x] `docs/wasm.md` export table and `docs/checking.md` §10 updated in the same change