### PR TITLE
Writing pass: the two templated tics, varied across nine documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,7 @@ exists today.
 ## 4 · Invariants — never break these
 
 - **Untouched LaTeX comes out byte-identical.** `emit(parse(u)) == u` for input containing no ExactTeX
-  constructs. A transporter that sometimes reformats is not a slower transporter, it is a false one, and the
-  file it corrupts is an already-accepted paper.
+  constructs. A transporter that sometimes reformats is a false transporter — and the file it corrupts is an already-accepted paper.
 - **Annotating never changes the PDF.** Adding a valid annotation must not alter a rendered pixel, and must
   not turn a passing build into a failing one. Test by fuzzing annotations and comparing rasters.
 - **Erasure, never injection.** No assertions, wrapper environments or support packages are written into the
@@ -86,8 +85,7 @@ exists today.
   changes its meaning.
 - **Numbers in docs have a command behind them.** If a README or a PR claims a coverage figure, a runtime or
   an error rate, a documented command reproduces it.
-- **Dependencies are permissively licensed.** MIT, Apache-2.0, BSD, ISC. SPDX identifier read from package
-  metadata, not recalled. GPL, AGPL and SSPL are never proposed — ExactTeX is MIT, which is why texlab's
+- **Dependencies are permissively licensed.** MIT, Apache-2.0, BSD, ISC. SPDX identifier (the standard machine-readable licence code, e.g. `MIT`, `GPL-3.0-only`) read from package metadata, not recalled. GPL, AGPL and SSPL are never proposed — ExactTeX is MIT, which is why texlab's
   parser cannot be reused.
 
 ---
@@ -182,8 +180,7 @@ This repo has one maintainer, who reviews every PR. That removes the second pair
 manufactured instead:
 
 - **Run the diff past a decorrelated model arm before requesting review.** An agent writing and one human
-  reviewing is a two-link chain whose second link is the only filter. A second model lineage reading the diff
-  is not a second opinion; it is a substrate whose errors do not correlate with the one that wrote the code.
+  reviewing is a two-link chain whose second link is the only filter. A second model lineage reading the diff is a substrate whose errors do not correlate with the one that wrote the code — which a same-lineage second opinion cannot give.
   It never authors the fix — it locates defects, and the maintainer decides what to adopt.
 - **The PR carries the evidence; the reviewer does not reconstruct it.** A PR whose test plan has no real
   command output is returned unread, not reviewed partially.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ not go in a README, a PR body, or a report.
   opaque region is a silent corruption of somebody's accepted paper. If a change makes the output "nicer",
   it is a bug.
 - **`?O` is not "invalid".** Ordinary LaTeX has an unknown *open* type and is consistent with everything.
-  Making it fail is not stricter checking, it is a broken promise: a renamed `.tex` must check clean.
+  Making it fail would break a promise rather than tighten the checking: a renamed `.tex` must check clean.
 - **A structural check has to survive the constructs that legitimately break it.** Count columns without
   summing `\multicolumn` widths and the checker reports false positives on ordinary tables.
 - **A hazard has to be reproduced before it is handled.** The parser's behaviour on `\catcode` is decided by

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -59,7 +59,7 @@ paper.xtex:212 — column 3 does not fit the width you declared
 
 Same fact, said in the author's terms, using the name the author gave the object. This is only possible
 because the author declared the entity. **That is what the syntax is for: it gives the tooling names to speak
-with.** Not brevity. Names.
+with, not brevity.**
 
 An agent repairing a document needs this even more than a human does. A human annoyed by a misplaced error
 complains; an agent edits the wrong place and loops without converging.
@@ -84,8 +84,8 @@ This is what separates ExactTeX from converters. MyST *converts* LaTeX into its 
 documentation calls that "a transitional solution" and states it is not a full LaTeX renderer. Converting is
 a one-way trip. Transporting lets you go back, hand the file to a coauthor, and submit it.
 
-Transport is not the product. It is the on-ramp that makes 3.1 and 3.2 reachable from documents that already
-exist.
+Transport is the on-ramp that makes 3.1 and 3.2 reachable from documents that already exist, not the
+product in itself.
 
 ## 4. Binding design rules
 

--- a/README.md
+++ b/README.md
@@ -107,18 +107,18 @@ Known(A) ~ Known(B)   if and only if A == B     <- this can fail
 ```
 
 `?O` is consistent with everything, so nothing involving unmodelled LaTeX can be inconsistent, so nothing
-involving unmodelled LaTeX can fail. **`?O` does not mean invalid. It means the compiler has no grounds.**
+involving unmodelled LaTeX can fail. **`?O` marks absence of grounds, not invalidity.**
 
 Two consequences worth stating plainly.
 
-**Renaming a `.tex` to `.xtex` and changing nothing checks clean.** Not by care taken case by case — by
-construction, because every entity in it is `?O`. That is the gradual guarantee (Siek, Vitousek, Cimini and
+**Renaming a `.tex` to `.xtex` and changing nothing checks clean, because every entity in it is `?O`.**
+That holds by construction, without case-by-case care. That is the gradual guarantee (Siek, Vitousek, Cimini and
 Boyland, SNAPL 2015) instantiated for documents, and it is what makes the on-ramp real rather than a
 promise.
 
 **You choose how much to annotate, and the compiler tells you how much you chose.** `xtex check` reports
-coverage: the fraction of the document it checked. This is the analogue of `any` and `noImplicitAny`. What
-matters is not the number but a fall in it — a file that was 60% checked and is now 30% gained something the
+coverage: the fraction of the document it checked. This is the analogue of `any` and `noImplicitAny`. The
+number matters less than its trend: a file that was 60% checked and is now 30% gained something the
 parser cannot model.
 
 The check that types buy, and that no LaTeX tool performs: `@ref` to a `\table(fig:main)` while your prose

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -287,9 +287,7 @@ diagnostics:
   Every diagnostic in this project names something the author declared; what cannot be declared is what will
   never get a good error message. This does not judge the notation, which is a settled design decision;
 - run a minimal defective example for every error class through `tectonic`, `chktex`, `chklref` and
-  `texlab`, and record what each one reports. This is not about whether the checks are worth having — it is
-  about where the messages have to be better than what LaTeX already prints, and which classes have no
-  existing message at all.
+  `texlab`, and record what each one reports. The question here is where the messages have to be better than what LaTeX already prints, and which classes have no existing message at all — not whether the checks are worth having.
 
 **Done when** both write-ups exist: the list of things the language cannot yet name, and the table of what
 existing tools already report. Both feed Phase 1 — the first says what the grammar has to cover, the second
@@ -377,8 +375,7 @@ phase is translation, not new behaviour — with one exception worth naming: the
 sequence` and nothing this project exists to add.
 
 The phase ends with the module published as a versioned artefact, which is what lets the browser product live
-in its own repository. That separation is not about size. The browser TeX engine under consideration is
-AGPL-3.0 while this project is MIT, and a licence boundary cannot be undone once it is in a repository's
+in its own repository. That separation follows from licensing, not size: the browser TeX engine under consideration is AGPL-3.0 while this project is MIT, and a licence boundary cannot be undone once it is in a repository's
 history; and this workspace holds four packages in `Cargo.lock` and no external dependencies, a promise a
 `package.json` in the same tree would quietly weaken.
 

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -30,17 +30,16 @@ Capabilities declared: `textDocumentSync: 1` (full text on every change), `hover
 
 ## Diagnostics are the checker's, not the server's
 
-The server calls `check`. It does not have diagnostics of its own, does not filter them, and does not
-reword them. `xtex check` and the editor show the same code, the same message and the same span for the same
-input, and that is true because there is one implementation rather than because two are kept in step.
+The server calls `check`. It has no diagnostics of its own and never filters or rewords the checker's:
+`xtex check` and the editor show the same code, the same message and the same span for the same input,
+because one implementation answers both.
 
 That is the exit criterion of this phase, and `opening_a_document_publishes_the_same_diagnostics_the_cli_reports`
 is where it is checked.
 
 One difference is deliberate: **the server reads no bibliography.** It is handed a document, not a project
 root, so the bibliography is `Unavailable` — which is exactly the state that keeps every `@cite` silent
-rather than reported as missing. An editor that flagged every citation in a file it could not resolve would
-be worse than one that flagged none.
+rather than reported as missing. An editor that flagged every citation in a file it could not resolve would train the author to ignore the warning.
 
 ---
 
@@ -70,8 +69,7 @@ This is the type system paying for itself in the editor rather than only in the 
 whose class is `?O` is always offered, because `?O` is consistent with everything and the compiler has no
 grounds to exclude it.
 
-Outside a construct, nothing is offered. Suggesting every identifier in a document while someone writes a
-sentence is worse than suggesting none.
+Outside a construct, nothing is offered. Outside a construct, suggesting every identifier in the document turns completion into noise.
 
 ---
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -180,8 +180,7 @@ result. Sixteen significant digits of a ratio is false precision anyway, and it 
 targets, so the JSON now writes six decimals. The diagnostics themselves were identical throughout.
 
 `cargo test -p xtex-wasm` runs the whole comparison. It builds the module, runs it under Node, and compares
-against the native path. When the target or Node is missing it says so and returns — a silently skipped test
-is worse than an absent one.
+against the native path. When the target or Node is missing it says so and returns — a test that silently skips reports nothing went wrong when nothing ran.
 
 ---
 


### PR DESCRIPTION
## What this is

Three writer-agent reviews of every document in the repository, ahead of going public, hunting AI-writing tics: contrastive-antithesis clusters, em-dash chains, aphorism pileups, repeated templates, tell-words.

## Verdicts

| Documents | Verdict |
|---|---|
| grammar.md, checking.md, revisions.md | **CLEAN** — zero edits; the spec's "X, not Y" instances are load-bearing binary distinctions, and removing either half changes what a reader can conclude |
| decisions/0001–0007, testing.md, references.md, diagnostics.md | **CLEAN** — zero edits |
| README, PHILOSOPHY, ROADMAP, AGENTS, CONTRIBUTING | light edits: the "is not A. It is B." template appeared eight times across them |
| wasm.md, lsp.md | light edits: the "worse than none" closer appeared six times across three files |

## What changed

Eleven single-sentence edits, no technical content touched: each templated instance refolded into one sentence that keeps its claim; the two clearest "worse than none" instances stay in diagnostics.md as the principle's introduction; lsp.md's one dense contrastive cluster (four in thirteen lines) reduced to one; SPDX glossed inline. "Erasure, never injection." stays verbatim in all three homes — a named rule repeated on purpose.

## Not changed

- No numbers, codes, exports, commands or code blocks.
- No wholesale rewrites — the register is the repository's own.