### PR TITLE
Docs deploy tolerates Pages being unavailable while private

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    # Pages is unavailable on this plan while the repository is private; the
+    # build must stay green anyway, and deploys begin the day it goes public.
+    continue-on-error: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The docs site builds green; the deploy step 404s because GitHub Pages cannot be enabled on a private repository under the current plan (verified via API: HTTP 422, 'Your current plan does not support GitHub Pages for this repository'). `continue-on-error` on the deploy job keeps main green; the build remains a required gate. When the repository goes public: enable Pages (Settings → Pages → Source: GitHub Actions) and the next push deploys to camilochs.github.io/exacttex with no further changes.