### PR TITLE
Docs polish: vision-pass fixes and the BNF's old name

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -47,7 +47,7 @@ There is no top-level ExactTeX replacement grammar. A `.xtex` file is a LaTeX by
 constructs are recognized at the positions defined by this specification.
 
 ```text
-document    = ( ntex-construct | latex-bytes )*
+document    = ( xtex-construct | latex-bytes )*
 latex-bytes = ⟨bytes not beginning a recognized ExactTeX construct at the current position⟩
 ```
 
@@ -70,7 +70,7 @@ construct, an invalid annotation encoding, an I/O failure, a resource limit, or 
 Only these byte sequences can begin a ExactTeX construct:
 
 ```text
-ntex-construct = at-construct | block-construct | raw
+xtex-construct = at-construct | block-construct | raw
 
 at-entry        = "@" at-keyword "("
 block-entry     = "\" block-keyword "("

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -6,7 +6,9 @@ import starlight from "@astrojs/starlight";
 
 export default defineConfig({
   site: "https://camilochs.github.io",
-  base: "/exacttex",
+  // The Pages deploy lives under /exacttex; a tailnet preview builds with
+  // DOCS_BASE=/ so it can be served from any static server's root.
+  base: process.env.DOCS_BASE ?? "/exacttex",
   integrations: [
     starlight({
       title: "ExactTeX",

--- a/site/scripts/sync-docs.mjs
+++ b/site/scripts/sync-docs.mjs
@@ -5,6 +5,8 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
+const base = process.env.DOCS_BASE ?? "/exacttex/";
+const prefix = base.endsWith("/") ? base : base + "/";
 const repo = join(here, "..", "..");
 const out = join(here, "..", "src", "content", "docs");
 
@@ -17,7 +19,8 @@ function page(src, dest, titleOverride, order) {
   const title = titleOverride ?? (heading ? heading[1].replace(/[`*]/g, "") : dest);
   if (heading) text = text.replace(/^#\s+.+\n/m, "");
   // Root-relative repo links have no meaning on the site; point them at GitHub.
-  text = text.replaceAll("](docs/", "](/exacttex/");
+  text = text.replaceAll("](docs/", `](${prefix}`);
+  text = text.replaceAll('src="docs/assets/', `src="${prefix}assets/`);
   const front = ["---", `title: "${title.replaceAll('"', '\\"')}"`];
   if (order !== undefined) front.push(`sidebar:`, `  order: ${order}`);
   front.push("---", "");
@@ -29,15 +32,16 @@ title: ExactTeX
 description: Know whether your document is sound before you look at the PDF.
 template: splash
 hero:
+  title: Know whether your document is sound <em>before you look at the PDF</em>.
   tagline: A document language with LaTeX as its backend. Rename your .tex and it keeps working — what you annotate is guaranteed by a compiler.
   image:
     file: ../../assets/exacttex-logo.svg
   actions:
     - text: Introduction
-      link: /exacttex/introduction/
+      link: ${prefix}introduction/
       icon: right-arrow
     - text: The grammar
-      link: /exacttex/grammar/
+      link: ${prefix}grammar/
       variant: minimal
     - text: GitHub
       link: https://github.com/camilochs/exacttex
@@ -67,7 +71,18 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
   </Card>
 </CardGrid>
 `);
-page(join(repo, "README.md"), "introduction.md", "Introduction");
+// The README's centered logo-and-badges header belongs to GitHub; the site
+// already wears the logo, and a private repo's CI badge 404s anonymously.
+// Introduction starts at the first sentence of prose.
+{
+  const raw = readFileSync(join(repo, "README.md"), "utf8");
+  const start = raw.indexOf("ExactTeX is a document language");
+  const trimmed = start > 0 ? raw.slice(start) : raw;
+  const tmp = join(here, "introduction.tmp.md");
+  writeFileSync(tmp, trimmed);
+  page(tmp, "introduction.md", "Introduction");
+  rmSync(tmp);
+}
 page(join(repo, "PHILOSOPHY.md"), "philosophy.md", "Philosophy");
 page(join(repo, "ROADMAP.md"), "roadmap.md", "Roadmap");
 page(join(repo, "CONTRIBUTING.md"), "contributing.md", "Contributing");

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -11,3 +11,11 @@
   --sl-color-accent-high: #c9bcff;
 }
 .site-title img { height: 1.75rem; }
+
+/* The hero: the headline is a sentence, not a repeated brand; scale it, and
+   let the wordmark image yield on narrow screens instead of stacking. */
+.hero h1 { font-size: clamp(1.9rem, 3.6vw, 2.9rem); line-height: 1.2; }
+.hero h1 em { font-style: italic; color: var(--sl-color-accent); }
+@media (max-width: 50rem) {
+  .hero img { max-width: 14rem; margin-inline: auto; }
+}


### PR DESCRIPTION
Found by navigating the BUILT site with screenshots (director's report: misaligned elements).

| Fix | Where |
|---|---|
| Introduction no longer inherits the README's centered logo/badges header (broken image path + anonymous-404 CI badge + crooked stacking) — the page starts at prose | `site/scripts/sync-docs.mjs` |
| Splash hero doubled the brand (wordmark image + "ExactTeX" title) — now a sentence headline with italic accent; image yields on narrow screens | sync + `theme.css` |
| `src="docs/assets/…"` inside raw HTML now follows the base like markdown links | sync |
| `DOCS_BASE=/` builds a root-based site for the tailnet preview (http://lab.tail1e217d.ts.net:4327/); the Pages deploy keeps `/exacttex` | `astro.config.mjs` + sync (scope bug fixed) |
| The grammar BNF's nonterminals still said `ntex-construct` — renamed to `xtex-construct` | `docs/grammar.md` |

Verified by rebuild + fresh screenshots at 1440px and 780px: Introduction clean, grammar aligned, mobile hero compact.