### PR TITLE
The code meets the floor it declares

### DIFF
--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -1054,17 +1054,16 @@ fn cause_at(bytes: &[u8], at: usize) -> String {
             let name = String::from_utf8_lossy(&name);
             // `\begin{lstlisting}` and `\begin{verbatim}` are different
             // problems and collapsing them into `\begin` would hide that.
-            if name == "begin" {
-                if let Some(open) = rest.get(6) {
-                    if *open == b'{' {
-                        let environment: Vec<u8> = rest[7..]
-                            .iter()
-                            .take_while(|byte| **byte != b'}')
-                            .copied()
-                            .collect();
-                        return format!("\\begin{{{}}}", String::from_utf8_lossy(&environment));
-                    }
-                }
+            if name == "begin"
+                && let Some(open) = rest.get(6)
+                && *open == b'{'
+            {
+                let environment: Vec<u8> = rest[7..]
+                    .iter()
+                    .take_while(|byte| **byte != b'}')
+                    .copied()
+                    .collect();
+                return format!("\\begin{{{}}}", String::from_utf8_lossy(&environment));
             }
             return format!("\\{name}");
         }

--- a/crates/xtex-core/src/bibliography.rs
+++ b/crates/xtex-core/src/bibliography.rs
@@ -257,10 +257,10 @@ fn collect_bibitems(region: &[u8], found: &mut Declared) {
             at = open;
             continue;
         };
-        if let Ok(key) = std::str::from_utf8(trim(&region[open..close])) {
-            if !key.is_empty() {
-                found.inline_keys.insert(key.to_owned());
-            }
+        if let Ok(key) = std::str::from_utf8(trim(&region[open..close]))
+            && !key.is_empty()
+        {
+            found.inline_keys.insert(key.to_owned());
         }
         at = close + 1;
     }
@@ -364,10 +364,11 @@ fn scan_bib(bytes: &[u8]) -> Result<BTreeSet<String>, String> {
         if !matches!(entry_type.as_slice(), b"preamble" | b"string") {
             validate_field_separators(bytes, body_start, close)?;
         }
-        if !matches!(entry_type.as_slice(), b"preamble" | b"string") && key_end > key_start {
-            if let Ok(key) = std::str::from_utf8(&bytes[key_start..key_end]) {
-                keys.insert(key.to_owned());
-            }
+        if !matches!(entry_type.as_slice(), b"preamble" | b"string")
+            && key_end > key_start
+            && let Ok(key) = std::str::from_utf8(&bytes[key_start..key_end])
+        {
+            keys.insert(key.to_owned());
         }
         at = close + 1;
     }

--- a/crates/xtex-core/src/check.rs
+++ b/crates/xtex-core/src/check.rs
@@ -196,34 +196,32 @@ pub fn check_documents(
                 // reported it at its entry token, and the grammar makes that a
                 // hard error (grammar.md §inline). Dropping it here was the
                 // hole that let `@id(x` fail only at its references.
-                if malformed {
-                    if let Some(entry) = inline_entry(kind) {
-                        // The half-written payload often names the thing the
-                        // writer was reaching for; when that name is declared,
-                        // point at the declaration so nobody has to hunt it.
-                        let related = half_written_target(sources, source, span, kind, table)
-                            .map(|(candidate, declaration)| {
-                                vec![Related {
-                                    source: declaration.payload.source,
-                                    span: declaration.payload.span,
-                                    message: format!("`{candidate}` is declared here"),
-                                }]
-                            })
-                            .unwrap_or_default();
-                        diagnostics.push(Diagnostic {
-                            code: "XT1014",
-                            entity: EntityClass::UnknownOpen,
-                            name: None,
-                            source,
-                            span,
-                            message: format!(
-                                "`{entry}` never closes before the end of its line — expected `)`"
-                            ),
-                            related,
-                            severity: Severity::Error,
-                            blame: Blame::XtexConstruct,
-                        });
-                    }
+                if malformed && let Some(entry) = inline_entry(kind) {
+                    // The half-written payload often names the thing the
+                    // writer was reaching for; when that name is declared,
+                    // point at the declaration so nobody has to hunt it.
+                    let related = half_written_target(sources, source, span, kind, table)
+                        .map(|(candidate, declaration)| {
+                            vec![Related {
+                                source: declaration.payload.source,
+                                span: declaration.payload.span,
+                                message: format!("`{candidate}` is declared here"),
+                            }]
+                        })
+                        .unwrap_or_default();
+                    diagnostics.push(Diagnostic {
+                        code: "XT1014",
+                        entity: EntityClass::UnknownOpen,
+                        name: None,
+                        source,
+                        span,
+                        message: format!(
+                            "`{entry}` never closes before the end of its line — expected `)`"
+                        ),
+                        related,
+                        severity: Severity::Error,
+                        blame: Blame::XtexConstruct,
+                    });
                 }
                 return;
             };

--- a/crates/xtex-core/src/scanner/mod.rs
+++ b/crates/xtex-core/src/scanner/mod.rs
@@ -201,26 +201,26 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
     while at < bytes.len() {
         match &region {
             Region::Prose => {
-                if let Some(&(interior_end, call_end)) = text_arguments.last() {
-                    if at >= interior_end {
-                        flush!(at.min(interior_end));
-                        text_arguments.pop();
-                        let tail = at.max(interior_end);
-                        if tail < call_end {
-                            pieces.push(Piece::Arguments(span(tail, call_end)));
-                            at = call_end;
-                        }
-                        text_start = at;
-                        continue;
+                if let Some(&(interior_end, call_end)) = text_arguments.last()
+                    && at >= interior_end
+                {
+                    flush!(at.min(interior_end));
+                    text_arguments.pop();
+                    let tail = at.max(interior_end);
+                    if tail < call_end {
+                        pieces.push(Piece::Arguments(span(tail, call_end)));
+                        at = call_end;
                     }
+                    text_start = at;
+                    continue;
                 }
-                if let Some((start, name)) = display_opening.as_ref() {
-                    if at == *start {
-                        enter!(at);
-                        region = Region::Environment { name: name.clone() };
-                        display_opening = None;
-                        continue;
-                    }
+                if let Some((start, name)) = display_opening.as_ref()
+                    && at == *start
+                {
+                    enter!(at);
+                    region = Region::Environment { name: name.clone() };
+                    display_opening = None;
+                    continue;
                 }
                 if display_opening.is_none()
                     && let Some(opening) = display_math_environment_opening(bytes, at)

--- a/crates/xtex-core/src/scanner/queries.rs
+++ b/crates/xtex-core/src/scanner/queries.rs
@@ -76,13 +76,12 @@ pub(crate) fn substitution_arrows(bytes: &[u8], start: usize, end: usize) -> usi
         let mut at = start + text.start();
         let text_end = start + text.end();
         while at + 1 < text_end {
-            if bytes[at] == b'\\' {
-                if let Extent::Through(next) = command_extent(bytes, at) {
-                    if next <= text_end {
-                        at = next;
-                        continue;
-                    }
-                }
+            if bytes[at] == b'\\'
+                && let Extent::Through(next) = command_extent(bytes, at)
+                && next <= text_end
+            {
+                at = next;
+                continue;
             }
             if !is_escaped(bytes, at) {
                 match bytes[at] {
@@ -111,13 +110,12 @@ pub fn substitution_separator(bytes: &[u8], start: usize, end: usize) -> Option<
         let mut at = start + text.start();
         let text_end = start + text.end();
         while at + 1 < text_end {
-            if bytes[at] == b'\\' {
-                if let Extent::Through(next) = command_extent(bytes, at) {
-                    if next <= text_end {
-                        at = next;
-                        continue;
-                    }
-                }
+            if bytes[at] == b'\\'
+                && let Extent::Through(next) = command_extent(bytes, at)
+                && next <= text_end
+            {
+                at = next;
+                continue;
             }
             if !is_escaped(bytes, at) {
                 match bytes[at] {

--- a/crates/xtex-core/src/sourcemap.rs
+++ b/crates/xtex-core/src/sourcemap.rs
@@ -344,10 +344,11 @@ fn sha256(input: &[u8]) -> [u8; 32] {
         0x1f83d9ab,
         0x5be0cd19,
     ];
-    for chunk in data.chunks_exact(64) {
+    for chunk in data.as_chunks::<64>().0 {
         let mut w = [0u32; 64];
-        for (i, word) in chunk.chunks_exact(4).enumerate() {
-            w[i] = u32::from_be_bytes(word.try_into().expect("four bytes"));
+        let (words, _) = chunk.as_chunks::<4>();
+        for (i, word) in words.iter().enumerate() {
+            w[i] = u32::from_be_bytes(*word);
         }
         for i in 16..64 {
             let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
@@ -383,8 +384,8 @@ fn sha256(input: &[u8]) -> [u8; 32] {
         }
     }
     let mut out = [0u8; 32];
-    for (chunk, word) in out.chunks_exact_mut(4).zip(h) {
-        chunk.copy_from_slice(&word.to_be_bytes());
+    for (chunk, word) in out.as_chunks_mut::<4>().0.iter_mut().zip(h) {
+        *chunk = word.to_be_bytes();
     }
     out
 }


### PR DESCRIPTION
Follow-up to #114: its MSRV job turned red on main because raising rust-version to 1.88 enables clippy lints that were silent under the old floor. Nine collapsible ifs become let-chains (a 1.88 feature — the very reason the floor rose), and the SHA-256 helper adopts as_chunks. No behaviour change; verified by clippy -D warnings, cargo fmt --check, and 234/234 tests executed on a local 1.88 toolchain.