### PR TITLE
The opening line says what the language is

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
   <img src="https://img.shields.io/badge/dependencies-0-082768" alt="zero dependencies">
 </p>
 
-ExactTeX is a document language with LaTeX as its backend. Rename a `.tex` file to `.xtex` and it keeps
-working — your LaTeX passes through byte for byte. From there you annotate what you want checked, and what
-you annotate is guaranteed.
+ExactTeX is LaTeX with gradual annotation: you name the object you want checked, and what you do not name
+stays ordinary LaTeX, transported byte for byte. Rename a `.tex` file to `.xtex` and it keeps working; from
+there you choose how much to annotate, and what you annotate is guaranteed.
 
 > **Status: the compiler works, and three doors open into it.** `xtex` parses, checks, emits LaTeX, writes
 > source maps and applies revisions; `xtex-lsp` gives an editor diagnostics, hover, completion and

--- a/site/scripts/sync-docs.mjs
+++ b/site/scripts/sync-docs.mjs
@@ -73,11 +73,15 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 `);
 // The README's centered logo-and-badges header belongs to GitHub; the site
 // already wears the logo, and a private repo's CI badge 404s anonymously.
-// Introduction starts at the first sentence of prose.
+// Introduction starts at the first line of prose — found by structure, not by
+// the sentence it happens to begin with: the earlier version searched for a
+// literal opening line and silently shipped the whole header the day that line
+// was reworded.
 {
   const raw = readFileSync(join(repo, "README.md"), "utf8");
-  const start = raw.indexOf("ExactTeX is a document language");
-  const trimmed = start > 0 ? raw.slice(start) : raw;
+  const lines = raw.split("\n");
+  const start = lines.findIndex((line) => line.trim() && !line.trimStart().startsWith("<"));
+  const trimmed = start > 0 ? lines.slice(start).join("\n") : raw;
   const tmp = join(here, "introduction.tmp.md");
   writeFileSync(tmp, trimmed);
   page(tmp, "introduction.md", "Introduction");


### PR DESCRIPTION
Fixes #116

Two changes that have to ship together.

**The README's first sentence.** It described "a document language with LaTeX as its backend" — one word from the phrasing `PHILOSOPHY.md` §7 rules out, and silent about the property the design rests on. It now reads:

> ExactTeX is LaTeX with gradual annotation: you name the object you want checked, and what you do not name stays ordinary LaTeX, transported byte for byte. Rename a `.tex` file to `.xtex` and it keeps working; from there you choose how much to annotate, and what you annotate is guaranteed.

"Gradual" qualifies the annotation, not the language. The claim stays inside what the repo can show: `EntityClass::is_consistent_with` is the consistency relation, the 992-file corpus is the evidence for transport, and `tests/render` is the evidence that annotating changes no pixel. No runtime casts and no blame are claimed, because a document is not run.

**The generator that keyed on that sentence.** `sync-docs.mjs` found where the README's prose begins by searching for the literal `"ExactTeX is a document language"`, falling back to the entire file. Rewording the line made the search miss, and the documentation site published the centered logo-and-badges header the script exists to strip — silently, with a clean "docs synced". It now finds the first line that is not part of the leading centered block.

## Test plan

Ran `npm run sync` in `site/` against the reworded README:

```
$ sed -n '4,6p' site/src/content/docs/introduction.md
ExactTeX is LaTeX with gradual annotation: you name the object you want checked, and what you do not name
stays ordinary LaTeX, transported byte for byte. Rename a `.tex` file to `.xtex` and it keeps working; from
there you choose how much to annotate, and what you annotate is guaranteed.
```

The page starts at the prose, with no `<p align="center">` header — which is what regressed before the second commit, and the reason both commits are in one PR.

No code paths touched: the diff is one paragraph of prose and three lines of the docs generator.