### PR TITLE
A revision inside a command argument is a real revision

### DIFF
--- a/crates/xtex-core/src/review.rs
+++ b/crates/xtex-core/src/review.rs
@@ -415,46 +415,124 @@ struct RevisionConstruct {
     on: Option<String>,
 }
 
+/// Every revision construct in the file, including those written inside a
+/// command's arguments.
+///
+/// `Piece::Arguments` is the one exclusion whose bytes are still document
+/// content — a `\label` inside `\caption{…}` is a real declaration — so a
+/// revision written into `\author{…}` is a real revision. Scanning only the
+/// top level reported "sidecar record has no construct" for a change the
+/// author could see on screen and could never accept (the director's book,
+/// 2026-08-31). The same reasoning fixed rename in #83.
 fn revision_constructs(bytes: &[u8]) -> Vec<RevisionConstruct> {
-    scan(bytes)
-        .into_iter()
-        .filter_map(|piece| {
-            let Piece::Construct { kind, span, .. } = piece else {
-                return None;
-            };
-            if !matches!(
-                kind,
-                EntryToken::Add | EntryToken::Del | EntryToken::Sub | EntryToken::Note
-            ) {
-                return None;
+    let mut found = Vec::new();
+    collect_revision_constructs(bytes, 0, 0, &mut found);
+    found.sort_by_key(|construct| construct.span.start());
+    found
+}
+
+/// Depth guard: an argument region whose inner scan returns the same region
+/// would otherwise recurse forever. Real documents nest a few levels.
+const ARGUMENT_DEPTH: usize = 8;
+
+fn collect_revision_constructs(
+    bytes: &[u8],
+    offset: usize,
+    depth: usize,
+    found: &mut Vec<RevisionConstruct>,
+) {
+    for piece in scan(bytes) {
+        if let Piece::Arguments(span) = piece {
+            if depth < ARGUMENT_DEPTH {
+                // Descend into each brace group's CONTENT: the piece itself
+                // spans `\cmd{…}`, so scanning it again would return the same
+                // region for ever.
+                let region = &bytes[span.start()..span.end()];
+                for (start, end) in brace_groups(region) {
+                    collect_revision_constructs(
+                        &region[start..end],
+                        offset + span.start() + start,
+                        depth + 1,
+                        found,
+                    );
+                }
             }
-            let source = &bytes[span.start()..span.end()];
-            let open = source.iter().position(|byte| *byte == b'(')? + 1;
-            let end = source[open..].iter().position(|byte| {
-                !byte.is_ascii_alphanumeric() && !matches!(byte, b'_' | b':' | b'.' | b'-')
-            })? + open;
-            Some(RevisionConstruct {
-                id: String::from_utf8_lossy(&source[open..end]).into_owned(),
-                kind,
-                span,
-                on: if kind == EntryToken::Note {
-                    let equals = source.iter().position(|byte| *byte == b'=')? + 1;
-                    let target_start = equals
-                        + source[equals..]
-                            .iter()
-                            .position(|byte| !byte.is_ascii_whitespace())?;
-                    let target_end = target_start
-                        + source[target_start..].iter().position(|byte| {
-                            !byte.is_ascii_alphanumeric()
-                                && !matches!(byte, b'_' | b':' | b'.' | b'-')
-                        })?;
-                    Some(String::from_utf8_lossy(&source[target_start..target_end]).into_owned())
-                } else {
-                    None
-                },
-            })
+            continue;
+        }
+        if let Some(construct) = revision_construct_of(bytes, offset, &piece) {
+            found.push(construct);
+        }
+    }
+}
+
+/// Byte ranges of each top-level `{…}` group's content within `bytes`.
+fn brace_groups(bytes: &[u8]) -> Vec<(usize, usize)> {
+    let mut groups = Vec::new();
+    let mut depth = 0usize;
+    let mut opened_at = 0usize;
+    let mut index = 0usize;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' => index += 1,
+            b'{' => {
+                depth += 1;
+                if depth == 1 {
+                    opened_at = index + 1;
+                }
+            }
+            b'}' if depth > 0 => {
+                depth -= 1;
+                if depth == 0 && index > opened_at {
+                    groups.push((opened_at, index));
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    groups
+}
+
+fn revision_construct_of(bytes: &[u8], offset: usize, piece: &Piece) -> Option<RevisionConstruct> {
+    let Piece::Construct { kind, span, .. } = *piece else {
+        return None;
+    };
+    {
+        if !matches!(
+            kind,
+            EntryToken::Add | EntryToken::Del | EntryToken::Sub | EntryToken::Note
+        ) {
+            return None;
+        }
+        let source = &bytes[span.start()..span.end()];
+        let open = source.iter().position(|byte| *byte == b'(')? + 1;
+        let end = source[open..].iter().position(|byte| {
+            !byte.is_ascii_alphanumeric() && !matches!(byte, b'_' | b':' | b'.' | b'-')
+        })? + open;
+        let span = Span::new(
+            u32::try_from(offset + span.start()).ok()?,
+            u32::try_from(offset + span.end()).ok()?,
+        );
+        Some(RevisionConstruct {
+            id: String::from_utf8_lossy(&source[open..end]).into_owned(),
+            kind,
+            span,
+            on: if kind == EntryToken::Note {
+                let equals = source.iter().position(|byte| *byte == b'=')? + 1;
+                let target_start = equals
+                    + source[equals..]
+                        .iter()
+                        .position(|byte| !byte.is_ascii_whitespace())?;
+                let target_end = target_start
+                    + source[target_start..].iter().position(|byte| {
+                        !byte.is_ascii_alphanumeric() && !matches!(byte, b'_' | b':' | b'.' | b'-')
+                    })?;
+                Some(String::from_utf8_lossy(&source[target_start..target_end]).into_owned())
+            } else {
+                None
+            },
         })
-        .collect()
+    }
 }
 
 fn kind_name(kind: EntryToken) -> &'static str {

--- a/crates/xtex-core/tests/revisions.rs
+++ b/crates/xtex-core/tests/revisions.rs
@@ -117,3 +117,75 @@ fn marked_imports_target_the_distinct_marked_artifact() {
     emit_view(&sources, &document, RevisionView::Marked, &mut output).unwrap();
     assert!(output.ends_with(b"\\input{part.marked.tex}"));
 }
+
+#[test]
+fn a_revision_inside_a_command_argument_is_a_real_revision() {
+    // The director's book, 2026-08-31: a deletion proposed on an author name
+    // inside `\\author{…}` showed in the margin and could never be accepted —
+    // `xtex revise` answered XT1012 "sidecar record has no construct", because
+    // only the top level was scanned. Arguments are document content (see
+    // `Piece::Arguments`), so a revision written there is a real revision.
+    // The same reasoning fixed rename in #83.
+    let text = b"\\author{@del(change:gabriela) {Gabriela Ochoa}, Camilo}\n".to_vec();
+
+    let (rewritten, removed) =
+        resolve(&text, "change:gabriela", Resolution::Accept).expect("the construct is found");
+    assert_eq!(
+        String::from_utf8_lossy(&rewritten),
+        "\\author{, Camilo}\n",
+        "accepting a deletion removes the payload where it stands"
+    );
+    assert_eq!(String::from_utf8_lossy(&removed), "Gabriela Ochoa");
+}
+
+#[test]
+fn revisions_are_found_wherever_the_document_carries_text() {
+    // Generality, demanded after the \author{…} case: a revision is a
+    // revision wherever the DOCUMENT carries text — a command argument, a
+    // nested argument, a caption inside an environment. And it is still not
+    // one where the document does not carry text: a comment, verbatim.
+    let cases: [(&str, &[u8]); 5] = [
+        ("prosa suelta", b"Texto @del(a:one) {fuera} normal.\n"),
+        (
+            "argumento simple",
+            b"\\author{@del(a:two) {Nombre}, Otro}\n",
+        ),
+        (
+            "argumento anidado",
+            b"\\textbf{\\footnote{@del(a:three) {al fondo}}}\n",
+        ),
+        (
+            "caption dentro de un entorno",
+            b"\\begin{figure}\n\\caption{Pie con @del(a:four) {sobra}.}\n\\end{figure}\n",
+        ),
+        (
+            "segundo argumento",
+            b"\\newcommand{\\x}{@del(a:five) {en el segundo}}\n",
+        ),
+    ];
+    for (what, text) in cases {
+        let ids = xtex_core::review::revision_ids(text);
+        assert_eq!(
+            ids.len(),
+            1,
+            "{what}: la revision debe verse, se vio {ids:?}"
+        );
+        let id = &ids[0];
+        resolve(text, id, Resolution::Accept)
+            .unwrap_or_else(|error| panic!("{what}: no se pudo aceptar: {error:?}"));
+    }
+
+    let blind: [(&str, &[u8]); 2] = [
+        ("comentario", b"% @del(a:six) {en un comentario}\nTexto.\n"),
+        (
+            "verbatim",
+            b"\\begin{verbatim}\n@del(a:seven) {literal}\n\\end{verbatim}\n",
+        ),
+    ];
+    for (what, text) in blind {
+        assert!(
+            xtex_core::review::revision_ids(text).is_empty(),
+            "{what}: no es contenido del documento y no debe contar como revision"
+        );
+    }
+}


### PR DESCRIPTION
## What broke

Proposing a deletion on an author name inside `\author{…}` produced a change the margin displayed and the compiler could never resolve:

```
$ xtex revise book.xtex --accept change:gabriela
error: XT1012: sidecar record 'change:gabriela' has no construct
```

Found on the director's 127-page Springer book, where `\author{…}` is exactly where a reviewer proposes a change.

## Why

`revision_constructs` scanned only the top level. `Piece::Arguments` is the one exclusion whose bytes are **still document content** — its own documentation says a `\label` inside `\caption{…}` is a real declaration — so a revision written there is a real revision. Recognition now descends into each brace group's content, at any nesting depth (guarded at 8).

This is the same conclusion #83 reached for rename, applied to the review path.

## General, and tested as such

A revision is found in running prose, in a simple argument, in a nested argument, in a caption inside an environment, and in a second argument. It is still **not** found in a comment or in verbatim, where the document carries no text — that boundary is asserted, not assumed.

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` are clean.