### PR TITLE
A reply takes the blank that separated it

### DIFF
--- a/crates/xtex-core/src/review.rs
+++ b/crates/xtex-core/src/review.rs
@@ -300,8 +300,15 @@ pub fn resolve(
     if construct.kind != EntryToken::Note {
         for reply in replies_to(&rewritten, id) {
             let text = rewritten[reply.span.start()..reply.span.end()].to_vec();
+            // A reply takes the blank that separated it. Leaving that byte
+            // behind put a stray space where the conversation had been —
+            // visible in the source and, inside a title, in the PDF.
+            let mut from = reply.span.start();
+            if from > 0 && rewritten[from - 1] == b' ' {
+                from -= 1;
+            }
             let mut without = Vec::with_capacity(rewritten.len());
-            without.extend_from_slice(&rewritten[..reply.span.start()]);
+            without.extend_from_slice(&rewritten[..from]);
             without.extend_from_slice(&rewritten[reply.span.end()..]);
             rewritten = without;
             removed.extend_from_slice(&text);

--- a/crates/xtex-core/tests/dialogues.rs
+++ b/crates/xtex-core/tests/dialogues.rs
@@ -184,3 +184,25 @@ fn resolving_a_change_does_not_leave_its_replies_dangling() {
         "the reply must go with the change it answered:\n{text}"
     );
 }
+
+#[test]
+fn a_resolved_dialogue_leaves_no_stray_blank_behind() {
+    // The director, 2026-08-31: rejecting a change that carried a reply left
+    // a space where the conversation had been. Inside a title that space is
+    // not only in the source — it is in the PDF.
+    let source =
+        b"\\author{Gabriela, @del(d:blum) {Christian} @note(n:why, on = d:blum) {moved}}\n";
+    let (rewritten, _) = resolve(source, "d:blum", Resolution::Reject).expect("resolves");
+    assert_eq!(
+        String::from_utf8_lossy(&rewritten),
+        "\\author{Gabriela, Christian}\n",
+        "the reply leaves, and takes the blank that separated it"
+    );
+
+    let (accepted, _) = resolve(source, "d:blum", Resolution::Accept).expect("resolves");
+    assert_eq!(
+        String::from_utf8_lossy(&accepted),
+        "\\author{Gabriela, }\n",
+        "accepting removes the name and the reply, and adds nothing"
+    );
+}


### PR DESCRIPTION
Rejecting a change that carried a reply left a stray space where the conversation had been — visible in the source and, inside a title, in the PDF itself.

The reply now leaves with the byte that separated it from the text before it. Asserted in `tests/dialogues.rs` for both resolutions: rejecting gives `\author{Gabriela, Christian}`, accepting gives `\author{Gabriela, }` — neither leaves anything behind.

`cargo test --workspace`, clippy and fmt clean.