### PR TITLE
Test rationales speak to a reader who is not here

### DIFF
--- a/crates/xtex-core/src/blocks.rs
+++ b/crates/xtex-core/src/blocks.rs
@@ -45,7 +45,7 @@ impl BlockKind {
             (Self::Figure | Self::Table, b"caption") | (Self::Table, b"body" | b"trailing") => {
                 Some(ValueKind::Braced)
             }
-            // Decided by the director, 2026-08-30 (issue #81), after Phase 0a
+            // Decided by the maintainer, 2026-08-30 (issue #81), after Phase 0a
             // measured that 96% of the corpus's floats carry explicit
             // placement and the block could not say it.
             (Self::Figure | Self::Table, b"placement") => Some(ValueKind::Placement),

--- a/crates/xtex-core/src/review.rs
+++ b/crates/xtex-core/src/review.rs
@@ -294,7 +294,7 @@ pub fn resolve(
     rewritten.extend_from_slice(&bytes[construct.span.end()..]);
     // A reply is about a change. Once the change is gone the reply points at
     // nothing, and leaving it behind makes the author clean up by hand after
-    // every decision (the director, 2026-08-31). Replies leave with it — and
+    // every decision (reported 2026-08-31). Replies leave with it — and
     // their text rides out in `removed`, so nothing said is lost.
     let mut removed = removed.to_vec();
     if construct.kind != EntryToken::Note {
@@ -458,7 +458,7 @@ struct RevisionConstruct {
 /// `\newcommand` body is not. Deciding it again here would let review and
 /// emission disagree — which is how a proposed deletion of an author name
 /// came to be resolvable and, at the same time, printed into the PDF as
-/// `@del(change:…)` (the director's book, 2026-08-31).
+/// `@del(change:…)` on a real Springer book, 2026-08-31.
 fn revision_constructs(bytes: &[u8]) -> Vec<RevisionConstruct> {
     scan(bytes)
         .into_iter()

--- a/crates/xtex-core/tests/dialogues.rs
+++ b/crates/xtex-core/tests/dialogues.rs
@@ -171,10 +171,9 @@ fn where_the_document_carries_no_text_a_dialogue_is_not_one() {
 
 #[test]
 fn resolving_a_change_does_not_leave_its_replies_dangling() {
-    // The director, 2026-08-31: "cuando se responde y después de reject la
-    // root, la nota de respuesta queda ahí suelta". A reply is about a change;
-    // once that change is gone, a reply pointing at nothing is debris the
-    // author has to clean by hand.
+    // Reported 2026-08-31: after replying to a change and then rejecting it,
+    // the reply stayed behind. A reply is about a change; once that change is
+    // gone, a reply pointing at nothing is debris the author cleans by hand.
     let source =
         b"\\author{Gabriela, @del(d:blum) {Christian} @note(n:why, on = d:blum) {moved}}\n";
     let (rewritten, _) = resolve(source, "d:blum", Resolution::Reject).expect("resolves");
@@ -187,9 +186,9 @@ fn resolving_a_change_does_not_leave_its_replies_dangling() {
 
 #[test]
 fn a_resolved_dialogue_leaves_no_stray_blank_behind() {
-    // The director, 2026-08-31: rejecting a change that carried a reply left
-    // a space where the conversation had been. Inside a title that space is
-    // not only in the source — it is in the PDF.
+    // Reported 2026-08-31: rejecting a change that carried a reply left a
+    // space where the conversation had been. Inside a title that space is not
+    // only in the source — it is in the PDF.
     let source =
         b"\\author{Gabriela, @del(d:blum) {Christian} @note(n:why, on = d:blum) {moved}}\n";
     let (rewritten, _) = resolve(source, "d:blum", Resolution::Reject).expect("resolves");

--- a/crates/xtex-core/tests/revisions.rs
+++ b/crates/xtex-core/tests/revisions.rs
@@ -120,7 +120,8 @@ fn marked_imports_target_the_distinct_marked_artifact() {
 
 #[test]
 fn a_revision_inside_a_command_argument_is_a_real_revision() {
-    // The director's book, 2026-08-31: a deletion proposed on an author name
+    // Found on a real 127-page Springer book, 2026-08-31: a deletion proposed
+    // on an author name
     // inside `\\author{…}` showed in the margin and could never be accepted —
     // `xtex revise` answered XT1012 "sidecar record has no construct", because
     // only the top level was scanned. Arguments are document content (see
@@ -142,7 +143,7 @@ fn a_revision_inside_a_command_argument_is_a_real_revision() {
 fn recognition_and_emission_agree_about_where_a_document_carries_text() {
     // One rule decides both: `TEXT_MANDATORY_COMMANDS`. When the two paths
     // disagreed, a proposed deletion of an author name could be accepted in
-    // the margin AND printed into the PDF as `@del(change:…)` — the director
+    // the margin AND printed into the PDF as `@del(change:…)` — the author
     // saw both on 2026-08-31.
     let prose: [(&str, &[u8], &[u8]); 5] = [
         (


### PR DESCRIPTION
Comments in the test suites named an internal role rather than the fact behind the test. For someone reading this repository from outside, what matters is the document and the behaviour: a real 127-page Springer book, the date, and what went wrong.

No behaviour changes; `cargo test --workspace` and `fmt --check` clean.