### PR TITLE
Open by zone, and say how young this is

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,42 @@ specific to working here** — it does not restate the other two.
 
 ---
 
+## What is open, and what is not
+
+The project is open by zone. The reason is not ceremony: the compiler holds a
+few invariants that hold the whole design up — untouched LaTeX comes out
+byte-identical, opaque bytes are never rewritten, one table decides where the
+document carries text — and those are easy to break by accident and expensive
+to discover later. So the closer a change sits to them, the more this project
+asks of it.
+
+**Open, and the most useful thing you can send.**
+
+- **Documents that break it.** A `.tex` or `.xtex` file that the compiler
+  mishandles, with what you expected and what you got. Licence and provenance
+  stated, so it can live in the corpus. This is worth more to the project than
+  any patch: every real document so far has found something.
+- **Bug reports** of any kind, especially with a minimal reproduction.
+- **Documentation, examples, the site, editor integrations, tooling around the
+  compiler.** Pull requests welcome, reviewed on their own merits.
+
+**Open with a contract: `xtex-cli`, `xtex-lsp`, `xtex-wasm`, diagnostics.**
+Pull requests welcome, and each one carries a test that would fail without it.
+A change that alters what the compiler *says* — a diagnostic's wording, a code,
+an exit status — is a change to an interface other tools read, so say so in the
+description.
+
+**Closed for now: `xtex-core`'s scanner, document model and emitter.**
+These are where the invariants live. Issues are read and answered; pull requests
+against them are likely to be declined, not because the idea is unwelcome but
+because the design is still moving under them and a merged change would freeze
+a decision that is not made yet. If you have one, open an issue first and it
+will get a real answer.
+
+This boundary is meant to move. When the core stops changing weekly, it opens.
+
+---
+
 ## Local stack
 
 Rust via [`rustup`](https://rustup.rs). Nothing else is installed globally.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,33 @@ still receives a `.tex` file.
 
 ---
 
+## How young this is
+
+The compiler is young, and pretending otherwise would waste your time.
+
+What is solid: the transport guarantee — untouched LaTeX comes out
+byte-identical — is the oldest invariant here and the most heavily tested. The
+checker, the emitter and the two surfaces (WebAssembly and LSP) answer
+identically for the same input, and a parity suite in CI holds them to it. A
+127-page Springer book with forty packages, an index, per-chapter
+bibliographies and TikZ compiles to the same page count as a full TeX Live.
+
+Where it is still tender: the change model. Three defects surfaced in one
+evening of real use in August 2026 — a revision written inside `\author{…}`
+was resolvable on screen and printed into the PDF as itself; a reply outlived
+the change it answered; and rejecting one left a stray space behind. All three
+were the same thing seen from three sides: two code paths consulting different
+rules about where a document carries text. They are fixed, each with a test
+that fails against the previous compiler, and `tests/dialogues.rs` now runs a
+full conversation through a title page, a caption, a nested command, a table
+cell and a list item.
+
+Which is the honest summary: **the parts that transport your document are
+careful; the parts that let people argue about it are new.** If you find
+something, the thing to send is the document.
+
+---
+
 ## Documentation
 
 The full documentation lives at **<https://camilochs.github.io/exacttex/>** — the language


### PR DESCRIPTION
**Contribution model (option 3, by zones).** Documents that break the compiler — with provenance and licence — are the most useful thing anyone can send, and everything around the compiler (docs, examples, site, editor integrations, tooling) is open. The CLI, LSP, wasm surface and diagnostics take pull requests that carry a test. The scanner, document model and emitter are closed for now, because the design still moves under them and a merged change would freeze a decision that is not made yet; issues there get a real answer. The boundary is written as temporary.

**A maturity section in the README.** It says what is solid (byte-identical transport, parity between the native and browser surfaces, a 127-page Springer book at the same page count as a full TeX Live) and what is tender (the change model, where three defects surfaced in one evening of real use in August 2026 — all three the same disagreement about where a document carries text, all three now fixed with tests that fail against the previous compiler).

The summary a reader gets: the parts that transport your document are careful; the parts that let people argue about it are new.