### PR TITLE
A diagnostic sentence carries its quantity

### DIFF
--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -1185,8 +1185,15 @@ fn report_record(record: &xtex_core::blame::Translated, emitted: &Path) -> bool 
         "warning[TEX]"
     };
     match &record.entity {
-        Some((name, class, visual)) => {
-            println!("{label}: {} `{name}` {}", class.name(), visual.name());
+        Some((name, class, visual, amount)) => {
+            match amount {
+                Some(amount) => println!(
+                    "{label}: {} `{name}` {} by {amount}",
+                    class.name(),
+                    visual.name()
+                ),
+                None => println!("{label}: {} `{name}` {}", class.name(), visual.name()),
+            }
             println!("  TeX said: {}", record.message);
         }
         None => println!("{label}: {}", record.message),

--- a/crates/xtex-core/src/blame.rs
+++ b/crates/xtex-core/src/blame.rs
@@ -36,8 +36,9 @@ pub struct Translated {
     /// The author's position, when a map segment supports one.
     pub span: Option<DiagnosticSpan>,
     /// The author's entity, when a map segment and a declaration both supply
-    /// the evidence: its name, its class, and how the failure reads.
-    pub entity: Option<(String, EntityClass, Visual)>,
+    /// the evidence: its name, its class, how the failure reads, and how
+    /// much — the engine's own quantity, where its message named one.
+    pub entity: Option<(String, EntityClass, Visual, Option<String>)>,
 }
 
 /// Merges the engine's stderr with its log file, the way the CLI always has.
@@ -123,6 +124,8 @@ fn translate_one(
         }
     };
 
+    // Read the amount before the message moves into the mapper.
+    let amount = crate::texlog::amount_in(&message).map(str::to_owned);
     let mapped = map_emitted_diagnostic(message, &emission.bytes, line, 1, &emission.map);
 
     // A typesetting failure is restated in the author's terms only when a map
@@ -132,7 +135,7 @@ fn translate_one(
     let entity = visual.and_then(|visual| {
         let span = mapped.span.as_ref()?;
         let (name, class) = entity_at(sources, document, table, span.offset as usize)?;
-        Some((name, class, visual))
+        Some((name, class, visual, amount.clone()))
     });
 
     Translated {
@@ -189,14 +192,19 @@ pub fn to_json(translated: &[Translated], out: &mut String) {
         }
         out.push_str(",\"entity\":");
         match &record.entity {
-            Some((name, class, visual)) => {
+            Some((name, class, visual, amount)) => {
                 out.push_str("{\"name\":");
                 push_json_string(name, out);
                 out.push_str(",\"class\":\"");
                 out.push_str(class.name());
                 out.push_str("\",\"reads\":\"");
                 out.push_str(visual.name());
-                out.push_str("\"}");
+                out.push_str("\",\"amount\":");
+                match amount {
+                    Some(amount) => push_json_string(amount, out),
+                    None => out.push_str("null"),
+                }
+                out.push('}');
             }
             None => out.push_str("null"),
         }

--- a/crates/xtex-core/src/texlog.rs
+++ b/crates/xtex-core/src/texlog.rs
@@ -112,6 +112,38 @@ pub fn classify(message: &str) -> Option<Visual> {
     None
 }
 
+/// The quantity a visual failure names, exactly as the engine wrote it.
+///
+/// `Overfull \hbox (113.94pt too wide)` carries it in parentheses; `Float
+/// too large for page by 327.53pt` after `by`. Value and unit stay together
+/// and untouched — `12.3pt` is the engine's number, not a recomputation —
+/// so the restated sentence can say *how much* without discarding evidence
+/// (issue #101). A message with no recognisable amount answers `None`, and
+/// the sentence simply goes without.
+#[must_use]
+pub fn amount_in(message: &str) -> Option<&str> {
+    if let Some(open) = message.find('(') {
+        let rest = &message[open + 1..];
+        for tail in ["pt too wide", "pt too high"] {
+            if let Some(end) = rest.find(tail) {
+                let digits = &rest[..end];
+                if !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit() || c == '.') {
+                    return Some(&rest[..end + 2]);
+                }
+            }
+        }
+    }
+    if let Some(at) = message.find(" by ") {
+        let rest = &message[at + 4..];
+        let end = rest.find("pt")? + 2;
+        let candidate = &rest[..end - 2];
+        if !candidate.is_empty() && candidate.chars().all(|c| c.is_ascii_digit() || c == '.') {
+            return Some(&rest[..end]);
+        }
+    }
+    None
+}
+
 /// The line a `.log` record names, when it names one in its own text.
 ///
 /// `LaTeX Warning: … on input line 9.` carries its line inside the sentence
@@ -396,5 +428,37 @@ mod tests {
         };
         assert_eq!(file, "odd:name.tex");
         assert_eq!(line, 12);
+    }
+}
+
+#[cfg(test)]
+mod amount_tests {
+    use super::amount_in;
+
+    #[test]
+    fn the_amount_is_the_engines_own_number() {
+        // Transcribed from the same live shapes the classifier holds.
+        assert_eq!(
+            amount_in("Overfull \\hbox (113.94pt too wide) in paragraph at lines 5--5"),
+            Some("113.94pt")
+        );
+        assert_eq!(
+            amount_in("Overfull \\vbox (38.48pt too high) detected at line 16"),
+            Some("38.48pt")
+        );
+        assert_eq!(
+            amount_in("LaTeX Warning: Float too large for page by 327.53pt on input line 9."),
+            Some("327.53pt")
+        );
+        // No amount, no invention.
+        assert_eq!(
+            amount_in("Missing character: There is no X in font ec-lmr10!"),
+            None
+        );
+        // A parenthesis that is not a measurement stays out.
+        assert_eq!(
+            amount_in("Overfull \\hbox (badness 10000) in paragraph"),
+            None
+        );
     }
 }


### PR DESCRIPTION
Closes #101.

The bar, from the issue: *your table "results" runs 12.3pt past the right margin*.

The restated sentence now integrates the quantity: `figure \`fig:plot\` overflows its line **by 42.0pt**`. The amount is the engine's own — value and unit transcribed from its message (`(113.94pt too wide)`, `by 327.53pt`), never recomputed — and a message with no recognisable amount goes without one rather than inventing it: `(badness 10000)` is asserted NOT to be an amount.

- `texlog::amount_in`, tested against the transcribed live shapes.
- The entity carries it as a fourth field; blame JSON adds `"amount": "42.0pt" | null`.
- The CLI prints it in the same sentence.

The UI half (Vitela's panel and hover) lands with the next wasm pin.