### PR TITLE
A table overfull names its column — when the evidence supports it

### DIFF
--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -1186,13 +1186,23 @@ fn report_record(record: &xtex_core::blame::Translated, emitted: &Path) -> bool 
     };
     match &record.entity {
         Some((name, class, visual, amount)) => {
-            match amount {
-                Some(amount) => println!(
+            // Decision 0018's sentences, in evidence order: the column when
+            // the trace named exactly one cell, otherwise the entity.
+            match (&record.column, amount) {
+                (Some((index, content)), Some(amount)) => println!(
+                    "{label}: {} `{name}` — column {index} does not fit; \"{content}\" runs {amount} past the declared width",
+                    class.name(),
+                ),
+                (Some((index, content)), None) => println!(
+                    "{label}: {} `{name}` — column {index} does not fit: \"{content}\"",
+                    class.name(),
+                ),
+                (None, Some(amount)) => println!(
                     "{label}: {} `{name}` {} by {amount}",
                     class.name(),
                     visual.name()
                 ),
-                None => println!("{label}: {} `{name}` {}", class.name(), visual.name()),
+                (None, None) => println!("{label}: {} `{name}` {}", class.name(), visual.name()),
             }
             println!("  TeX said: {}", record.message);
         }

--- a/crates/xtex-core/src/blame.rs
+++ b/crates/xtex-core/src/blame.rs
@@ -39,6 +39,12 @@ pub struct Translated {
     /// the evidence: its name, its class, how the failure reads, and how
     /// much — the engine's own quantity, where its message named one.
     pub entity: Option<(String, EntityClass, Visual, Option<String>)>,
+    /// For a table overfull whose box trace named the offending content:
+    /// the column it sits in (one-based) and that content, quoted. Only
+    /// present when the content matches exactly ONE cell of the author's
+    /// row — a confident wrong column is worse than a located table
+    /// (decision 0018).
+    pub column: Option<(u32, String)>,
 }
 
 /// Merges the engine's stderr with its log file, the way the CLI always has.
@@ -110,8 +116,14 @@ fn translate_one(
             visual,
             line,
             message,
+            trace,
             ..
-        } => ("warning", *line, message.clone(), Some(*visual)),
+        } => (
+            "warning",
+            *line,
+            message.clone(),
+            Some((*visual, trace.clone())),
+        ),
         Record::Unrecognised(text) => {
             return Translated {
                 kind: "unrecognised",
@@ -120,12 +132,17 @@ fn translate_one(
                 blame: None,
                 span: None,
                 entity: None,
+                column: None,
             };
         }
     };
 
     // Read the amount before the message moves into the mapper.
     let amount = crate::texlog::amount_in(&message).map(str::to_owned);
+    let (visual, trace) = match visual {
+        Some((visual, trace)) => (Some(visual), trace),
+        None => (None, None),
+    };
     let mapped = map_emitted_diagnostic(message, &emission.bytes, line, 1, &emission.map);
 
     // A typesetting failure is restated in the author's terms only when a map
@@ -137,6 +154,13 @@ fn translate_one(
         let (name, class) = entity_at(sources, document, table, span.offset as usize)?;
         Some((name, class, visual, amount.clone()))
     });
+    let column = entity
+        .as_ref()
+        .filter(|(_, class, ..)| *class == EntityClass::Table)
+        .and_then(|_| {
+            let trace = trace.as_deref()?;
+            column_of(&emission.bytes, line, trace)
+        });
 
     Translated {
         kind,
@@ -145,7 +169,41 @@ fn translate_one(
         blame: Some(mapped.blame),
         span: mapped.span,
         entity,
+        column,
     }
+}
+
+/// The one-based column whose cell carries the trace content — and the
+/// content itself — when exactly one cell of the row does.
+///
+/// The row is the EMITTED line the engine named: the trace content came
+/// from that very line, and in a transported table body its `&`-separated
+/// cells are the author's own. Matching is containment over
+/// whitespace-collapsed text, both directions. Zero matches or several
+/// answer `None`: the honest sentence then names the table, never a
+/// guessed column (decision 0018).
+fn column_of(emitted: &[u8], line: u32, trace: &str) -> Option<(u32, String)> {
+    let text = std::str::from_utf8(emitted).ok()?;
+    let row = text.lines().nth(line.checked_sub(1)? as usize)?;
+    let collapse = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+    let needle = collapse(trace);
+    if needle.len() < 4 {
+        return None;
+    }
+    let mut hit = None;
+    for (index, cell) in row.split('&').enumerate() {
+        let cell_text = collapse(cell);
+        if cell_text.is_empty() {
+            continue;
+        }
+        if cell_text.contains(&needle) || needle.contains(&cell_text) {
+            if hit.is_some() {
+                return None;
+            }
+            hit = Some((u32::try_from(index + 1).ok()?, needle.clone()));
+        }
+    }
+    hit
 }
 
 /// Renders translations as JSON, one renderer for both hosts.
@@ -187,6 +245,16 @@ pub fn to_json(translated: &[Translated], out: &mut String) {
                     ",\"offset\":{},\"length\":{},\"line\":{},\"column\":{}}}",
                     span.offset, span.length, span.line, span.column
                 );
+            }
+            None => out.push_str("null"),
+        }
+        out.push_str(",\"column\":");
+        match &record.column {
+            Some((index, content)) => {
+                use std::fmt::Write as _;
+                let _ = write!(out, "{{\"index\":{index},\"content\":");
+                push_json_string(content, out);
+                out.push('}');
             }
             None => out.push_str("null"),
         }

--- a/crates/xtex-core/src/texlog.rs
+++ b/crates/xtex-core/src/texlog.rs
@@ -82,6 +82,10 @@ pub enum Record {
         line: u32,
         /// The engine's own words, unchanged.
         message: String,
+        /// The box trace that followed — the engine printing the very
+        /// content that did not fit — where the raw log carried one.
+        /// What lets a table overfull name its column (decision 0018).
+        trace: Option<String>,
     },
     /// A line that matched no known form.
     ///
@@ -166,19 +170,39 @@ pub fn line_in_message(message: &str) -> Option<u32> {
 #[must_use]
 pub fn parse_log(log: &str, file: &str) -> Vec<Record> {
     let mut records = Vec::new();
-    for line in log.lines() {
-        let line = line.trim_end();
+    let lines: Vec<&str> = log.lines().collect();
+    for (index, raw) in lines.iter().enumerate() {
+        let line = raw.trim_end();
         let Some(visual) = classify(line) else {
             continue;
         };
         let Some(number) = line_in_message(line).or_else(|| line_after(line)) else {
             continue;
         };
+        // An Overfull record is followed by the box trace — the engine
+        // printing the very content that did not fit. Keeping it is what
+        // lets a table overfull name its column by matching that content
+        // against the row's cells (decision 0018). The trace ends at the
+        // bare `[]` line the engine closes it with.
+        let mut trace = String::new();
+        for follow in lines.iter().skip(index + 1).take(3) {
+            let follow = follow.trim_end();
+            if follow.trim() == "[]" || follow.is_empty() {
+                break;
+            }
+            if let Some(text) = trace_text(follow) {
+                if !trace.is_empty() {
+                    trace.push(' ');
+                }
+                trace.push_str(&text);
+            }
+        }
         let record = Record::Typeset {
             visual,
             file: file.to_owned(),
             line: number,
             message: line.to_owned(),
+            trace: (!trace.is_empty()).then_some(trace),
         };
         if !records.contains(&record) {
             records.push(record);
@@ -187,6 +211,35 @@ pub fn parse_log(log: &str, file: &str) -> Vec<Record> {
     records
 }
 
+/// The readable text of one box-trace line: font runs, `[]` markers and
+/// `|` edges stripped, discretionary hyphens rejoined.
+///
+/// `[]\OT1/cmr/m/n/10 ThisWordIsFarTooWide|` becomes
+/// `ThisWordIsFarTooWide`. A line that carries no text answers `None`.
+fn trace_text(line: &str) -> Option<String> {
+    let mut out = String::new();
+    let mut rest = line;
+    while let Some(at) = rest.find('\\') {
+        out.push_str(&rest[..at]);
+        // A control word runs to the first non-letter; its trailing space
+        // separates it from the text it applies to.
+        let after = &rest[at + 1..];
+        let end = after
+            .find(|c: char| !c.is_ascii_alphanumeric() && c != '/' && c != '.' && c != '-')
+            .unwrap_or(after.len());
+        rest = after[end..].strip_prefix(' ').unwrap_or(&after[end..]);
+    }
+    out.push_str(rest);
+    let cleaned: String = out.replace("[]", "").replace('|', "").trim().to_owned();
+    (!cleaned.is_empty()).then_some(cleaned)
+}
+
+/// The line a `.log` record names, when it names one in its own text.
+///
+/// `LaTeX Warning: … on input line 9.` carries its line inside the sentence
+/// rather than in a `file:line:` prefix, which is why the raw log needs its own
+/// reader: that record never reaches stderr at all.
+#[must_use]
 /// The line an `Overfull` record names in its trailing `at line N` or
 /// `at lines N--M`.
 fn line_after(message: &str) -> Option<u32> {

--- a/crates/xtex-core/tests/table_column.rs
+++ b/crates/xtex-core/tests/table_column.rs
@@ -1,0 +1,110 @@
+//! A table overfull names its column — when the evidence supports it.
+//!
+//! Decision 0018, measured against the live engine first: paragraph-shaped
+//! columns localize an overfull to the ROW and the box trace prints the
+//! offending cell's own content. Attribution is therefore content matching
+//! against the row's cells — never width arithmetic, never a guess.
+
+use xtex_core::blame::{merge_records, translate};
+use xtex_core::source::Sources;
+use xtex_core::sourcemap::emit_with_map;
+use xtex_core::{parse, project};
+
+const DOC: &[u8] = b"\\documentclass{article}\n\
+\\table(tab:sizes) {\n\
+  placement = ht\n\
+  caption = {Sizes.}\n\
+  body = {\n\
+    \\begin{tabular}{p{1cm}p{2cm}p{1cm}}\n\
+      short & ThisWordIsFarTooWideForItsColumn & also \\\\\n\
+    \\end{tabular}\n\
+  }\n\
+}\n";
+
+/// The emitted line that carries the too-wide row, found rather than
+/// hard-coded so an emitter change cannot silently invalidate the log.
+fn emitted_row_line(emitted: &[u8]) -> u32 {
+    let text = String::from_utf8_lossy(emitted);
+    let line = text
+        .lines()
+        .position(|l| l.contains("ThisWordIsFarTooWideForItsColumn"))
+        .expect("the row is emitted");
+    u32::try_from(line + 1).expect("fits")
+}
+
+fn translated_for(log: &str) -> Vec<xtex_core::blame::Translated> {
+    let mut sources = Sources::new();
+    let id = sources.add("t.xtex", DOC.to_vec());
+    let document = parse(&sources, id);
+    let emission = emit_with_map(&sources, &document).expect("emits");
+    let store = xtex_core::io::Memory::new().with_input("t.xtex".to_owned(), DOC.to_vec());
+    let analysed = project::analyse(&store, "t.xtex").expect("analyses");
+    let records = merge_records(None, Some(log), "t.tex");
+    translate(&records, &emission, &sources, &document, &analysed.table)
+}
+
+#[test]
+fn the_column_is_named_when_the_trace_matches_one_cell() {
+    let mut sources = Sources::new();
+    let id = sources.add("t.xtex", DOC.to_vec());
+    let document = parse(&sources, id);
+    let emission = emit_with_map(&sources, &document).expect("emits");
+    let row = emitted_row_line(&emission.bytes);
+    // The log shapes are transcribed from a live pdfTeX run (decision 0018).
+    let log = format!(
+        "Overfull \\hbox (137.35315pt too wide) in paragraph at lines {row}--{row}\n\
+         []\\OT1/cmr/m/n/10 ThisWordIsFarTooWideForItsColumn|\n\
+         []\n"
+    );
+    let translated = translated_for(&log);
+    let record = translated
+        .iter()
+        .find(|t| t.column.is_some())
+        .expect("one record carries the column");
+    let (index, content) = record.column.as_ref().expect("checked");
+    assert_eq!(*index, 2, "the offending word sits in the second cell");
+    assert!(content.contains("ThisWordIsFarTooWide"));
+    let (name, ..) = record.entity.as_ref().expect("the table is the entity");
+    assert_eq!(name, "tab:sizes");
+}
+
+#[test]
+fn an_ambiguous_trace_names_no_column() {
+    // The same word in two cells: two records with identical traces. A
+    // confident wrong column is worse than a located table, so none is named.
+    let doc = b"\\documentclass{article}\n\
+\\table(tab:twin) {\n\
+  placement = ht\n\
+  caption = {Twins.}\n\
+  body = {\n\
+    \\begin{tabular}{p{1cm}p{1cm}}\n\
+      SameWordTooWideForBoth & SameWordTooWideForBoth \\\\\n\
+    \\end{tabular}\n\
+  }\n\
+}\n";
+    let mut sources = Sources::new();
+    let id = sources.add("t.xtex", doc.to_vec());
+    let document = parse(&sources, id);
+    let emission = emit_with_map(&sources, &document).expect("emits");
+    let text = String::from_utf8_lossy(&emission.bytes);
+    let row = u32::try_from(
+        text.lines()
+            .position(|l| l.contains("SameWordTooWideForBoth"))
+            .expect("emitted")
+            + 1,
+    )
+    .expect("fits");
+    let log = format!(
+        "Overfull \\hbox (94.65866pt too wide) in paragraph at lines {row}--{row}\n\
+         []|\\OT1/cmr/m/n/10 SameWordTooWideForBoth|\n\
+         []\n"
+    );
+    let store = xtex_core::io::Memory::new().with_input("t.xtex".to_owned(), doc.to_vec());
+    let analysed = project::analyse(&store, "t.xtex").expect("analyses");
+    let records = merge_records(None, Some(&log), "t.tex");
+    let translated = translate(&records, &emission, &sources, &document, &analysed.table);
+    assert!(
+        translated.iter().all(|t| t.column.is_none()),
+        "an ambiguous trace must not name a column"
+    );
+}


### PR DESCRIPTION
Implements decision 0018 (closes #100), to the letter of what the investigation measured.

**The mechanism is content matching, not width arithmetic.** `parse_log` now keeps the box trace that follows an Overfull record — the engine printing the very content that did not fit — as a field on the record (font runs and box markers stripped). For a table entity, that content is matched against the `&`-separated cells of the **emitted** row the engine named. The map lands on the `\table` block, not the row; the emitted line is where the cells are, and in a transported body they are the author's own bytes.

**The evidence rule, enforced:** exactly one matching cell names the column (one-based, content quoted). Zero or several name nothing, and the sentence falls back to the table with #101's amount — a confident wrong column is worse than a located table.

The CLI sentence meets the issue's bar:

`warning[TEX]: table \`tab:sizes\` — column 2 does not fit; "ThisWordIsFarTooWideForItsColumn" runs 137.35315pt past the declared width`

Blame JSON adds `"column": {"index": N, "content": "…"} | null` for the surfaces; Vitela picks it up with the next wasm pin.

`tests/table_column.rs` holds both halves end to end against a real emission and the transcribed log shapes: the named column, and the twin-cell ambiguity naming none. 15 suites, clippy `-D warnings` and fmt clean.