### PR TITLE
A book, not the book

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ What is solid: the transport guarantee — untouched LaTeX comes out
 byte-identical — is the oldest invariant here and the most heavily tested. The
 checker, the emitter and the two surfaces (WebAssembly and LSP) answer
 identically for the same input, and a parity suite in CI holds them to it. A
-127-page Springer book with forty packages, an index, per-chapter
+book of a little over a hundred pages — forty packages, an index, per-chapter
 bibliographies and TikZ compiles to the same page count as a full TeX Live.
 
 Where it is still tender: the change model. Three defects surfaced in one

--- a/crates/xtex-core/src/review.rs
+++ b/crates/xtex-core/src/review.rs
@@ -458,7 +458,7 @@ struct RevisionConstruct {
 /// `\newcommand` body is not. Deciding it again here would let review and
 /// emission disagree — which is how a proposed deletion of an author name
 /// came to be resolvable and, at the same time, printed into the PDF as
-/// `@del(change:…)` on a real Springer book, 2026-08-31.
+/// `@del(change:…)` on a real book, 2026-08-31.
 fn revision_constructs(bytes: &[u8]) -> Vec<RevisionConstruct> {
     scan(bytes)
         .into_iter()

--- a/crates/xtex-core/tests/revisions.rs
+++ b/crates/xtex-core/tests/revisions.rs
@@ -120,7 +120,7 @@ fn marked_imports_target_the_distinct_marked_artifact() {
 
 #[test]
 fn a_revision_inside_a_command_argument_is_a_real_revision() {
-    // Found on a real 127-page Springer book, 2026-08-31: a deletion proposed
+    // Found on a real book of a little over a hundred pages, 2026-08-31: a deletion proposed
     // on an author name
     // inside `\\author{…}` showed in the margin and could never be accepted —
     // `xtex revise` answered XT1012 "sidecar record has no construct", because

--- a/docs/decisions/0007-project-bundle.md
+++ b/docs/decisions/0007-project-bundle.md
@@ -9,7 +9,7 @@ Two shapes were considered for getting a multi-file project into the WebAssembly
 functions.
 
 **Call back into the host per file.** The only thing this buys is not knowing the file set in advance —
-and the host is an editor, which is the thing that opened the files. Measured against a real Springer
+and the host is an editor, which is the thing that opened the files. Measured against a real
 monograph: 388 KB across 20 files, checked in 71 ms *including twenty process starts*; in-process there is
 nothing to save. And WebAssembly imports are synchronous, so a file arriving over a network cannot be
 awaited from inside one without heavy machinery. The shape that appears to serve the network case serves


### PR DESCRIPTION
The docs and test rationales kept naming one identifiable manuscript — its page count and publisher — where all a reader needs is the scale. Now: *a real book of a little over a hundred pages*. No behaviour changes.