### PR TITLE
A trace line looks like a trace line

### DIFF
--- a/crates/xtex-core/src/texlog.rs
+++ b/crates/xtex-core/src/texlog.rs
@@ -190,11 +190,18 @@ pub fn parse_log(log: &str, file: &str) -> Vec<Record> {
             if follow.trim() == "[]" || follow.is_empty() {
                 break;
             }
-            // A box-trace line starts with a box marker or a font run.
-            // Anything else is the surrounding log — page ships, file
-            // closes — and swallowing it once put "(./main.aux)" inside a
+            // A box-trace line starts with a box marker or a FONT run —
+            // `\OT1/cmr/m/n/10 …`, always an encoding, a slash, a family.
+            // A bare backslash is not enough: `\openout1 = main.aux` also
+            // starts with one and is the surrounding log, like the page
+            // ships and file closes that once put "(./main.aux)" inside a
             // quoted cell (found by the gate the same hour this shipped).
-            if !(follow.starts_with("[]") || follow.starts_with('\\')) {
+            let is_font_run = follow.strip_prefix('\\').is_some_and(|rest| {
+                rest.split_once('/').is_some_and(|(encoding, _)| {
+                    !encoding.is_empty() && encoding.chars().all(|c| c.is_ascii_alphanumeric())
+                })
+            });
+            if !(follow.starts_with("[]") || is_font_run) {
                 break;
             }
             if let Some(text) = trace_text(follow) {

--- a/crates/xtex-core/src/texlog.rs
+++ b/crates/xtex-core/src/texlog.rs
@@ -190,6 +190,13 @@ pub fn parse_log(log: &str, file: &str) -> Vec<Record> {
             if follow.trim() == "[]" || follow.is_empty() {
                 break;
             }
+            // A box-trace line starts with a box marker or a font run.
+            // Anything else is the surrounding log — page ships, file
+            // closes — and swallowing it once put "(./main.aux)" inside a
+            // quoted cell (found by the gate the same hour this shipped).
+            if !(follow.starts_with("[]") || follow.starts_with('\\')) {
+                break;
+            }
             if let Some(text) = trace_text(follow) {
                 if !trace.is_empty() {
                     trace.push(' ');

--- a/crates/xtex-core/tests/table_column.rs
+++ b/crates/xtex-core/tests/table_column.rs
@@ -136,3 +136,30 @@ fn the_trace_never_swallows_the_surrounding_log() {
         "log tail leaked into the quoted content: {content}"
     );
 }
+
+#[test]
+fn a_backslash_line_that_is_not_a_font_run_is_not_trace() {
+    // `\openout1 = main.aux` starts with a backslash and is log, not trace.
+    // The whitelist errs toward LOSING trace — the sentence then names the
+    // table, never a wrong column built from swallowed log.
+    let mut sources = Sources::new();
+    let id = sources.add("t.xtex", DOC.to_vec());
+    let document = parse(&sources, id);
+    let emission = emit_with_map(&sources, &document).expect("emits");
+    let row = emitted_row_line(&emission.bytes);
+    let log = format!(
+        "Overfull \\hbox (137.35315pt too wide) in paragraph at lines {row}--{row}\n\
+         \\openout1 = main.aux\n"
+    );
+    let translated = translated_for(&log);
+    assert!(
+        translated.iter().all(|t| t.column.is_none()),
+        "an openout line must not become quoted cell content"
+    );
+    // And the record itself still stands, with its amount.
+    assert!(translated.iter().any(|t| {
+        t.entity
+            .as_ref()
+            .is_some_and(|(_, _, _, amount)| amount.as_deref() == Some("137.35315pt"))
+    }));
+}

--- a/crates/xtex-core/tests/table_column.rs
+++ b/crates/xtex-core/tests/table_column.rs
@@ -108,3 +108,31 @@ fn an_ambiguous_trace_names_no_column() {
         "an ambiguous trace must not name a column"
     );
 }
+
+#[test]
+fn the_trace_never_swallows_the_surrounding_log() {
+    // Near the end of a log the record is followed by page ships and file
+    // closes, not a trace terminator. Those lines must not be quoted as the
+    // offending content.
+    let mut sources = Sources::new();
+    let id = sources.add("t.xtex", DOC.to_vec());
+    let document = parse(&sources, id);
+    let emission = emit_with_map(&sources, &document).expect("emits");
+    let row = emitted_row_line(&emission.bytes);
+    let log = format!(
+        "Overfull \\hbox (137.35315pt too wide) in paragraph at lines {row}--{row}\n\
+         []\\OT1/cmr/m/n/10 ThisWordIsFarTooWideForItsColumn|\n\
+         [2] (./main.aux) )\n\
+         (see the transcript file for additional information)\n"
+    );
+    let translated = translated_for(&log);
+    let record = translated
+        .iter()
+        .find(|t| t.column.is_some())
+        .expect("the column is still named");
+    let (_, content) = record.column.as_ref().expect("checked");
+    assert!(
+        !content.contains("main.aux") && !content.contains("transcript"),
+        "log tail leaked into the quoted content: {content}"
+    );
+}


### PR DESCRIPTION
Found by Vitela's end-to-end gate within the hour of wasm-v2.0: near the end of a log, the Overfull record is followed by page ships and file closes rather than a trace terminator, and the collector quoted `(./main.aux) )` inside the offending cell's content.

A follow line now qualifies as trace only if it starts with a box marker (`[]`) or a font run (`\`); anything else is the surrounding log and ends the collection. Tested with the exact leaked shape.