### PR TITLE
A citation's definition is the key's own line in the bib

### DIFF
--- a/crates/xtex-core/src/bibliography.rs
+++ b/crates/xtex-core/src/bibliography.rs
@@ -312,7 +312,28 @@ pub fn keys_in_bib(bytes: &[u8]) -> Option<BTreeSet<String>> {
 }
 
 fn scan_bib(bytes: &[u8]) -> Result<BTreeSet<String>, String> {
-    let mut keys = BTreeSet::new();
+    Ok(scan_bib_entries(bytes)?
+        .into_iter()
+        .map(|(key, _)| key)
+        .collect())
+}
+
+/// The span of `key`'s own token in a `.bib` file, when the file declares it.
+///
+/// This is a citation's definition site: the one place a `@cite` can send
+/// the editor. The scan is [`scan_bib`]'s — same entries, same skips — so a
+/// key this finds is exactly a key the checker accepts.
+#[must_use]
+pub fn entry_span_in_bib(bytes: &[u8], key: &str) -> Option<Span> {
+    scan_bib_entries(bytes)
+        .ok()?
+        .into_iter()
+        .find(|(found, _)| found == key)
+        .map(|(_, span)| span)
+}
+
+fn scan_bib_entries(bytes: &[u8]) -> Result<Vec<(String, Span)>, String> {
+    let mut keys = Vec::new();
     let mut at = 0usize;
     while at < bytes.len() {
         if bytes[at] != b'@' {
@@ -368,7 +389,8 @@ fn scan_bib(bytes: &[u8]) -> Result<BTreeSet<String>, String> {
             && key_end > key_start
             && let Ok(key) = std::str::from_utf8(&bytes[key_start..key_end])
         {
-            keys.insert(key.to_owned());
+            #[allow(clippy::cast_possible_truncation)] // a .bib past 4GB is not a .bib
+            keys.push((key.to_owned(), Span::new(key_start as u32, key_end as u32)));
         }
         at = close + 1;
     }

--- a/crates/xtex-core/src/editor.rs
+++ b/crates/xtex-core/src/editor.rs
@@ -268,6 +268,45 @@ pub fn definition_site(
     Some((declaration.payload.source, declaration.construct))
 }
 
+/// A citation's definition site: the key's own line in the `.bib`.
+///
+/// The symbol table holds constructs, and a citation's declaration is not a
+/// construct — it is the `@entry{key,` line of a resource the document
+/// declared. The resources consulted are exactly [`declared_in`]'s, loaded
+/// through the same loader the checker uses, and interned into `sources` so
+/// the ordinary definition JSON path speaks for the answer too.
+///
+/// `None` when the position is not a citation, or no declared resource
+/// holds the key — the same silence as an unknown identifier.
+///
+/// [`declared_in`]: crate::bibliography::declared_in
+pub fn citation_definition_site(
+    sources: &mut Sources,
+    loader: &impl crate::io::SourceLoader,
+    document: &Document,
+    id: crate::source::SourceId,
+    offset: usize,
+) -> Option<(crate::source::SourceId, Span)> {
+    let located = construct_at(sources, document, offset)?;
+    if located.kind != EntryToken::Cite {
+        return None;
+    }
+    let key = located.name;
+    let declared = crate::bibliography::declared_in(sources, id);
+    for resource in &declared.resources {
+        let Ok(bib) = loader.load(&resource.name, Some(id), sources) else {
+            continue;
+        };
+        let Some(bytes) = sources.get(bib).map(crate::source::Source::bytes) else {
+            continue;
+        };
+        if let Some(span) = crate::bibliography::entry_span_in_bib(bytes, &key) {
+            return Some((bib, span));
+        }
+    }
+    None
+}
+
 /// The text between a construct's parentheses.
 fn payload_text(sources: &Sources, source: SourceId, span: Span) -> Option<String> {
     payload_text_for(sources, source, span, EntryToken::Id)

--- a/crates/xtex-core/tests/citation_definition.rs
+++ b/crates/xtex-core/tests/citation_definition.rs
@@ -1,0 +1,70 @@
+//! A citation's definition is the key's own line in the declared `.bib`.
+
+use xtex_core::editor::citation_definition_site;
+use xtex_core::io::{Memory, SourceLoader};
+use xtex_core::parse;
+use xtex_core::source::Sources;
+
+const DOC: &str = "\\documentclass{article}\n\\begin{document}\nSee @cite(knuth1984).\n\\bibliography{refs}\n\\end{document}\n";
+const BIB: &str = "% typesetting classics\n@book{lamport1994, title={LaTeX}}\n@book{knuth1984, title={The TeXbook}}\n";
+
+fn project() -> (
+    Memory,
+    Sources,
+    xtex_core::document::Document,
+    xtex_core::source::SourceId,
+) {
+    let memory = Memory::new()
+        .with_input("main.xtex", DOC.as_bytes().to_vec())
+        .with_input("refs.bib", BIB.as_bytes().to_vec());
+    let mut sources = Sources::new();
+    let id = memory
+        .load("main.xtex", None, &mut sources)
+        .expect("root loads");
+    let document = parse(&sources, id);
+    (memory, sources, document, id)
+}
+
+#[test]
+fn a_cite_lands_on_its_bib_entry() {
+    let (memory, mut sources, document, id) = project();
+    let offset = DOC.find("@cite").expect("cite is in the doc") + 7;
+    let (bib, span) = citation_definition_site(&mut sources, &memory, &document, id, offset)
+        .expect("the key is declared in refs.bib");
+    let bytes = sources.get(bib).expect("bib interned").bytes();
+    assert_eq!(
+        &bytes[span.start()..span.end()],
+        b"knuth1984",
+        "the span is the key's own token"
+    );
+    let before = &BIB[..BIB.find("knuth1984").expect("key in bib")];
+    assert_eq!(
+        span.start(),
+        before.len(),
+        "and it sits at the right offset"
+    );
+}
+
+#[test]
+fn a_position_outside_a_cite_stays_silent() {
+    let (memory, mut sources, document, id) = project();
+    let offset = DOC.find("See").expect("prose is in the doc");
+    assert!(citation_definition_site(&mut sources, &memory, &document, id, offset).is_none());
+}
+
+#[test]
+fn an_unknown_key_stays_silent() {
+    let (memory, sources, document, id) = project();
+    let doc2 = DOC.replace("knuth1984", "knuth1985");
+    let memory2 = Memory::new()
+        .with_input("main.xtex", doc2.as_bytes().to_vec())
+        .with_input("refs.bib", BIB.as_bytes().to_vec());
+    let mut sources2 = Sources::new();
+    let id2 = memory2
+        .load("main.xtex", None, &mut sources2)
+        .expect("root loads");
+    let document2 = parse(&sources2, id2);
+    let offset = doc2.find("@cite").expect("cite is in the doc") + 7;
+    assert!(citation_definition_site(&mut sources2, &memory2, &document2, id2, offset).is_none());
+    let _ = (memory, sources, document, id);
+}

--- a/crates/xtex-wasm/src/lib.rs
+++ b/crates/xtex-wasm/src/lib.rs
@@ -336,11 +336,7 @@ pub unsafe extern "C" fn xtex_rename_apply(pointer: *const u8, len: usize) -> *m
 /// an opaque region returns the empty result rather than a guess.
 fn positional_query(
     bytes: &[u8],
-    answer: impl Fn(
-        &xtex_core::project::Analysed,
-        &xtex_core::document::Document,
-        usize,
-    ) -> Option<String>,
+    answer: impl Fn(&mut xtex_core::project::Analysed, &Memory, usize, usize) -> Option<String>,
 ) -> Vec<u8> {
     let mut at = 0usize;
     let Some(target) = take_text(bytes, &mut at) else {
@@ -362,8 +358,8 @@ fn positional_query(
     let Some(position) = analysed.names.iter().position(|(_, name)| *name == target) else {
         return Vec::new();
     };
-    let document = &analysed.documents[position];
-    answer(&analysed, document, offset).map_or_else(Vec::new, String::into_bytes)
+    let mut analysed = analysed;
+    answer(&mut analysed, &bundle.store, position, offset).map_or_else(Vec::new, String::into_bytes)
 }
 
 /// Hover text for a position. See `positional_query` for the input.
@@ -374,12 +370,17 @@ fn positional_query(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn xtex_hover(pointer: *const u8, len: usize) -> *mut u8 {
     let bytes = unsafe { input(pointer, len) };
-    result(&positional_query(&bytes, |analysed, document, offset| {
-        let found = xtex_core::editor::hover(&analysed.sources, document, &analysed.table, offset)?;
-        let mut json = String::new();
-        xtex_core::editor::hover_to_json(&found, &mut json);
-        Some(json)
-    }))
+    result(&positional_query(
+        &bytes,
+        |analysed, _, position, offset| {
+            let document = &analysed.documents[position];
+            let found =
+                xtex_core::editor::hover(&analysed.sources, document, &analysed.table, offset)?;
+            let mut json = String::new();
+            xtex_core::editor::hover_to_json(&found, &mut json);
+            Some(json)
+        },
+    ))
 }
 
 /// Completions at a position. See `positional_query` for the input.
@@ -390,16 +391,24 @@ pub unsafe extern "C" fn xtex_hover(pointer: *const u8, len: usize) -> *mut u8 {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn xtex_completions(pointer: *const u8, len: usize) -> *mut u8 {
     let bytes = unsafe { input(pointer, len) };
-    result(&positional_query(&bytes, |analysed, document, offset| {
-        let items =
-            xtex_core::editor::completions(&analysed.sources, document, &analysed.table, offset);
-        if items.is_empty() {
-            return None;
-        }
-        let mut json = String::new();
-        xtex_core::editor::completions_to_json(&items, &mut json);
-        Some(json)
-    }))
+    result(&positional_query(
+        &bytes,
+        |analysed, _, position, offset| {
+            let document = &analysed.documents[position];
+            let items = xtex_core::editor::completions(
+                &analysed.sources,
+                document,
+                &analysed.table,
+                offset,
+            );
+            if items.is_empty() {
+                return None;
+            }
+            let mut json = String::new();
+            xtex_core::editor::completions_to_json(&items, &mut json);
+            Some(json)
+        },
+    ))
 }
 
 /// The declaration a position refers to. See `positional_query`.
@@ -410,17 +419,39 @@ pub unsafe extern "C" fn xtex_completions(pointer: *const u8, len: usize) -> *mu
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn xtex_definition(pointer: *const u8, len: usize) -> *mut u8 {
     let bytes = unsafe { input(pointer, len) };
-    result(&positional_query(&bytes, |analysed, document, offset| {
-        let (source, span) = xtex_core::editor::definition_site(
-            &analysed.sources,
-            document,
-            &analysed.table,
-            offset,
-        )?;
-        let mut json = String::new();
-        xtex_core::editor::definition_to_json(&analysed.sources, source, span, &mut json);
-        Some(json)
-    }))
+    result(&positional_query(
+        &bytes,
+        |analysed, store, position, offset| {
+            let document_id = analysed.names[position].0;
+            let document = &analysed.documents[position];
+            // A construct's declaration first; failing that, a citation's — the
+            // key's own line in the declared .bib, which the symbol table never
+            // holds because a bib entry is not a construct.
+            let site = xtex_core::editor::definition_site(
+                &analysed.sources,
+                document,
+                &analysed.table,
+                offset,
+            );
+            let (source, span) = if let Some(found) = site {
+                found
+            } else {
+                let xtex_core::project::Analysed {
+                    sources, documents, ..
+                } = analysed;
+                xtex_core::editor::citation_definition_site(
+                    sources,
+                    store,
+                    &documents[position],
+                    document_id,
+                    offset,
+                )?
+            };
+            let mut json = String::new();
+            xtex_core::editor::definition_to_json(&analysed.sources, source, span, &mut json);
+            Some(json)
+        },
+    ))
 }
 
 /// Emits the bundle's root under one revision view.


### PR DESCRIPTION
Go-to-definition worked for constructs (@ref to its section) and stayed silent for citations: a bib entry is not a construct, so the symbol table never holds it and the editor had nowhere to send you.

- The bib scanner records each key's own span — same walk, same skips as the checker, so a key it finds is exactly a key the checker accepts.
- `citation_definition_site` consults the document's declared resources through the same loader the checker reads, and interns the bib into `Sources` so `definition_to_json` answers unchanged.
- The wasm definition query tries the construct site first, then the citation's.
- Tests: the cite lands on the key's own token at the right offset; prose and unknown keys stay silent.

16 suites, clippy, fmt clean.