### PR TITLE
A plain \cite lands on the same bib line

### DIFF
--- a/crates/xtex-core/src/bibliography.rs
+++ b/crates/xtex-core/src/bibliography.rs
@@ -318,6 +318,110 @@ fn scan_bib(bytes: &[u8]) -> Result<BTreeSet<String>, String> {
         .collect())
 }
 
+/// Citation commands a reader may look inside: `\cite` and the natbib and
+/// biblatex families. `cite` covers every `\cite…` variant by prefix; the
+/// rest carry the word later in their name, where a prefix cannot reach it.
+const CITATION_COMMANDS: &[&str] = &[
+    "cite",
+    "Cite",
+    "parencite",
+    "Parencite",
+    "textcite",
+    "Textcite",
+    "autocite",
+    "Autocite",
+    "footcite",
+    "smartcite",
+    "nocite",
+];
+
+/// The plain-LaTeX citation key under `offset`: a `\cite{a,b}` (or any of
+/// [`CITATION_COMMANDS`], starred, with optional `[…]` arguments) whose
+/// braces cover the offset, answered as the one key the cursor is on.
+///
+/// Plain `\cite` is the author's LaTeX, outside any ExactTeX construct, and
+/// the checker never reports its keys. Navigation asks a different question
+/// — "where is this defined?" — and the answer is the same either way. The
+/// offset must fall in one of [`crate::scanner::readable_for`]'s regions,
+/// same prose and same skips as every other reader, so a commented-out
+/// citation stays silent here exactly as it does everywhere else. (The
+/// command's shape is read from the bytes directly, because the scanner
+/// splits a starred or bracketed `\citep*[…]{…}` across two regions.)
+#[must_use]
+pub fn latex_citation_key_at(bytes: &[u8], offset: usize) -> Option<String> {
+    crate::scanner::readable_for(bytes, CITATION_COMMANDS)
+        .into_iter()
+        .find(|region| offset >= region.start() && offset < region.end())?;
+
+    // The brace group covering the offset. Keys carry no braces of their
+    // own, so the nearest brace to the left decides: a `}` means the offset
+    // sits between groups, not inside one.
+    let open = bytes[..offset]
+        .iter()
+        .rposition(|&b| b == b'{' || b == b'}')?;
+    if bytes[open] != b'{' {
+        return None;
+    }
+    let close = open + bytes[open..].iter().position(|&b| b == b'}')?;
+    if offset >= close {
+        return None;
+    }
+
+    // Walk left from the brace over what a citation may carry — up to two
+    // `[…]` arguments and a star — to the command that owns the group.
+    let mut cursor = open;
+    for _ in 0..2 {
+        if cursor > 0 && bytes[cursor - 1] == b']' {
+            cursor = bytes[..cursor - 1].iter().rposition(|&b| b == b'[')?;
+        }
+    }
+    if cursor > 0 && bytes[cursor - 1] == b'*' {
+        cursor -= 1;
+    }
+    let name_end = cursor;
+    while cursor > 0 && bytes[cursor - 1].is_ascii_alphabetic() {
+        cursor -= 1;
+    }
+    if cursor == name_end || cursor == 0 || bytes[cursor - 1] != b'\\' {
+        return None;
+    }
+    let name = &bytes[cursor..name_end];
+    if !CITATION_COMMANDS
+        .iter()
+        .any(|command| name.starts_with(command.as_bytes()))
+    {
+        return None;
+    }
+
+    // The one key the cursor is on, out of a comma-separated list. A cursor
+    // sitting exactly on a comma is on no key, and no key is the answer.
+    let mut start = open + 1;
+    let mut boundary = start;
+    while boundary <= close {
+        if boundary < close && bytes[boundary] != b',' {
+            boundary += 1;
+            continue;
+        }
+        if offset >= start && offset < boundary {
+            let mut from = start;
+            let mut to = boundary;
+            while from < to && bytes[from].is_ascii_whitespace() {
+                from += 1;
+            }
+            while to > from && bytes[to - 1].is_ascii_whitespace() {
+                to -= 1;
+            }
+            if from == to {
+                return None;
+            }
+            return Some(String::from_utf8_lossy(&bytes[from..to]).into_owned());
+        }
+        start = boundary + 1;
+        boundary += 1;
+    }
+    None
+}
+
 /// The span of `key`'s own token in a `.bib` file, when the file declares it.
 ///
 /// This is a citation's definition site: the one place a `@cite` can send

--- a/crates/xtex-core/src/editor.rs
+++ b/crates/xtex-core/src/editor.rs
@@ -287,11 +287,13 @@ pub fn citation_definition_site(
     id: crate::source::SourceId,
     offset: usize,
 ) -> Option<(crate::source::SourceId, Span)> {
-    let located = construct_at(sources, document, offset)?;
-    if located.kind != EntryToken::Cite {
-        return None;
-    }
-    let key = located.name;
+    let key = match construct_at(sources, document, offset) {
+        Some(located) if located.kind == EntryToken::Cite => located.name,
+        // Plain `\cite{…}`: no construct and no checker guarantee, but
+        // "where is this defined?" has the same answer either way. The
+        // recognition is navigational only; diagnostics are unchanged.
+        _ => crate::bibliography::latex_citation_key_at(sources.get(id)?.bytes(), offset)?,
+    };
     let declared = crate::bibliography::declared_in(sources, id);
     for resource in &declared.resources {
         let Ok(bib) = loader.load(&resource.name, Some(id), sources) else {

--- a/crates/xtex-core/tests/citation_definition.rs
+++ b/crates/xtex-core/tests/citation_definition.rs
@@ -52,6 +52,85 @@ fn a_position_outside_a_cite_stays_silent() {
     assert!(citation_definition_site(&mut sources, &memory, &document, id, offset).is_none());
 }
 
+/// A project whose root is the author's plain LaTeX: `\cite`, not `@cite`.
+fn plain_project(
+    doc: &str,
+) -> (
+    Memory,
+    Sources,
+    xtex_core::document::Document,
+    xtex_core::source::SourceId,
+) {
+    let memory = Memory::new()
+        .with_input("paper.tex", doc.as_bytes().to_vec())
+        .with_input("refs.bib", BIB.as_bytes().to_vec());
+    let mut sources = Sources::new();
+    let id = memory
+        .load("paper.tex", None, &mut sources)
+        .expect("root loads");
+    let document = parse(&sources, id);
+    (memory, sources, document, id)
+}
+
+const PLAIN: &str = "\\documentclass{article}\n\\begin{document}\nSee \\cite{knuth1984}.\n\\bibliography{refs}\n\\end{document}\n";
+
+#[test]
+fn a_plain_latex_cite_lands_on_the_same_bib_entry() {
+    let (memory, mut sources, document, id) = plain_project(PLAIN);
+    let offset = PLAIN.find("knuth1984").expect("key is in the doc");
+    let (bib, span) = citation_definition_site(&mut sources, &memory, &document, id, offset)
+        .expect("a plain \\cite navigates like an @cite");
+    let bytes = sources.get(bib).expect("bib interned").bytes();
+    assert_eq!(&bytes[span.start()..span.end()], b"knuth1984");
+}
+
+#[test]
+fn a_multi_key_cite_answers_the_key_under_the_cursor() {
+    let doc = PLAIN.replace(
+        "\\cite{knuth1984}",
+        "\\citep*[see][p.~5]{lamport1994, knuth1984}",
+    );
+    let (memory, mut sources, document, id) = plain_project(&doc);
+    let offset = doc.find("knuth1984").expect("key is in the doc") + 3;
+    let (bib, span) = citation_definition_site(&mut sources, &memory, &document, id, offset)
+        .expect("the second key answers for a cursor on it");
+    let bytes = sources.get(bib).expect("bib interned").bytes();
+    assert_eq!(
+        &bytes[span.start()..span.end()],
+        b"knuth1984",
+        "the answer is the key under the cursor, not the first in the list"
+    );
+}
+
+#[test]
+fn a_cursor_on_the_command_name_stays_silent() {
+    let (memory, mut sources, document, id) = plain_project(PLAIN);
+    let offset = PLAIN.find("\\cite").expect("cite is in the doc") + 2;
+    assert!(citation_definition_site(&mut sources, &memory, &document, id, offset).is_none());
+}
+
+#[test]
+fn a_non_citation_command_stays_silent() {
+    let doc = PLAIN.replace("\\cite{knuth1984}", "\\textbf{knuth1984}");
+    let (memory, mut sources, document, id) = plain_project(&doc);
+    let offset = doc.find("knuth1984").expect("key is in the doc");
+    assert!(
+        citation_definition_site(&mut sources, &memory, &document, id, offset).is_none(),
+        "a brace group is only a citation when a citation command owns it"
+    );
+}
+
+#[test]
+fn a_commented_out_cite_stays_silent() {
+    let doc = PLAIN.replace("See \\cite{knuth1984}.", "% \\cite{knuth1984}");
+    let (memory, mut sources, document, id) = plain_project(&doc);
+    let offset = doc.find("knuth1984").expect("key is in the doc");
+    assert!(
+        citation_definition_site(&mut sources, &memory, &document, id, offset).is_none(),
+        "a commented citation is the author's note, not a usage"
+    );
+}
+
 #[test]
 fn an_unknown_key_stays_silent() {
     let (memory, sources, document, id) = project();


### PR DESCRIPTION
Go-to-definition answered for @cite and stayed silent for the author's plain \cite — the same key, the same declared .bib, no landing. The navigational query now recognises the LaTeX citation family (\cite and the natbib/biblatex commands, starred, with optional arguments) at the offset and answers with the key under the cursor, out of a comma-separated list.

- Recognition is bounded by the scanner's readable regions — same prose, same skips — so a commented-out citation stays silent, and the checker's stance is untouched: plain \cite keys are still never reported missing (`a_plain_latex_citation_is_never_reported` stands unchanged).
- The brace group covering the offset is walked left to the command that owns it, because the scanner splits a starred or bracketed `\citep*[…]{…}` across two regions.
- Tests: the plain cite lands on its bib entry; a multi-key cite answers the key under the cursor; the command name, a comment, a non-citation command, and prose stay silent. Each new gate was mutation-checked (first-key-always, no-region-gate, no-family-check — all caught).

Workspace suites, clippy, fmt clean.