### PR TITLE
A citation lands in the LSP too

### DIFF
--- a/crates/xtex-lsp/src/main.rs
+++ b/crates/xtex-lsp/src/main.rs
@@ -27,7 +27,10 @@ use json::{Value, write_text};
 use xtex_core::bibliography::{Bibliography, Unavailable};
 use xtex_core::check::check_with_labels;
 use xtex_core::document::Document;
-use xtex_core::editor::{Position, completions, construct_at, definition, hover, offset_at};
+use xtex_core::editor::{
+    Position, citation_definition_site, completions, construct_at, definition, definition_site,
+    hover, offset_at,
+};
 use xtex_core::parse;
 use xtex_core::rename::plan;
 use xtex_core::scanner::EntryToken;
@@ -195,8 +198,47 @@ fn on_completion(uri: &str, text: &str, position: Position) -> Option<String> {
 }
 
 fn on_definition(uri: &str, text: &str, position: Position) -> Option<String> {
-    let (sources, document, table) = analyse(uri, text);
     let offset = offset_at(text.as_bytes(), position)?;
+    // The project-wide path keeps the loader alive, because a definition can
+    // land in another file — a citation's always does, in the `.bib` — and
+    // answering it takes the target file's identity, its own text for the
+    // positions, and the ability to read the `.bib` beside the root. The
+    // citation fallback is the WebAssembly surface's chain, so the two
+    // hosts answer alike (#131).
+    if let Some(overlay) = overlay_for(uri, text)
+        && let Ok(analysed) = xtex_core::project::analyse(&overlay, &overlay.root)
+    {
+        let xtex_core::project::Analysed {
+            mut sources,
+            documents,
+            names,
+            table,
+        } = analysed;
+        let document = documents.first()?;
+        let root = names.first()?.0;
+        let (source, span) = definition_site(&sources, document, &table, offset)
+            .or_else(|| citation_definition_site(&mut sources, &overlay, document, root, offset))?;
+        let target = sources.get(source)?;
+        let (line, column) = line_column(target.bytes(), span.start());
+        let (end_line, end_column) = line_column(target.bytes(), span.end());
+        let target_uri = if target.name() == overlay.root {
+            uri.to_owned()
+        } else {
+            format!(
+                "file://{}",
+                overlay.dir.join(target.name()).to_string_lossy()
+            )
+        };
+        let mut body = String::from(r#"{"uri":"#);
+        write_text(&target_uri, &mut body);
+        let _ = write!(
+            body,
+            r#","range":{{"start":{{"line":{line},"character":{column}}},"end":{{"line":{end_line},"character":{end_column}}}}}}}"#
+        );
+        return Some(body);
+    }
+    // A URI that is not a file answers from the buffer alone, as before.
+    let (sources, document, table) = analyse(uri, text);
     let span = definition(&sources, &document, &table, offset)?;
     let (line, column) = line_column(text.as_bytes(), span.start());
     let (end_line, end_column) = line_column(text.as_bytes(), span.end());
@@ -215,21 +257,23 @@ fn on_definition(uri: &str, text: &str, position: Position) -> Option<String> {
 /// uses, so the two hosts cannot diverge. A URI that is not a file, or an
 /// import that cannot be read, falls back to the buffer alone: a worse answer
 /// beats no answer while the author is mid-keystroke.
+fn overlay_for(uri: &str, text: &str) -> Option<Overlay> {
+    let path = std::path::Path::new(uri.strip_prefix("file://")?);
+    let (dir, name) = (path.parent()?, path.file_name()?);
+    Some(Overlay {
+        dir: dir.to_path_buf(),
+        root: name.to_string_lossy().into_owned(),
+        text: text.to_owned(),
+    })
+}
+
 fn analyse(uri: &str, text: &str) -> (Sources, Document, SymbolTable) {
-    if let Some(path) = uri.strip_prefix("file://") {
-        let path = std::path::Path::new(path);
-        if let (Some(dir), Some(name)) = (path.parent(), path.file_name()) {
-            let overlay = Overlay {
-                dir: dir.to_path_buf(),
-                root: name.to_string_lossy().into_owned(),
-                text: text.to_owned(),
-            };
-            if let Ok(analysed) = xtex_core::project::analyse(&overlay, &overlay.root) {
-                let mut documents = analysed.documents;
-                if !documents.is_empty() {
-                    return (analysed.sources, documents.remove(0), analysed.table);
-                }
-            }
+    if let Some(overlay) = overlay_for(uri, text)
+        && let Ok(analysed) = xtex_core::project::analyse(&overlay, &overlay.root)
+    {
+        let mut documents = analysed.documents;
+        if !documents.is_empty() {
+            return (analysed.sources, documents.remove(0), analysed.table);
         }
     }
     let mut sources = Sources::new();

--- a/crates/xtex-lsp/tests/protocol.rs
+++ b/crates/xtex-lsp/tests/protocol.rs
@@ -60,8 +60,12 @@ fn talk(bodies: &[String]) -> Vec<String> {
 }
 
 fn open(uri: &str) -> String {
+    open_with(uri, DOCUMENT)
+}
+
+fn open_with(uri: &str, document: &str) -> String {
     let mut text = String::new();
-    xtex_lsp_escape(DOCUMENT, &mut text);
+    xtex_lsp_escape(document, &mut text);
     format!(
         r#"{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{uri}","text":{text}}}}}}}"#
     )
@@ -81,8 +85,12 @@ fn xtex_lsp_escape(text: &str, out: &mut String) {
 }
 
 fn positional(id: u32, method: &str, line: u32, character: u32) -> String {
+    positional_in(id, method, "file:///p.xtex", line, character)
+}
+
+fn positional_in(id: u32, method: &str, uri: &str, line: u32, character: u32) -> String {
     format!(
-        r#"{{"jsonrpc":"2.0","id":{id},"method":"textDocument/{method}","params":{{"textDocument":{{"uri":"file:///p.xtex"}},"position":{{"line":{line},"character":{character}}}}}}}"#
+        r#"{{"jsonrpc":"2.0","id":{id},"method":"textDocument/{method}","params":{{"textDocument":{{"uri":"{uri}"}},"position":{{"line":{line},"character":{character}}}}}}}"#
     )
 }
 
@@ -158,6 +166,46 @@ fn definition_points_at_the_declaring_construct() {
     let reply = frames.last().expect("a reply");
     // The `\figure` block is the second line, zero-based line one.
     assert!(reply.contains(r#""line":1"#), "{reply}");
+}
+
+#[test]
+fn a_citation_lands_on_its_bib_entry_in_its_own_file() {
+    // The .bib must exist ON DISK beside the root: the loader reads it the
+    // way an editor's project actually is, not through a fixture shortcut.
+    let dir = std::env::temp_dir().join(format!("xtex-lsp-cite-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("tempdir");
+    std::fs::write(
+        dir.join("refs.bib"),
+        "% classics\n@book{knuth1984, title={The TeXbook}}\n",
+    )
+    .expect("the bib is written");
+    let uri = format!("file://{}/paper.tex", dir.display());
+    let frames = talk(&[
+        open_with(&uri, "See \\cite{knuth1984}.\n\\bibliography{refs}\n"),
+        positional_in(6, "definition", &uri, 0, 12),
+        EXIT.to_owned(),
+    ]);
+    let reply = frames.last().expect("a reply");
+    assert!(
+        reply.contains("refs.bib"),
+        "the answer names the bib file: {reply}"
+    );
+    // The key's own token sits on the @book line — zero-based line one.
+    assert!(reply.contains(r#""line":1"#), "{reply}");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn a_definition_reply_names_the_file_it_lands_in() {
+    // The root's own constructs answer with the REQUEST's uri, not "" — an
+    // empty uri sent every cross-file landing to the wrong buffer.
+    let frames = talk(&[
+        open("file:///p.xtex"),
+        positional(7, "definition", 2, 9),
+        EXIT.to_owned(),
+    ]);
+    let reply = frames.last().expect("a reply");
+    assert!(reply.contains("file:///p.xtex"), "{reply}");
 }
 
 #[test]


### PR DESCRIPTION
The desktop server's go-to-definition answered constructs only, and its reply carried an empty uri with positions computed on the open buffer — every cross-file landing went to the wrong place, and a citation's always crosses files (into the .bib). The reply now names the file it lands in, with positions computed on that file's text, and the citation fallback is the WebAssembly surface's chain — so the two hosts answer alike, which is what docs/wasm.md promises. Closes #131.

- `overlay_for` extracted from `analyse`: `on_definition` needs the loader kept alive to read the .bib beside the root.
- Tests: a \cite lands on its bib entry in refs.bib's own file (a real .bib on disk); a definition reply names the file it lands in. Both mutation-checked (no-fallback and empty-uri mutants caught).

Workspace suites, clippy, fmt clean.