### PR TITLE
A verification is a dated record

### DIFF
--- a/crates/xtex-core/src/json.rs
+++ b/crates/xtex-core/src/json.rs
@@ -1,11 +1,12 @@
-//! Just enough JSON to speak LSP.
+//! Just enough JSON for the two callers that need it.
 //!
-//! Not a JSON library and not on its way to becoming one. It reads the handful
-//! of shapes the protocol sends us and writes the handful we send back, and a
-//! message using something outside that is refused rather than guessed at.
+//! Not a JSON library and not on its way to becoming one. The language server
+//! reads the handful of shapes the protocol sends and writes the handful it
+//! answers; the verification record ({`crate::verification`}) reads and writes
+//! its own fixed shape. Anything outside those shapes is refused rather than
+//! guessed at.
 //!
-//! Written by hand for the reason in `docs/decisions/0005`: the compiler core
-//! has no dependencies and the server is small enough to keep it that way.
+//! Written by hand for the standing reason: this crate has no dependencies.
 
 use std::fmt::Write as _;
 

--- a/crates/xtex-core/src/lib.rs
+++ b/crates/xtex-core/src/lib.rs
@@ -50,6 +50,7 @@ pub mod diagnostics;
 pub mod document;
 pub mod editor;
 pub mod io;
+pub mod json;
 pub mod labels;
 pub mod project;
 pub mod rename;
@@ -60,6 +61,7 @@ pub mod source;
 pub mod sourcemap;
 pub mod symbols;
 pub mod texlog;
+pub mod verification;
 
 use std::error::Error;
 use std::fmt;

--- a/crates/xtex-core/src/verification.rs
+++ b/crates/xtex-core/src/verification.rs
@@ -1,0 +1,393 @@
+//! The verification record: what the world answered, dated.
+//!
+//! External verification never happens here — the core owns no network and
+//! never will. What lives here is the RECORD a verifier leaves behind: for
+//! each claim the document makes about the world (a bibliography entry, a
+//! url, a doi, a repository), what was asked, what source answered, when,
+//! and with which verdict. The record is a project sidecar; the check reads
+//! it offline, so compilation stays deterministic whatever the network did.
+//!
+//! # The rule that keeps this honest
+//!
+//! A record that does not parse is *no record* — the same all-or-nothing
+//! stance the bibliography reader takes. A partial record would let a stale
+//! or mangled verdict pass as a fresh one, which is worse than none: it
+//! reports success while measuring something else.
+//!
+//! Every verdict is a dated statement, never a timeless fact: `fetched_at`
+//! is part of the claim's meaning, and an `Unverified` verdict must carry
+//! the note saying why — an unreachable source is never "probably fine".
+
+use crate::json::{self, Value};
+
+/// What kind of thing the document asserted exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaimKind {
+    /// An entry in a declared `.bib`, keyed by its citation key.
+    BibEntry,
+    /// A `\url{…}` or `\href{…}` target.
+    Url,
+    /// A DOI, wherever it was written.
+    Doi,
+    /// A source repository address.
+    Repository,
+}
+
+impl ClaimKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::BibEntry => "bib-entry",
+            Self::Url => "url",
+            Self::Doi => "doi",
+            Self::Repository => "repository",
+        }
+    }
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "bib-entry" => Some(Self::BibEntry),
+            "url" => Some(Self::Url),
+            "doi" => Some(Self::Doi),
+            "repository" => Some(Self::Repository),
+            _ => None,
+        }
+    }
+}
+
+/// The verdict on a bibliographic claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BibVerdict {
+    /// Every compared field matches the source.
+    Verified,
+    /// Some fields match and some differ — the diffs say which.
+    Partial,
+    /// The source answers with a different work altogether.
+    Mismatch,
+    /// The source could not be consulted; the note says why.
+    Unverified,
+}
+
+impl BibVerdict {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Verified => "verified",
+            Self::Partial => "partial",
+            Self::Mismatch => "mismatch",
+            Self::Unverified => "unverified",
+        }
+    }
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "verified" => Some(Self::Verified),
+            "partial" => Some(Self::Partial),
+            "mismatch" => Some(Self::Mismatch),
+            "unverified" => Some(Self::Unverified),
+            _ => None,
+        }
+    }
+}
+
+/// The verdict on a reachability claim (urls, dois, repositories).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reachability {
+    /// The address answered.
+    Reachable,
+    /// The address did not answer; the note says how it failed.
+    Unreachable,
+    /// The address answered from somewhere else — worth a look.
+    Redirected,
+}
+
+impl Reachability {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Reachable => "reachable",
+            Self::Unreachable => "unreachable",
+            Self::Redirected => "redirected",
+        }
+    }
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "reachable" => Some(Self::Reachable),
+            "unreachable" => Some(Self::Unreachable),
+            "redirected" => Some(Self::Redirected),
+            _ => None,
+        }
+    }
+}
+
+/// A claim's verdict, in the vocabulary its kind speaks.
+///
+/// Bibliographic entries and reachable addresses are different questions
+/// with different honest answers; one enum forced over both would deform
+/// whichever it was not designed for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// For [`ClaimKind::BibEntry`].
+    Bibliographic(BibVerdict),
+    /// For urls, dois and repositories.
+    Reachability(Reachability),
+}
+
+/// How much a differing field matters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffSeverity {
+    /// The author list, always: a fabricated author list behind a valid
+    /// DOI is exactly the failure verification exists to catch.
+    High,
+    /// Everything else.
+    Medium,
+}
+
+/// One field where the document and the source disagree, both values kept.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldDiff {
+    /// Which field (`authors`, `title`, `year`, …).
+    pub field: String,
+    /// What the document says.
+    pub in_document: String,
+    /// What the source says.
+    pub in_source: String,
+    /// How much the disagreement matters.
+    pub severity: DiffSeverity,
+}
+
+/// One verified claim: what was asked, what answered, when, and the verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedClaim {
+    /// What kind of claim this is.
+    pub kind: ClaimKind,
+    /// The claim's target: a citation key, or an address.
+    pub target: String,
+    /// The document's fields as they were compared, normalized.
+    pub fields: Vec<(String, String)>,
+    /// A hash of the source's raw response — the fingerprint later runs
+    /// compare against. Empty only when nothing answered.
+    pub response_hash: String,
+    /// Which source answered (`crossref-doi`, `crossref-query`, `dblp`,
+    /// `arxiv`, `http`).
+    pub source: String,
+    /// When, as RFC 3339 in UTC. Part of the verdict's meaning: the record
+    /// never claims timeless existence.
+    pub fetched_at: String,
+    /// The dated verdict.
+    pub verdict: Verdict,
+    /// Where document and source disagree.
+    pub diffs: Vec<FieldDiff>,
+    /// Why verification failed, when it did. Mandatory for
+    /// [`BibVerdict::Unverified`] and [`Reachability::Unreachable`].
+    pub failure_note: Option<String>,
+}
+
+/// A parsed verification record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerificationRecord {
+    /// The record's claims, in file order.
+    pub claims: Vec<VerifiedClaim>,
+}
+
+/// The format version this module reads and writes.
+const VERSION: i64 = 1;
+
+/// Why a record was refused. The message is for the diagnostic (`XT1015`);
+/// nothing partial survives a refusal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordError {
+    /// What was wrong, in a sentence.
+    pub message: String,
+}
+
+fn refuse<T>(message: impl Into<String>) -> Result<T, RecordError> {
+    Err(RecordError {
+        message: message.into(),
+    })
+}
+
+/// Parses a `.xtexverified` record, whole or not at all.
+///
+/// # Errors
+///
+/// Any malformation — bad JSON, an unknown kind or verdict, a verdict in
+/// the wrong vocabulary for its kind, a missing date, an `unverified` or
+/// `unreachable` claim without its note — refuses the whole record.
+pub fn parse_record(bytes: &[u8]) -> Result<VerificationRecord, RecordError> {
+    let Some(value) = json::parse(bytes) else {
+        return refuse("the record is not valid JSON");
+    };
+    let Some(version) = value.get("version").and_then(Value::integer) else {
+        return refuse("the record carries no version");
+    };
+    if version != VERSION {
+        return refuse(format!("record version {version} is not {VERSION}"));
+    }
+    let Some(Value::List(raw_claims)) = value.get("claims") else {
+        return refuse("the record carries no claims list");
+    };
+    let mut claims = Vec::new();
+    for (index, raw) in raw_claims.iter().enumerate() {
+        claims.push(parse_claim(raw).map_err(|error| RecordError {
+            message: format!("claim {index}: {}", error.message),
+        })?);
+    }
+    Ok(VerificationRecord { claims })
+}
+
+fn field(raw: &Value, name: &str) -> Result<String, RecordError> {
+    match raw.get(name).and_then(Value::text) {
+        Some(text) => Ok(text.to_owned()),
+        None => refuse(format!("`{name}` is missing")),
+    }
+}
+
+fn parse_claim(raw: &Value) -> Result<VerifiedClaim, RecordError> {
+    let kind_name = field(raw, "kind")?;
+    let Some(kind) = ClaimKind::from_name(&kind_name) else {
+        return refuse(format!("unknown kind `{kind_name}`"));
+    };
+    let target = field(raw, "target")?;
+    let verdict_name = field(raw, "verdict")?;
+    let verdict = match kind {
+        ClaimKind::BibEntry => match BibVerdict::from_name(&verdict_name) {
+            Some(v) => Verdict::Bibliographic(v),
+            None => {
+                return refuse(format!("`{verdict_name}` is not a bibliographic verdict"));
+            }
+        },
+        _ => match Reachability::from_name(&verdict_name) {
+            Some(v) => Verdict::Reachability(v),
+            None => {
+                return refuse(format!("`{verdict_name}` is not a reachability verdict"));
+            }
+        },
+    };
+    let fetched_at = field(raw, "fetched_at")?;
+    if fetched_at.is_empty() {
+        return refuse("`fetched_at` is empty — a verdict is a dated statement");
+    }
+    let source = field(raw, "source")?;
+    let response_hash = raw
+        .get("response_hash")
+        .and_then(Value::text)
+        .unwrap_or("")
+        .to_owned();
+    let failure_note = raw
+        .get("failure_note")
+        .and_then(Value::text)
+        .map(str::to_owned);
+    let failed = matches!(
+        verdict,
+        Verdict::Bibliographic(BibVerdict::Unverified)
+            | Verdict::Reachability(Reachability::Unreachable)
+    );
+    if failed && failure_note.as_deref().unwrap_or("").is_empty() {
+        return refuse(format!(
+            "`{verdict_name}` without a failure note — an unanswered source is never \"probably fine\""
+        ));
+    }
+    if !failed && response_hash.is_empty() {
+        return refuse("`response_hash` is empty on a verdict that claims an answer");
+    }
+    let mut fields = Vec::new();
+    if let Some(Value::Map(entries)) = raw.get("fields") {
+        for (name, value) in entries {
+            let Some(text) = value.text() else {
+                return refuse(format!("field `{name}` is not text"));
+            };
+            fields.push((name.clone(), text.to_owned()));
+        }
+    }
+    let mut diffs = Vec::new();
+    if let Some(Value::List(raw_diffs)) = raw.get("diffs") {
+        for raw_diff in raw_diffs {
+            let severity_name = field(raw_diff, "severity")?;
+            let severity = match severity_name.as_str() {
+                "high" => DiffSeverity::High,
+                "medium" => DiffSeverity::Medium,
+                other => return refuse(format!("unknown severity `{other}`")),
+            };
+            diffs.push(FieldDiff {
+                field: field(raw_diff, "field")?,
+                in_document: field(raw_diff, "in_document")?,
+                in_source: field(raw_diff, "in_source")?,
+                severity,
+            });
+        }
+    }
+    Ok(VerifiedClaim {
+        kind,
+        target,
+        fields,
+        response_hash,
+        source,
+        fetched_at,
+        verdict,
+        diffs,
+        failure_note,
+    })
+}
+
+/// Renders a record as canonical JSON, the shape [`parse_record`] reads.
+#[must_use]
+pub fn write_record(record: &VerificationRecord) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = write!(out, "{{\"version\":{VERSION},\"claims\":[");
+    for (index, claim) in record.claims.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push_str("{\"kind\":");
+        json::write_text(claim.kind.name(), &mut out);
+        out.push_str(",\"target\":");
+        json::write_text(&claim.target, &mut out);
+        out.push_str(",\"verdict\":");
+        let verdict_name = match claim.verdict {
+            Verdict::Bibliographic(v) => v.name(),
+            Verdict::Reachability(v) => v.name(),
+        };
+        json::write_text(verdict_name, &mut out);
+        out.push_str(",\"source\":");
+        json::write_text(&claim.source, &mut out);
+        out.push_str(",\"fetched_at\":");
+        json::write_text(&claim.fetched_at, &mut out);
+        out.push_str(",\"response_hash\":");
+        json::write_text(&claim.response_hash, &mut out);
+        out.push_str(",\"fields\":{");
+        for (findex, (name, value)) in claim.fields.iter().enumerate() {
+            if findex > 0 {
+                out.push(',');
+            }
+            json::write_text(name, &mut out);
+            out.push(':');
+            json::write_text(value, &mut out);
+        }
+        out.push_str("},\"diffs\":[");
+        for (dindex, diff) in claim.diffs.iter().enumerate() {
+            if dindex > 0 {
+                out.push(',');
+            }
+            out.push_str("{\"field\":");
+            json::write_text(&diff.field, &mut out);
+            out.push_str(",\"in_document\":");
+            json::write_text(&diff.in_document, &mut out);
+            out.push_str(",\"in_source\":");
+            json::write_text(&diff.in_source, &mut out);
+            out.push_str(",\"severity\":");
+            json::write_text(
+                match diff.severity {
+                    DiffSeverity::High => "high",
+                    DiffSeverity::Medium => "medium",
+                },
+                &mut out,
+            );
+            out.push('}');
+        }
+        out.push(']');
+        if let Some(note) = &claim.failure_note {
+            out.push_str(",\"failure_note\":");
+            json::write_text(note, &mut out);
+        }
+        out.push('}');
+    }
+    out.push_str("]}");
+    out
+}

--- a/crates/xtex-core/tests/verification_record.rs
+++ b/crates/xtex-core/tests/verification_record.rs
@@ -1,0 +1,114 @@
+//! A verification record is a dated statement, whole or not at all.
+
+use xtex_core::verification::{
+    BibVerdict, ClaimKind, DiffSeverity, FieldDiff, Reachability, Verdict, VerificationRecord,
+    VerifiedClaim, parse_record, write_record,
+};
+
+fn sample() -> VerificationRecord {
+    VerificationRecord {
+        claims: vec![
+            VerifiedClaim {
+                kind: ClaimKind::BibEntry,
+                target: "knuth1984".to_owned(),
+                fields: vec![
+                    ("title".to_owned(), "The TeXbook".to_owned()),
+                    ("authors".to_owned(), "Donald E. Knuth".to_owned()),
+                ],
+                response_hash: "ab12cd34".to_owned(),
+                source: "crossref-doi".to_owned(),
+                fetched_at: "2026-09-01T10:00:00Z".to_owned(),
+                verdict: Verdict::Bibliographic(BibVerdict::Partial),
+                diffs: vec![FieldDiff {
+                    field: "authors".to_owned(),
+                    in_document: "D. Knuth".to_owned(),
+                    in_source: "Donald E. Knuth".to_owned(),
+                    severity: DiffSeverity::High,
+                }],
+                failure_note: None,
+            },
+            VerifiedClaim {
+                kind: ClaimKind::Url,
+                target: "https://example.org/dataset".to_owned(),
+                fields: Vec::new(),
+                response_hash: String::new(),
+                source: "http".to_owned(),
+                fetched_at: "2026-09-01T10:00:05Z".to_owned(),
+                verdict: Verdict::Reachability(Reachability::Unreachable),
+                diffs: Vec::new(),
+                failure_note: Some("timed out after 10s".to_owned()),
+            },
+        ],
+    }
+}
+
+#[test]
+fn a_record_survives_the_round_trip_field_for_field() {
+    let record = sample();
+    let written = write_record(&record);
+    let parsed = parse_record(written.as_bytes()).expect("the canonical shape parses");
+    assert_eq!(parsed, record, "every field travels");
+}
+
+#[test]
+fn the_written_shape_carries_the_verdict_the_date_and_both_diff_sides() {
+    let written = write_record(&sample());
+    for needle in [
+        "\"verdict\":\"partial\"",
+        "\"fetched_at\":\"2026-09-01T10:00:00Z\"",
+        "\"in_document\":\"D. Knuth\"",
+        "\"in_source\":\"Donald E. Knuth\"",
+        "\"severity\":\"high\"",
+        "\"failure_note\":\"timed out after 10s\"",
+    ] {
+        assert!(written.contains(needle), "missing {needle} in {written}");
+    }
+}
+
+#[test]
+fn a_record_that_is_not_json_is_no_record() {
+    assert!(parse_record(b"not json at all").is_err());
+}
+
+#[test]
+fn an_unknown_verdict_refuses_the_whole_record() {
+    let written = write_record(&sample()).replace("\"partial\"", "\"probably\"");
+    let error = parse_record(written.as_bytes()).expect_err("refused");
+    assert!(error.message.contains("probably"), "{}", error.message);
+}
+
+#[test]
+fn a_verdict_in_the_wrong_vocabulary_is_refused() {
+    // a bib entry answered with a reachability verdict
+    let written = write_record(&sample()).replace("\"partial\"", "\"reachable\"");
+    assert!(parse_record(written.as_bytes()).is_err());
+}
+
+#[test]
+fn an_unverified_claim_without_its_note_is_refused() {
+    let mut record = sample();
+    record.claims[1].failure_note = None;
+    let written = write_record(&record);
+    let error = parse_record(written.as_bytes()).expect_err("refused");
+    assert!(error.message.contains("failure note"), "{}", error.message);
+}
+
+#[test]
+fn an_answering_verdict_without_a_response_hash_is_refused() {
+    let mut record = sample();
+    record.claims[0].response_hash = String::new();
+    let written = write_record(&record);
+    assert!(parse_record(written.as_bytes()).is_err());
+}
+
+#[test]
+fn a_missing_date_is_refused_because_a_verdict_is_a_dated_statement() {
+    let written = write_record(&sample()).replace("2026-09-01T10:00:00Z", "");
+    assert!(parse_record(written.as_bytes()).is_err());
+}
+
+#[test]
+fn a_wrong_version_is_refused_whole() {
+    let written = write_record(&sample()).replace("\"version\":1", "\"version\":2");
+    assert!(parse_record(written.as_bytes()).is_err());
+}

--- a/crates/xtex-lsp/src/main.rs
+++ b/crates/xtex-lsp/src/main.rs
@@ -16,14 +16,12 @@
 //! A message not in the table is not answered, and the editor's own fallback
 //! is the correct behaviour.
 
-mod json;
 mod rpc;
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::io::{BufReader, Write};
 
-use json::{Value, write_text};
 use xtex_core::bibliography::{Bibliography, Unavailable};
 use xtex_core::check::check_with_labels;
 use xtex_core::document::Document;
@@ -31,6 +29,7 @@ use xtex_core::editor::{
     Position, citation_definition_site, completions, construct_at, definition, definition_site,
     hover, offset_at,
 };
+use xtex_core::json::{Value, write_text};
 use xtex_core::parse;
 use xtex_core::rename::plan;
 use xtex_core::scanner::EntryToken;

--- a/crates/xtex-lsp/src/rpc.rs
+++ b/crates/xtex-lsp/src/rpc.rs
@@ -13,7 +13,7 @@ pub struct Message {
     /// The method the client named.
     pub method: String,
     /// `params`, unexamined.
-    pub params: crate::json::Value,
+    pub params: xtex_core::json::Value,
 }
 
 /// Reads one message, or `None` at end of stream.
@@ -48,7 +48,7 @@ pub fn read(input: &mut impl BufRead) -> std::io::Result<Option<Message>> {
     let mut body = vec![0u8; length];
     input.read_exact(&mut body)?;
 
-    let Some(value) = crate::json::parse(&body) else {
+    let Some(value) = xtex_core::json::parse(&body) else {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             "a frame body was not JSON",
@@ -56,16 +56,16 @@ pub fn read(input: &mut impl BufRead) -> std::io::Result<Option<Message>> {
     };
     let method = value
         .get("method")
-        .and_then(crate::json::Value::text)
+        .and_then(xtex_core::json::Value::text)
         .unwrap_or_default()
         .to_owned();
     Ok(Some(Message {
-        id: value.get("id").and_then(crate::json::Value::integer),
+        id: value.get("id").and_then(xtex_core::json::Value::integer),
         method,
         params: value
             .get("params")
             .cloned()
-            .unwrap_or(crate::json::Value::Null),
+            .unwrap_or(xtex_core::json::Value::Null),
     }))
 }
 


### PR DESCRIPTION
First step of external verification (#134): the record format a verifier leaves behind and the deterministic core reads.

- `xtex_core::verification`: claims (bib-entry / url / doi / repository), per-kind verdict vocabularies, per-field diffs with both values, dated (`fetched_at` is part of a verdict's meaning), with response hashes for later fingerprint comparison.
- Whole-or-nothing parsing: bad JSON, unknown kind/verdict, cross-vocabulary verdicts, missing date, `unverified`/`unreachable` without a failure note, or an answering verdict without its hash — each refuses the entire record.
- The LSP's JSON module moves to `xtex_core::json`, shared, still zero dependencies.
- 9 tests; three mutants (note enforcement, vocabulary check, writer) caught by their tests. Workspace suites, clippy, fmt clean.

Closes #134.