### PR TITLE
The document's external claims, inventoried

### DIFF
--- a/crates/xtex-cli/src/main.rs
+++ b/crates/xtex-cli/src/main.rs
@@ -151,6 +151,9 @@ fn main() -> ExitCode {
     if first == "check" {
         return check_command(&args[1..]);
     }
+    if first == "claims" {
+        return claims_command(&args[1..]);
+    }
     if first == "compile" {
         return compile_command(&args[1..]);
     }
@@ -241,6 +244,46 @@ fn run_check(root: &str) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography)
         root: PathBuf::from("."),
     };
     xtex_core::project::check_project(&loader, root, read_prefixes(Path::new(root)))
+}
+
+/// `xtex claims <file>` — the document's external claims, inventoried as
+/// JSON: every declared bibliography entry with its fields, every url,
+/// doi and repository address, each with the span it was written at.
+/// Deterministic and offline; the verifier consumes this, the network
+/// never enters here.
+fn claims_command(args: &[String]) -> ExitCode {
+    let inputs: Vec<&str> = args
+        .iter()
+        .filter(|arg| !arg.starts_with("--"))
+        .map(String::as_str)
+        .collect();
+    if inputs.len() != 1 {
+        eprintln!("usage: xtex claims <file.xtex>");
+        return ExitCode::from(2);
+    }
+    let loader = FileSystem {
+        root: PathBuf::from("."),
+    };
+    match xtex_core::project::analyse(&loader, inputs[0]) {
+        Ok(analysed) => {
+            let xtex_core::project::Analysed {
+                mut sources, names, ..
+            } = analysed;
+            let ids: Vec<_> = names.iter().map(|(id, _)| *id).collect();
+            let root = ids.first().copied();
+            let Some(root) = root else {
+                eprintln!("error: nothing loaded");
+                return ExitCode::from(2);
+            };
+            let claims = xtex_core::claims::collect(&mut sources, &loader, root, &ids);
+            println!("{}", xtex_core::claims::to_json(&sources, &claims));
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::from(2)
+        }
+    }
 }
 
 fn check_command(args: &[String]) -> ExitCode {

--- a/crates/xtex-core/src/bibliography.rs
+++ b/crates/xtex-core/src/bibliography.rs
@@ -436,6 +436,82 @@ pub fn entry_span_in_bib(bytes: &[u8], key: &str) -> Option<Span> {
         .map(|(_, span)| span)
 }
 
+/// The named entry's fields, parsed: `title`, `author`, `doi`, … — names
+/// lowercased, one level of braces stripped from values. This is the
+/// document's side of a verification diff; the scan and balancing are
+/// [`scan_bib_entries`]'s, so an entry it reads is exactly an entry the
+/// checker accepts.
+#[must_use]
+pub fn entry_fields(bytes: &[u8], key: &str) -> Option<Vec<(String, String)>> {
+    let span = entry_span_in_bib(bytes, key)?;
+    // From just past the key to the entry's balanced close.
+    let mut at = span.end();
+    let mut depth = 1usize; // we are inside the entry's opener
+    let mut fields = Vec::new();
+    while at < bytes.len() && depth > 0 {
+        match bytes[at] {
+            b',' | b' ' | b'\t' | b'\n' | b'\r' => at += 1,
+            b'}' | b')' => {
+                depth -= 1;
+                at += 1;
+            }
+            _ => {
+                let name_start = at;
+                while matches!(bytes.get(at), Some(b) if b.is_ascii_alphanumeric() || *b == b'-' || *b == b'_')
+                {
+                    at += 1;
+                }
+                if at == name_start {
+                    at += 1;
+                    continue;
+                }
+                let name = String::from_utf8_lossy(&bytes[name_start..at]).to_lowercase();
+                at = skip_space(bytes, at);
+                if bytes.get(at) != Some(&b'=') {
+                    continue;
+                }
+                at = skip_space(bytes, at + 1);
+                let value = match bytes.get(at) {
+                    Some(b'{') => {
+                        let start = at + 1;
+                        let mut inner = 1usize;
+                        at += 1;
+                        while at < bytes.len() && inner > 0 {
+                            match bytes[at] {
+                                b'{' => inner += 1,
+                                b'}' => inner -= 1,
+                                _ => {}
+                            }
+                            at += 1;
+                        }
+                        String::from_utf8_lossy(&bytes[start..at.saturating_sub(1)]).into_owned()
+                    }
+                    Some(b'"') => {
+                        let start = at + 1;
+                        at += 1;
+                        while at < bytes.len() && bytes[at] != b'"' {
+                            at += 1;
+                        }
+                        let value = String::from_utf8_lossy(&bytes[start..at]).into_owned();
+                        at += 1;
+                        value
+                    }
+                    _ => {
+                        let start = at;
+                        while matches!(bytes.get(at), Some(b) if *b != b',' && *b != b'}' && *b != b')')
+                        {
+                            at += 1;
+                        }
+                        String::from_utf8_lossy(&bytes[start..at]).trim().to_owned()
+                    }
+                };
+                fields.push((name, value.trim().to_owned()));
+            }
+        }
+    }
+    Some(fields)
+}
+
 fn scan_bib_entries(bytes: &[u8]) -> Result<Vec<(String, Span)>, String> {
     let mut keys = Vec::new();
     let mut at = 0usize;

--- a/crates/xtex-core/src/claims.rs
+++ b/crates/xtex-core/src/claims.rs
@@ -1,0 +1,178 @@
+//! Everything a document asserts about the world outside it.
+//!
+//! The deterministic half of external verification: no network, no verdicts
+//! — just the inventory of claims, each with the span it was written at, so
+//! any later finding lands where the author can act on it. Recognition is
+//! bounded by the scanner's readable regions: a commented `\\url` is the
+//! author's note and claims nothing, the same rule every reader follows.
+
+use crate::io::SourceLoader;
+use crate::source::{SourceId, Sources, Span};
+use crate::verification::ClaimKind;
+
+/// One assertion the document makes about the world.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Claim {
+    /// What kind of thing is claimed to exist.
+    pub kind: ClaimKind,
+    /// The claim's target: a citation key, an address, or a DOI.
+    pub target: String,
+    /// The file the claim was written in.
+    pub source: SourceId,
+    /// Where in that file.
+    pub span: Span,
+    /// For bibliography entries: the entry's fields (lowercased names,
+    /// braces stripped) — the document's side of a verification diff.
+    pub fields: Vec<(String, String)>,
+}
+
+/// Hosts whose addresses are source repositories rather than plain pages.
+const FORGES: &[&str] = &[
+    "github.com",
+    "gitlab.com",
+    "bitbucket.org",
+    "codeberg.org",
+    "sr.ht",
+];
+
+fn classify(address: &str) -> (ClaimKind, String) {
+    if let Some(rest) = address
+        .strip_prefix("https://doi.org/")
+        .or_else(|| address.strip_prefix("http://doi.org/"))
+        .or_else(|| address.strip_prefix("https://dx.doi.org/"))
+    {
+        return (ClaimKind::Doi, rest.to_owned());
+    }
+    let host = address
+        .strip_prefix("https://")
+        .or_else(|| address.strip_prefix("http://"))
+        .unwrap_or(address)
+        .split('/')
+        .next()
+        .unwrap_or("");
+    if FORGES
+        .iter()
+        .any(|forge| host == *forge || host.ends_with(&format!(".{forge}")))
+    {
+        return (ClaimKind::Repository, address.to_owned());
+    }
+    (ClaimKind::Url, address.to_owned())
+}
+
+/// Collects the project's external claims: every declared bibliography
+/// entry with its fields, and every `\\url{…}` / `\\href{…}{…}` target,
+/// classified (a doi.org address is a DOI claim, a forge address is a
+/// repository claim).
+#[must_use]
+pub fn collect(
+    sources: &mut Sources,
+    loader: &impl SourceLoader,
+    root: SourceId,
+    files: &[SourceId],
+) -> Vec<Claim> {
+    let mut claims = Vec::new();
+
+    for &id in files {
+        let Some(bytes) = sources.get(id).map(|s| s.bytes().to_vec()) else {
+            continue;
+        };
+        for region in crate::scanner::readable_for(&bytes, &["url", "href"]) {
+            let slice = &bytes[region.start()..region.end()];
+            let Some(rest) = slice
+                .strip_prefix(b"\\url{")
+                .or_else(|| slice.strip_prefix(b"\\href{"))
+            else {
+                continue;
+            };
+            let Some(close) = rest.iter().position(|b| *b == b'}') else {
+                continue;
+            };
+            let address = String::from_utf8_lossy(&rest[..close]).trim().to_owned();
+            if address.is_empty() {
+                continue;
+            }
+            let start = region.start() + (slice.len() - rest.len());
+            #[allow(clippy::cast_possible_truncation)] // a source past 4GB is not a source
+            let span = Span::new(start as u32, (start + close) as u32);
+            let (kind, target) = classify(&address);
+            claims.push(Claim {
+                kind,
+                target,
+                source: id,
+                span,
+                fields: Vec::new(),
+            });
+        }
+    }
+
+    // The declared bibliographies: one claim per entry, fields attached.
+    let declared = crate::bibliography::declared_in(sources, root);
+    for resource in &declared.resources {
+        let Ok(bib) = loader.load(&resource.name, Some(root), sources) else {
+            continue;
+        };
+        let Some(bytes) = sources.get(bib).map(|s| s.bytes().to_vec()) else {
+            continue;
+        };
+        let Some(keys) = crate::bibliography::keys_in_bib(&bytes) else {
+            continue;
+        };
+        for key in keys {
+            let Some(span) = crate::bibliography::entry_span_in_bib(&bytes, &key) else {
+                continue;
+            };
+            let fields = crate::bibliography::entry_fields(&bytes, &key).unwrap_or_default();
+            claims.push(Claim {
+                kind: ClaimKind::BibEntry,
+                target: key,
+                source: bib,
+                span,
+                fields,
+            });
+        }
+    }
+    claims
+}
+
+/// Renders claims as JSON: kind, target, file, span, and any fields.
+#[must_use]
+pub fn to_json(sources: &Sources, claims: &[Claim]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::from("{\"claims\":[");
+    for (index, claim) in claims.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        out.push_str("{\"kind\":");
+        let kind = match claim.kind {
+            ClaimKind::BibEntry => "bib-entry",
+            ClaimKind::Url => "url",
+            ClaimKind::Doi => "doi",
+            ClaimKind::Repository => "repository",
+        };
+        crate::json::write_text(kind, &mut out);
+        out.push_str(",\"target\":");
+        crate::json::write_text(&claim.target, &mut out);
+        let file = sources.get(claim.source).map_or("", |s| s.name());
+        out.push_str(",\"file\":");
+        crate::json::write_text(file, &mut out);
+        let _ = write!(
+            out,
+            ",\"offset\":{},\"length\":{}",
+            claim.span.start(),
+            claim.span.len()
+        );
+        out.push_str(",\"fields\":{");
+        for (findex, (name, value)) in claim.fields.iter().enumerate() {
+            if findex > 0 {
+                out.push(',');
+            }
+            crate::json::write_text(name, &mut out);
+            out.push(':');
+            crate::json::write_text(value, &mut out);
+        }
+        out.push_str("}}");
+    }
+    out.push_str("]}");
+    out
+}

--- a/crates/xtex-core/src/lib.rs
+++ b/crates/xtex-core/src/lib.rs
@@ -46,6 +46,7 @@ pub mod bibliography;
 pub mod blame;
 pub mod blocks;
 pub mod check;
+pub mod claims;
 pub mod diagnostics;
 pub mod document;
 pub mod editor;

--- a/crates/xtex-core/tests/claims_inventory.rs
+++ b/crates/xtex-core/tests/claims_inventory.rs
@@ -1,0 +1,106 @@
+//! The document's external claims, inventoried — deterministically, with
+//! the span each claim was written at, and nothing from a comment.
+
+use xtex_core::claims::{Claim, collect};
+use xtex_core::io::{Memory, SourceLoader};
+use xtex_core::verification::ClaimKind;
+
+const ROOT: &str = "\\documentclass{article}\n\\begin{document}\n\
+Data at \\url{https://example.org/data}.\n\
+% \\url{https://commented.example.org} — the author's note, not a claim\n\
+Code at \\href{https://github.com/knuth/tex}{the repository}.\n\
+Paper at \\url{https://doi.org/10.1145/3-540}.\n\
+\\input{chapter}\n\
+\\bibliography{refs}\n\\end{document}\n";
+
+const CHAPTER: &str = "More at \\url{https://example.org/appendix}.\n";
+
+const BIB: &str = "@book{knuth1984,\n  title = {The {TeX}book},\n  author = \"Donald E. Knuth\",\n  year = 1984,\n  doi = {10.5555/1096283}\n}\n";
+
+fn inventory() -> (xtex_core::source::Sources, Vec<Claim>) {
+    let memory = Memory::new()
+        .with_input("main.tex", ROOT.as_bytes().to_vec())
+        .with_input("chapter.tex", CHAPTER.as_bytes().to_vec())
+        .with_input("refs.bib", BIB.as_bytes().to_vec());
+    let mut sources = xtex_core::source::Sources::new();
+    let root = memory.load("main.tex", None, &mut sources).expect("root");
+    let chapter = memory
+        .load("chapter.tex", Some(root), &mut sources)
+        .expect("chapter");
+    let claims = collect(&mut sources, &memory, root, &[root, chapter]);
+    (sources, claims)
+}
+
+fn by_kind(claims: &[Claim], kind: ClaimKind) -> Vec<&Claim> {
+    claims.iter().filter(|c| c.kind == kind).collect()
+}
+
+#[test]
+fn every_kind_is_inventoried_and_classified() {
+    let (_, claims) = inventory();
+    let urls = by_kind(&claims, ClaimKind::Url);
+    assert_eq!(urls.len(), 2, "{claims:?}");
+    assert!(urls.iter().any(|c| c.target == "https://example.org/data"));
+    assert!(
+        urls.iter()
+            .any(|c| c.target == "https://example.org/appendix"),
+        "the included chapter's claim counts"
+    );
+    let repos = by_kind(&claims, ClaimKind::Repository);
+    assert_eq!(repos.len(), 1);
+    assert_eq!(repos[0].target, "https://github.com/knuth/tex");
+    let dois = by_kind(&claims, ClaimKind::Doi);
+    assert_eq!(dois.len(), 1);
+    assert_eq!(
+        dois[0].target, "10.1145/3-540",
+        "the doi.org address claims the DOI itself"
+    );
+}
+
+#[test]
+fn a_commented_url_claims_nothing() {
+    let (_, claims) = inventory();
+    assert!(
+        claims.iter().all(|c| !c.target.contains("commented")),
+        "{claims:?}"
+    );
+}
+
+#[test]
+fn a_bib_entry_arrives_with_its_fields() {
+    let (_, claims) = inventory();
+    let entries = by_kind(&claims, ClaimKind::BibEntry);
+    assert_eq!(entries.len(), 1);
+    let entry = entries[0];
+    assert_eq!(entry.target, "knuth1984");
+    let field = |name: &str| {
+        entry
+            .fields
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, v)| v.as_str())
+    };
+    assert_eq!(field("title"), Some("The {TeX}book"));
+    assert_eq!(
+        field("author"),
+        Some("Donald E. Knuth"),
+        "quoted values read"
+    );
+    assert_eq!(field("year"), Some("1984"), "bare values read");
+    assert_eq!(field("doi"), Some("10.5555/1096283"));
+}
+
+#[test]
+fn every_span_lands_on_the_written_claim() {
+    let (sources, claims) = inventory();
+    for claim in &claims {
+        let bytes = sources.get(claim.source).expect("source").bytes();
+        let written = &bytes[claim.span.start()..claim.span.end()];
+        let text = String::from_utf8_lossy(written);
+        match claim.kind {
+            ClaimKind::BibEntry => assert_eq!(text, claim.target, "the key's own token"),
+            ClaimKind::Doi => assert!(text.contains(&claim.target), "{text}"),
+            _ => assert_eq!(text, claim.target, "the address as written"),
+        }
+    }
+}


### PR DESCRIPTION
The deterministic half of external verification (#135): no network, no verdicts — the inventory of claims with spans, consumed later by the checker (#136) and the verifier (#137).

- `xtex_core::claims`: bib entries with parsed fields, `\url`/`\href` targets classified (doi.org → DOI claim, forge host → repository claim), comment-aware via the scanner's readable regions, spans landing on the written claim.
- `bibliography::entry_fields`: the entry's fields (braced, quoted and bare values), same scan and balancing the checker accepts.
- `xtex claims <file>` prints the inventory as JSON.
- 4 tests, 3 mutants caught; workspace suites, clippy, fmt clean. Closes #135.