### PR TITLE
The check reads the record and never the network

### DIFF
--- a/crates/xtex-core/src/verification.rs
+++ b/crates/xtex-core/src/verification.rs
@@ -391,3 +391,219 @@ pub fn write_record(record: &VerificationRecord) -> String {
     out.push_str("]}");
     out
 }
+
+/// Days since the civil epoch for an RFC 3339 date's day part, or `None`
+/// for a shape this reader does not recognise. Enough calendar for an age
+/// in days; not a datetime library and not on its way to becoming one.
+fn civil_days(date: &str) -> Option<i64> {
+    let bytes = date.as_bytes();
+    if bytes.len() < 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return None;
+    }
+    let number = |range: std::ops::Range<usize>| -> Option<i64> {
+        std::str::from_utf8(&bytes[range]).ok()?.parse().ok()
+    };
+    let (y, m, d) = (number(0..4)?, number(5..7)?, number(8..10)?);
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    // Howard Hinnant's days-from-civil, the standard branchless form.
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = (m + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    Some(era * 146_097 + doe - 719_468)
+}
+
+/// What the record-aware check needs, all supplied by the caller — this
+/// module owns no clock and no filesystem, deliberately.
+pub struct RecordCheck<'a> {
+    /// The parsed record.
+    pub record: &'a VerificationRecord,
+    /// The document's claims (see [`crate::claims`]).
+    pub claims: &'a [crate::claims::Claim],
+    /// The symbol table, for the one severity question: does an explicit
+    /// `@cite` demand this key?
+    pub table: &'a crate::symbols::SymbolTable,
+    /// Today, RFC 3339 — the caller's clock, never ours.
+    pub now: &'a str,
+    /// The freshness window, in days.
+    pub max_age_days: i64,
+}
+
+/// The deterministic half of verification: findings from crossing the
+/// document's claims with the record — offline, reproducible, dated.
+///
+/// Three findings exist, each speaking its date plainly:
+/// - the claim was **edited since its verification** (the document's fields
+///   no longer match the record's), which retires the old verdict — the
+///   drift is reported and the verdict is not replayed;
+/// - the verification **expired** (older than the window);
+/// - the recorded verdict itself: `partial`/`mismatch` replayed with their
+///   diffs, `unverified`/`unreachable` with their notes.
+///
+/// Severity follows the standing policy: a bibliographic finding is a hard
+/// error only when an explicit `@cite` demands the key AND the finding is a
+/// mismatch or a high-severity diff (the author list). Everything else —
+/// every reachability finding included, because a plain `\url` is not a
+/// construct — is advisory.
+#[must_use]
+pub fn check_against_record(input: &RecordCheck<'_>) -> Vec<crate::check::Diagnostic> {
+    use crate::check::{Blame, Diagnostic, Severity};
+    use crate::symbols::EntityClass;
+    let mut findings = Vec::new();
+    let demanded: std::collections::BTreeSet<&str> =
+        input.table.citations().map(|(key, _)| key).collect();
+    let today = civil_days(input.now);
+
+    for claim in input.claims {
+        let Some(recorded) = input
+            .record
+            .claims
+            .iter()
+            .find(|r| r.kind == claim.kind && r.target == claim.target)
+        else {
+            continue; // never verified: the verifier's business, not a finding
+        };
+        let entity = match claim.kind {
+            ClaimKind::BibEntry => EntityClass::Citation,
+            _ => EntityClass::UnknownOpen,
+        };
+        let date = &recorded.fetched_at[..recorded.fetched_at.len().min(10)];
+        let mut push = |code: &'static str, severity: Severity, message: String| {
+            findings.push(Diagnostic {
+                code,
+                entity,
+                name: Some(claim.target.clone()),
+                source: claim.source,
+                span: claim.span,
+                message,
+                related: Vec::new(),
+                severity,
+                blame: if severity == Severity::Error {
+                    Blame::XtexConstruct
+                } else {
+                    Blame::Unresolved
+                },
+            });
+        };
+
+        // Drift retires the verdict: an edited claim's old diffs are noise.
+        if claim.kind == ClaimKind::BibEntry && claim.fields != recorded.fields {
+            push(
+                "XT1016",
+                Severity::Advisory,
+                format!(
+                    "`{}` was edited after its verification ({date}) — the recorded verdict no longer speaks for it; verify again",
+                    claim.target
+                ),
+            );
+            continue;
+        }
+
+        match (today, civil_days(&recorded.fetched_at)) {
+            (Some(now), Some(then)) => {
+                let age = now - then;
+                if age > input.max_age_days {
+                    push(
+                        "XT1017",
+                        Severity::Advisory,
+                        format!(
+                            "`{}` was last verified {age} days ago ({date}) — older than the {}-day window",
+                            claim.target, input.max_age_days
+                        ),
+                    );
+                }
+            }
+            _ => {
+                push(
+                    "XT1017",
+                    Severity::Advisory,
+                    format!("`{}` carries an unreadable verification date", claim.target),
+                );
+            }
+        }
+
+        match recorded.verdict {
+            Verdict::Bibliographic(BibVerdict::Verified)
+            | Verdict::Reachability(Reachability::Reachable) => {}
+            Verdict::Bibliographic(BibVerdict::Partial) => {
+                let matched: Vec<&str> = recorded
+                    .fields
+                    .iter()
+                    .map(|(name, _)| name.as_str())
+                    .filter(|name| !recorded.diffs.iter().any(|diff| diff.field == *name))
+                    .collect();
+                let mut message = format!("partial against {} (as of {date})", recorded.source);
+                if !matched.is_empty() {
+                    message.push_str(&format!(" — {} match", matched.join(", ")));
+                }
+                for diff in &recorded.diffs {
+                    message.push_str(&format!(
+                        "; {} differs: this entry says \"{}\", the source says \"{}\"",
+                        diff.field, diff.in_document, diff.in_source
+                    ));
+                }
+                let hard = demanded.contains(claim.target.as_str())
+                    && recorded
+                        .diffs
+                        .iter()
+                        .any(|diff| diff.severity == DiffSeverity::High);
+                push(
+                    "XT1018",
+                    if hard {
+                        Severity::Error
+                    } else {
+                        Severity::Advisory
+                    },
+                    message,
+                );
+            }
+            Verdict::Bibliographic(BibVerdict::Mismatch) => {
+                let hard = demanded.contains(claim.target.as_str());
+                push(
+                    "XT1018",
+                    if hard {
+                        Severity::Error
+                    } else {
+                        Severity::Advisory
+                    },
+                    format!(
+                        "the source answers with a different work ({}, as of {date})",
+                        recorded.source
+                    ),
+                );
+            }
+            Verdict::Bibliographic(BibVerdict::Unverified) => {
+                push(
+                    "XT1019",
+                    Severity::Advisory,
+                    format!(
+                        "could not be verified ({date}): {}",
+                        recorded.failure_note.as_deref().unwrap_or("no note")
+                    ),
+                );
+            }
+            Verdict::Reachability(Reachability::Unreachable) => {
+                push(
+                    "XT1019",
+                    Severity::Advisory,
+                    format!(
+                        "unreachable as of {date}: {}",
+                        recorded.failure_note.as_deref().unwrap_or("no note")
+                    ),
+                );
+            }
+            Verdict::Reachability(Reachability::Redirected) => {
+                push(
+                    "XT1019",
+                    Severity::Advisory,
+                    format!("answered from somewhere else as of {date} — worth a look"),
+                );
+            }
+        }
+    }
+    findings
+}

--- a/crates/xtex-core/tests/record_check.rs
+++ b/crates/xtex-core/tests/record_check.rs
@@ -1,0 +1,251 @@
+//! The record-aware check: offline, dated, and graded by the standing
+//! severity policy — hard only where an explicit construct demands it.
+
+use xtex_core::check::Severity;
+use xtex_core::claims::Claim;
+use xtex_core::source::{Sources, Span};
+use xtex_core::symbols::SymbolTable;
+use xtex_core::verification::{
+    BibVerdict, ClaimKind, DiffSeverity, FieldDiff, Reachability, RecordCheck, Verdict,
+    VerificationRecord, VerifiedClaim, check_against_record,
+};
+
+const NOW: &str = "2026-09-01T12:00:00Z";
+const FRESH: &str = "2026-08-30T12:00:00Z";
+const OLD: &str = "2026-05-01T12:00:00Z";
+
+/// A document whose `@cite` demands `knuth1984` and nothing else.
+fn table_and_sources() -> (Sources, SymbolTable, xtex_core::source::SourceId) {
+    let mut sources = Sources::new();
+    let id = sources.add(
+        "main.xtex",
+        b"\\documentclass{article}\n\\begin{document}\nSee @cite(knuth1984).\n\\end{document}\n"
+            .to_vec(),
+    );
+    let document = xtex_core::parse(&sources, id);
+    let mut table = SymbolTable::new();
+    table.merge(&sources, &document);
+    (sources, table, id)
+}
+
+fn bib_claim(id: xtex_core::source::SourceId, key: &str, title: &str) -> Claim {
+    Claim {
+        kind: ClaimKind::BibEntry,
+        target: key.to_owned(),
+        source: id,
+        span: Span::new(0, 4),
+        fields: vec![("title".to_owned(), title.to_owned())],
+    }
+}
+
+fn recorded(key: &str, title: &str, verdict: Verdict, fetched_at: &str) -> VerifiedClaim {
+    VerifiedClaim {
+        kind: ClaimKind::BibEntry,
+        target: key.to_owned(),
+        fields: vec![("title".to_owned(), title.to_owned())],
+        response_hash: "cafe".to_owned(),
+        source: "crossref-doi".to_owned(),
+        fetched_at: fetched_at.to_owned(),
+        verdict,
+        diffs: Vec::new(),
+        failure_note: None,
+    }
+}
+
+fn run(
+    claims: &[Claim],
+    record: &VerificationRecord,
+    table: &SymbolTable,
+) -> Vec<xtex_core::check::Diagnostic> {
+    check_against_record(&RecordCheck {
+        record,
+        claims,
+        table,
+        now: NOW,
+        max_age_days: 30,
+    })
+}
+
+#[test]
+fn a_fresh_verified_claim_is_silent() {
+    let (_, table, id) = table_and_sources();
+    let claims = [bib_claim(id, "knuth1984", "The TeXbook")];
+    let record = VerificationRecord {
+        claims: vec![recorded(
+            "knuth1984",
+            "The TeXbook",
+            Verdict::Bibliographic(BibVerdict::Verified),
+            FRESH,
+        )],
+    };
+    assert!(run(&claims, &record, &table).is_empty());
+}
+
+#[test]
+fn an_edited_claim_retires_its_verdict_and_reports_the_drift() {
+    let (_, table, id) = table_and_sources();
+    let claims = [bib_claim(id, "knuth1984", "The TeXbook, 2nd impression")];
+    let mut old = recorded(
+        "knuth1984",
+        "The TeXbook",
+        Verdict::Bibliographic(BibVerdict::Mismatch),
+        FRESH,
+    );
+    old.diffs.push(FieldDiff {
+        field: "authors".to_owned(),
+        in_document: "X".to_owned(),
+        in_source: "Y".to_owned(),
+        severity: DiffSeverity::High,
+    });
+    let record = VerificationRecord { claims: vec![old] };
+    let findings = run(&claims, &record, &table);
+    assert_eq!(findings.len(), 1, "{findings:?}");
+    assert_eq!(findings[0].code, "XT1016");
+    assert_eq!(findings[0].severity, Severity::Advisory);
+    assert!(
+        findings[0]
+            .message
+            .contains("edited after its verification")
+    );
+}
+
+#[test]
+fn an_expired_verification_says_its_age_in_days() {
+    let (_, table, id) = table_and_sources();
+    let claims = [bib_claim(id, "knuth1984", "The TeXbook")];
+    let record = VerificationRecord {
+        claims: vec![recorded(
+            "knuth1984",
+            "The TeXbook",
+            Verdict::Bibliographic(BibVerdict::Verified),
+            OLD,
+        )],
+    };
+    let findings = run(&claims, &record, &table);
+    assert_eq!(findings.len(), 1, "{findings:?}");
+    assert_eq!(findings[0].code, "XT1017");
+    assert!(
+        findings[0].message.contains("123 days ago"),
+        "{}",
+        findings[0].message
+    );
+}
+
+#[test]
+fn a_high_severity_diff_on_a_demanded_key_is_a_hard_error() {
+    let (_, table, id) = table_and_sources();
+    let claims = [bib_claim(id, "knuth1984", "The TeXbook")];
+    let mut partial = recorded(
+        "knuth1984",
+        "The TeXbook",
+        Verdict::Bibliographic(BibVerdict::Partial),
+        FRESH,
+    );
+    partial.diffs.push(FieldDiff {
+        field: "authors".to_owned(),
+        in_document: "D. Knuth and A. Nobody".to_owned(),
+        in_source: "Donald E. Knuth".to_owned(),
+        severity: DiffSeverity::High,
+    });
+    let record = VerificationRecord {
+        claims: vec![partial],
+    };
+    let findings = run(&claims, &record, &table);
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].code, "XT1018");
+    assert_eq!(
+        findings[0].severity,
+        Severity::Error,
+        "authors on a demanded key"
+    );
+    assert!(
+        findings[0].message.contains("authors differs"),
+        "{}",
+        findings[0].message
+    );
+    assert!(
+        findings[0].message.contains("A. Nobody"),
+        "both sides speak"
+    );
+}
+
+#[test]
+fn the_same_finding_on_an_undemanded_key_is_advisory() {
+    let (_, table, id) = table_and_sources();
+    // `lamport1994` is in no @cite: the gradual policy keeps it advisory.
+    let claims = [bib_claim(id, "lamport1994", "LaTeX")];
+    let mut partial = recorded(
+        "lamport1994",
+        "LaTeX",
+        Verdict::Bibliographic(BibVerdict::Partial),
+        FRESH,
+    );
+    partial.diffs.push(FieldDiff {
+        field: "authors".to_owned(),
+        in_document: "L".to_owned(),
+        in_source: "Leslie Lamport".to_owned(),
+        severity: DiffSeverity::High,
+    });
+    let record = VerificationRecord {
+        claims: vec![partial],
+    };
+    let findings = run(&claims, &record, &table);
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].severity, Severity::Advisory);
+}
+
+#[test]
+fn an_unverified_claim_replays_its_note_dated() {
+    let (_, table, id) = table_and_sources();
+    let claims = [bib_claim(id, "knuth1984", "The TeXbook")];
+    let mut unverified = recorded(
+        "knuth1984",
+        "The TeXbook",
+        Verdict::Bibliographic(BibVerdict::Unverified),
+        FRESH,
+    );
+    unverified.response_hash = String::new();
+    unverified.failure_note = Some("crossref timed out".to_owned());
+    let record = VerificationRecord {
+        claims: vec![unverified],
+    };
+    let findings = run(&claims, &record, &table);
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].code, "XT1019");
+    assert_eq!(findings[0].severity, Severity::Advisory);
+    assert!(findings[0].message.contains("crossref timed out"));
+    assert!(findings[0].message.contains("2026-08-30"), "dated");
+}
+
+#[test]
+fn an_unreachable_url_is_never_a_hard_error() {
+    let (_, table, id) = table_and_sources();
+    let claims = [Claim {
+        kind: ClaimKind::Url,
+        target: "https://example.org/data".to_owned(),
+        source: id,
+        span: Span::new(0, 4),
+        fields: Vec::new(),
+    }];
+    let record = VerificationRecord {
+        claims: vec![VerifiedClaim {
+            kind: ClaimKind::Url,
+            target: "https://example.org/data".to_owned(),
+            fields: Vec::new(),
+            response_hash: String::new(),
+            source: "http".to_owned(),
+            fetched_at: FRESH.to_owned(),
+            verdict: Verdict::Reachability(Reachability::Unreachable),
+            diffs: Vec::new(),
+            failure_note: Some("404".to_owned()),
+        }],
+    };
+    let findings = run(&claims, &record, &table);
+    assert_eq!(findings.len(), 1);
+    assert_eq!(
+        findings[0].severity,
+        Severity::Advisory,
+        "a plain \\url is not a construct"
+    );
+    assert!(findings[0].message.contains("unreachable as of 2026-08-30"));
+}


### PR DESCRIPTION
The deterministic half of verification (#136): claims (#135) × record (#134) → dated findings, offline.

- Drift retires the verdict (edited-since-verified reported, old diffs not replayed); expiry degrades with its age in days; partial/mismatch/unverified/unreachable replay dated, with both sides of every diff.
- Severity per the standing gradual policy: hard only for a demanded `@cite` key with a mismatch or high-severity (authors) diff; reachability always advisory.
- No clock in core (caller supplies `now`); days-from-civil in fifteen lines, zero dependencies.
- 7 tests, 3 mutants caught; workspace, clippy, fmt clean. Closes #136.