### PR TITLE
The wasm surface carries claims and verdicts

### DIFF
--- a/crates/xtex-core/src/project.rs
+++ b/crates/xtex-core/src/project.rs
@@ -17,6 +17,18 @@ use crate::scanner::EntryToken;
 use crate::source::{SourceId, Sources};
 use crate::symbols::{EntityClass, SymbolTable};
 
+/// Everything one project walk produces — what [`check_project`] returns
+/// plus the table and ids the record-aware variant needs.
+struct Checked {
+    sources: Sources,
+    diagnostics: Vec<Diagnostic>,
+    coverage: f64,
+    bibliography: Bibliography,
+    table: SymbolTable,
+    root_id: crate::source::SourceId,
+    ids: Vec<crate::source::SourceId>,
+}
+
 /// Checks one document root, wherever its bytes live.
 ///
 /// This is the whole pipeline behind `xtex check`, host-independent: the
@@ -32,6 +44,88 @@ pub fn check_project(
     root: &str,
     prefixes: crate::symbols::PrefixMap,
 ) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography), IoError> {
+    let checked = check_project_inner(loader, root, prefixes)?;
+    Ok((
+        checked.sources,
+        checked.diagnostics,
+        checked.coverage,
+        checked.bibliography,
+    ))
+}
+
+/// The record's half of a [`check_project_with_record`] call, all supplied
+/// by the caller: the raw record bytes, the caller's clock, the window.
+pub struct RecordInput<'a> {
+    /// The `.xtexverified` bytes, unparsed.
+    pub record: &'a [u8],
+    /// Today, RFC 3339 — the caller's clock, never this crate's.
+    pub now: &'a str,
+    /// The freshness window, in days.
+    pub max_age_days: i64,
+}
+
+/// [`check_project`], with the verification record's dated findings
+/// appended. An unreadable record is itself an advisory — never a silent
+/// skip, never a hard failure: verification is opt-in and its record must
+/// not be able to break a build by rotting.
+///
+/// # Errors
+///
+/// Exactly [`check_project`]'s: the record can add findings, never an error.
+pub fn check_project_with_record(
+    loader: &impl SourceLoader,
+    root: &str,
+    prefixes: crate::symbols::PrefixMap,
+    record: Option<RecordInput<'_>>,
+) -> Result<(Sources, Vec<Diagnostic>, f64, Bibliography), IoError> {
+    let mut checked = check_project_inner(loader, root, prefixes)?;
+    if let Some(input) = record {
+        match crate::verification::parse_record(input.record) {
+            Err(error) => checked.diagnostics.push(Diagnostic {
+                code: "XT1015",
+                entity: EntityClass::UnknownOpen,
+                name: None,
+                source: checked.root_id,
+                span: crate::source::Span::new(0, 0),
+                message: format!("the verification record is unreadable: {}", error.message),
+                related: Vec::new(),
+                severity: Severity::Advisory,
+                blame: Blame::Unresolved,
+            }),
+            Ok(parsed) => {
+                let claims = crate::claims::collect(
+                    &mut checked.sources,
+                    loader,
+                    checked.root_id,
+                    &checked.ids,
+                );
+                checked
+                    .diagnostics
+                    .extend(crate::verification::check_against_record(
+                        &crate::verification::RecordCheck {
+                            record: &parsed,
+                            claims: &claims,
+                            table: &checked.table,
+                            now: input.now,
+                            max_age_days: input.max_age_days,
+                        },
+                    ));
+            }
+        }
+    }
+    Ok((
+        checked.sources,
+        checked.diagnostics,
+        checked.coverage,
+        checked.bibliography,
+    ))
+}
+
+fn check_project_inner(
+    loader: &impl SourceLoader,
+    root: &str,
+    prefixes: crate::symbols::PrefixMap,
+) -> Result<Checked, IoError> {
     let mut sources = Sources::new();
     let root_id = loader.load(root, None, &mut sources)?;
     let mut table = SymbolTable::with_prefixes(prefixes);
@@ -128,7 +222,19 @@ pub fn check_project(
     ));
     diagnostics.extend(import_diagnostics);
     let coverage = root_coverage(&sources, &documents);
-    Ok((sources, diagnostics, coverage, bibliography))
+    let ids: Vec<_> = documents
+        .iter()
+        .map(super::document::Document::source)
+        .collect();
+    Ok(Checked {
+        sources,
+        diagnostics,
+        coverage,
+        bibliography,
+        table,
+        root_id,
+        ids,
+    })
 }
 
 fn root_coverage(sources: &Sources, documents: &[crate::document::Document]) -> f64 {

--- a/crates/xtex-wasm/src/lib.rs
+++ b/crates/xtex-wasm/src/lib.rs
@@ -201,6 +201,99 @@ pub unsafe extern "C" fn xtex_check_json(pointer: *const u8, len: usize) -> *mut
     result(json.as_bytes())
 }
 
+/// The document's external claims, inventoried as `xtex claims` prints
+/// them: every declared bibliography entry with its fields, every url, doi
+/// and repository address, each with the span it was written at.
+/// Deterministic and offline, like everything on this surface.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_claims(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    let Some(bundle) = decode_bundle(&bytes) else {
+        return result(&[]);
+    };
+    let Ok(analysed) = xtex_core::project::analyse(&bundle.store, &bundle.root) else {
+        return result(&[]);
+    };
+    let xtex_core::project::Analysed {
+        mut sources, names, ..
+    } = analysed;
+    let ids: Vec<_> = names.iter().map(|(id, _)| *id).collect();
+    let Some(&root) = ids.first() else {
+        return result(&[]);
+    };
+    let claims = xtex_core::claims::collect(&mut sources, &bundle.store, root, &ids);
+    result(xtex_core::claims::to_json(&sources, &claims).as_bytes())
+}
+
+/// [`xtex_check_json`], with a verification record's dated findings
+/// appended. Input: `u32 now_len · now` (RFC 3339, the HOST's clock — this
+/// module deliberately cannot ask one), `u32 max_age_days`, `u32
+/// record_len · record` (the `.xtexverified` bytes; zero length = no
+/// record, plain check), then the bundle. The network never enters here:
+/// the host produced the record however it liked, and this surface only
+/// reads it.
+///
+/// # Safety
+///
+/// `pointer` must point at `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xtex_check_with_record(pointer: *const u8, len: usize) -> *mut u8 {
+    let bytes = unsafe { input(pointer, len) };
+    let mut at = 0usize;
+    let Some(now) = take_text(&bytes, &mut at) else {
+        return result(&[]);
+    };
+    let Some(field_end) = at.checked_add(4) else {
+        return result(&[]);
+    };
+    let Some(field) = bytes.get(at..field_end) else {
+        return result(&[]);
+    };
+    let max_age_days = i64::from(u32::from_le_bytes([field[0], field[1], field[2], field[3]]));
+    at = field_end;
+    let Some(record_end) = at.checked_add(4) else {
+        return result(&[]);
+    };
+    let Some(field) = bytes.get(at..record_end) else {
+        return result(&[]);
+    };
+    let record_len = u32::from_le_bytes([field[0], field[1], field[2], field[3]]) as usize;
+    at = record_end;
+    let Some(record) = bytes.get(at..at + record_len) else {
+        return result(&[]);
+    };
+    at += record_len;
+    let Some(bundle) = decode_bundle(&bytes[at..]) else {
+        return result(&[]);
+    };
+    let record_input = if record.is_empty() {
+        None
+    } else {
+        Some(xtex_core::project::RecordInput {
+            record,
+            now: &now,
+            max_age_days,
+        })
+    };
+    let Ok((sources, diagnostics, coverage, bibliography)) =
+        xtex_core::project::check_project_with_record(
+            &bundle.store,
+            &bundle.root,
+            xtex_core::symbols::PrefixMap::default(),
+            record_input,
+        )
+    else {
+        return result(&[]);
+    };
+    let mut json = String::new();
+    to_json(&sources, &diagnostics, coverage, &bibliography, &mut json);
+    result(json.as_bytes())
+}
+
 /// The project's identity inventory: every declaration with its class, its
 /// site, and how many references demand it. One JSON array, sorted by name —
 /// what an editor needs to draw the typed world and to say "3 references"

--- a/crates/xtex-wasm/tests/parity.mjs
+++ b/crates/xtex-wasm/tests/parity.mjs
@@ -68,6 +68,28 @@ JSON.parse(new TextDecoder().decode(checkJson));
 writeFileSync(`${outDir}/wasm.json`, checkJson);
 writeFileSync(`${outDir}/wasm.map`, call("xtex_source_map", project));
 
+// The claims inventory parses as JSON, and the record-aware check with NO
+// record must equal the plain check byte for byte — the record is opt-in
+// and its absence must change nothing.
+const claimsJson = call("xtex_claims", project);
+JSON.parse(new TextDecoder().decode(claimsJson));
+writeFileSync(`${outDir}/wasm.claims.json`, claimsJson);
+{
+  const now = new TextEncoder().encode("2026-01-01T00:00:00Z");
+  const input = new Uint8Array(4 + now.length + 4 + 4 + project.length);
+  const view = new DataView(input.buffer);
+  let at = 0;
+  view.setUint32(at, now.length, true); at += 4;
+  input.set(now, at); at += now.length;
+  view.setUint32(at, 30, true); at += 4;
+  view.setUint32(at, 0, true); at += 4;
+  input.set(project, at);
+  const recordless = call("xtex_check_with_record", input);
+  if (Buffer.compare(Buffer.from(recordless), Buffer.from(checkJson)) !== 0) {
+    throw new Error("xtex_check_with_record without a record diverged from the plain check");
+  }
+}
+
 // Helper: length-prefixed texts followed by the bundle.
 function framed(texts, bundleBytes) {
   const enc = new TextEncoder();

--- a/crates/xtex-wasm/tests/record_surface.rs
+++ b/crates/xtex-wasm/tests/record_surface.rs
@@ -1,0 +1,139 @@
+//! The surface carries claims and verdicts — called directly, natively:
+//! the same functions the browser calls, minus the browser.
+
+use xtex_core::verification::{
+    BibVerdict, ClaimKind, DiffSeverity, FieldDiff, Verdict, VerificationRecord, VerifiedClaim,
+    write_record,
+};
+use xtex_wasm::{xtex_check_with_record, xtex_claims};
+
+fn push_text(out: &mut Vec<u8>, text: &str) {
+    out.extend_from_slice(&u32::try_from(text.len()).expect("fits").to_le_bytes());
+    out.extend_from_slice(text.as_bytes());
+}
+
+fn bundle(root: &str, files: &[(&str, &str)]) -> Vec<u8> {
+    let mut out = Vec::new();
+    push_text(&mut out, root);
+    out.extend_from_slice(&u32::try_from(files.len()).expect("fits").to_le_bytes());
+    for (name, content) in files {
+        push_text(&mut out, name);
+        out.extend_from_slice(&u32::try_from(content.len()).expect("fits").to_le_bytes());
+        out.extend_from_slice(content.as_bytes());
+    }
+    out
+}
+
+fn call(function: unsafe extern "C" fn(*const u8, usize) -> *mut u8, input: &[u8]) -> String {
+    let pointer = unsafe { function(input.as_ptr(), input.len()) };
+    assert!(!pointer.is_null());
+    let len = u32::from_le_bytes(
+        unsafe { std::slice::from_raw_parts(pointer, 4) }
+            .try_into()
+            .expect("length"),
+    ) as usize;
+    let bytes = unsafe { std::slice::from_raw_parts(pointer.add(4), len) }.to_vec();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+const MAIN: &str = "\\documentclass{article}\n\\begin{document}\nSee @cite(knuth1984) and \\url{https://example.org/data}.\n\\bibliography{refs}\n\\end{document}\n";
+const BIB: &str = "@book{knuth1984,\n  title = {The TeXbook},\n  author = {Donald E. Knuth}\n}\n";
+
+#[test]
+fn the_claims_export_inventories_the_bundle() {
+    let input = bundle("main.tex", &[("main.tex", MAIN), ("refs.bib", BIB)]);
+    let answer = call(xtex_claims, &input);
+    assert!(answer.contains("\"kind\":\"bib-entry\""), "{answer}");
+    assert!(answer.contains("\"target\":\"knuth1984\""), "{answer}");
+    assert!(answer.contains("\"kind\":\"url\""), "{answer}");
+    assert!(answer.contains("https://example.org/data"), "{answer}");
+    assert!(
+        answer.contains("\"title\":\"The TeXbook\""),
+        "the fields travel: {answer}"
+    );
+}
+
+#[test]
+fn the_record_aware_check_appends_dated_findings() {
+    let record = VerificationRecord {
+        claims: vec![VerifiedClaim {
+            kind: ClaimKind::BibEntry,
+            target: "knuth1984".to_owned(),
+            fields: vec![
+                ("title".to_owned(), "The TeXbook".to_owned()),
+                ("author".to_owned(), "Donald E. Knuth".to_owned()),
+            ],
+            response_hash: "cafe".to_owned(),
+            source: "crossref-doi".to_owned(),
+            fetched_at: "2026-08-30T00:00:00Z".to_owned(),
+            verdict: Verdict::Bibliographic(BibVerdict::Partial),
+            diffs: vec![FieldDiff {
+                field: "authors".to_owned(),
+                in_document: "Donald E. Knuth".to_owned(),
+                in_source: "Donald E. Knuth and X. Fabricated".to_owned(),
+                severity: DiffSeverity::High,
+            }],
+            failure_note: None,
+        }],
+    };
+    let written = write_record(&record);
+    let mut input = Vec::new();
+    push_text(&mut input, "2026-09-01T00:00:00Z");
+    input.extend_from_slice(&30u32.to_le_bytes());
+    input.extend_from_slice(&u32::try_from(written.len()).expect("fits").to_le_bytes());
+    input.extend_from_slice(written.as_bytes());
+    input.extend_from_slice(&bundle(
+        "main.tex",
+        &[("main.tex", MAIN), ("refs.bib", BIB)],
+    ));
+    let answer = call(xtex_check_with_record, &input);
+    assert!(answer.contains("XT1018"), "the partial replays: {answer}");
+    assert!(
+        answer.contains("X. Fabricated"),
+        "both sides speak: {answer}"
+    );
+    assert!(answer.contains("2026-08-30"), "dated: {answer}");
+    assert!(
+        answer.contains("\"error\""),
+        "authors on a demanded key is hard: {answer}"
+    );
+}
+
+#[test]
+fn an_empty_record_length_is_the_plain_check() {
+    let mut input = Vec::new();
+    push_text(&mut input, "2026-09-01T00:00:00Z");
+    input.extend_from_slice(&30u32.to_le_bytes());
+    input.extend_from_slice(&0u32.to_le_bytes());
+    input.extend_from_slice(&bundle(
+        "main.tex",
+        &[("main.tex", MAIN), ("refs.bib", BIB)],
+    ));
+    let answer = call(xtex_check_with_record, &input);
+    assert!(
+        !answer.contains("XT1015"),
+        "no record is not an unreadable record: {answer}"
+    );
+    assert!(!answer.contains("XT1018"), "{answer}");
+    assert!(
+        answer.contains("\"coverage\""),
+        "the plain check shape: {answer}"
+    );
+}
+
+#[test]
+fn an_unreadable_record_is_an_advisory_not_a_silent_skip() {
+    let mut input = Vec::new();
+    push_text(&mut input, "2026-09-01T00:00:00Z");
+    input.extend_from_slice(&30u32.to_le_bytes());
+    let garbage = b"not a record";
+    input.extend_from_slice(&u32::try_from(garbage.len()).expect("fits").to_le_bytes());
+    input.extend_from_slice(garbage);
+    input.extend_from_slice(&bundle(
+        "main.tex",
+        &[("main.tex", MAIN), ("refs.bib", BIB)],
+    ));
+    let answer = call(xtex_check_with_record, &input);
+    assert!(answer.contains("XT1015"), "{answer}");
+    assert!(answer.contains("unreadable"), "{answer}");
+}


### PR DESCRIPTION
Hosts get the two deterministic halves (#138): `xtex_claims` (the inventory as `xtex claims` prints it) and `xtex_check_with_record` (the plain check plus the record's dated findings; zero record length = plain check byte for byte, asserted by the parity driver; unreadable record = XT1015 advisory, never a broken build).

`check_project` splits into an inner walk; `check_project_with_record` builds on it so the CLI (#137) answers through the same function. The surface stays network-free.

Native tests drive the exports directly; the export-coverage guard passes; workspace, CI-exact clippy (`-D warnings`), fmt clean. Closes #138.