### PR TITLE
The provider offers instead of checking

### DIFF
--- a/crates/xtex-verify/src/lib.rs
+++ b/crates/xtex-verify/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod bucket;
 pub mod compare;
+pub mod materialize;
 pub mod run;
 pub mod sources;
 pub mod transport;

--- a/crates/xtex-verify/src/main.rs
+++ b/crates/xtex-verify/src/main.rs
@@ -96,8 +96,54 @@ fn now_utc() -> String {
     )
 }
 
+/// `xtex-verify materialize <doi>` — the constructive half: a BibTeX
+/// entry transcribed from the DOI's live record, printed with its dated
+/// provenance comment. Nothing is composed from memory; a DOI the source
+/// does not know is an error, never a guessed entry.
+fn materialize(args: &[String]) -> ExitCode {
+    let mut doi = None;
+    let mut key = None;
+    let mut now = None;
+    for argument in args {
+        if let Some(value) = argument.strip_prefix("--key=") {
+            key = Some(value.to_owned());
+        } else if let Some(value) = argument.strip_prefix("--now=") {
+            now = Some(value.to_owned());
+        } else if argument.starts_with("--") {
+            eprintln!("usage: xtex-verify materialize <doi> [--key=name]");
+            return ExitCode::from(2);
+        } else {
+            doi = Some(argument.clone());
+        }
+    }
+    let Some(doi) = doi else {
+        eprintln!("usage: xtex-verify materialize <doi> [--key=name]");
+        return ExitCode::from(2);
+    };
+    match xtex_verify::materialize::entry_from_doi(
+        &xtex_verify::transport::Http,
+        "xtex-verify (https://github.com/camilochs/exacttex)",
+        Duration::from_secs(10),
+        &doi,
+        key.as_deref(),
+        &now.unwrap_or_else(now_utc),
+    ) {
+        Ok(entry) => {
+            println!("{}", entry.bibtex);
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.first().is_some_and(|first| first == "materialize") {
+        return materialize(&args[1..]);
+    }
     let mut root_arg = None;
     let mut max_age_days = 30i64;
     let mut mailto = String::new();

--- a/crates/xtex-verify/src/materialize.rs
+++ b/crates/xtex-verify/src/materialize.rs
@@ -1,0 +1,169 @@
+//! The provider's constructive half: a bibliography entry TRANSCRIBED
+//! from its DOI's authoritative source — never composed from memory. An
+//! entry nobody typed cannot carry an invented field, and the dated
+//! provenance comment it ships with says where every field came from.
+
+use std::fmt::Write as _;
+use std::time::Duration;
+
+use xtex_core::json::{self, Value};
+
+use crate::transport::{Transport, TransportError};
+
+/// What materializing one DOI produced.
+#[derive(Debug)]
+pub struct Materialized {
+    /// The suggested citation key (first author's family name + year).
+    pub key: String,
+    /// The BibTeX entry, provenance comment included.
+    pub bibtex: String,
+}
+
+fn text_of(value: &Value, name: &str) -> Option<String> {
+    match value.get(name)? {
+        Value::List(items) => items.first().and_then(Value::text).map(str::to_owned),
+        other => other.text().map(str::to_owned),
+    }
+}
+
+fn year_of(value: &Value) -> Option<i64> {
+    let parts = value.get("issued")?.get("date-parts")?;
+    let Value::List(list) = parts else {
+        return None;
+    };
+    let Some(Value::List(first)) = list.first() else {
+        return None;
+    };
+    first.first().and_then(Value::integer)
+}
+
+fn authors_of(value: &Value) -> Vec<(String, String)> {
+    let Some(Value::List(people)) = value.get("author") else {
+        return Vec::new();
+    };
+    people
+        .iter()
+        .filter_map(|person| {
+            let given = person.get("given").and_then(Value::text).unwrap_or("");
+            let family = person.get("family").and_then(Value::text).unwrap_or("");
+            if given.is_empty() && family.is_empty() {
+                None
+            } else {
+                Some((given.to_owned(), family.to_owned()))
+            }
+        })
+        .collect()
+}
+
+/// The BibTeX entry type for a Crossref work type — the common cases
+/// named, everything else an honest `@misc`.
+fn entry_type(crossref_type: &str) -> (&'static str, &'static str) {
+    match crossref_type {
+        "journal-article" => ("article", "journal"),
+        "proceedings-article" => ("inproceedings", "booktitle"),
+        "book" | "monograph" | "edited-book" | "reference-book" => ("book", "publisher"),
+        "book-chapter" => ("incollection", "booktitle"),
+        _ => ("misc", "howpublished"),
+    }
+}
+
+/// Fetches the DOI's record from Crossref and transcribes it as BibTeX.
+///
+/// # Errors
+///
+/// A transport failure, a non-200 answer, or an answer with no title —
+/// each as a message naming what refused. Nothing is ever filled in from
+/// anywhere but the fetched record.
+pub fn entry_from_doi(
+    transport: &dyn Transport,
+    user_agent: &str,
+    timeout: Duration,
+    doi: &str,
+    key_override: Option<&str>,
+    now: &str,
+) -> Result<Materialized, String> {
+    let encoded: String = doi
+        .bytes()
+        .map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'-' | b'_' | b'/' | b'(' | b')' => {
+                char::from(byte).to_string()
+            }
+            other => format!("%{other:02X}"),
+        })
+        .collect();
+    let url = format!("https://api.crossref.org/works/{encoded}");
+    let response = transport
+        .get(&url, user_agent, timeout)
+        .map_err(|error: TransportError| error.to_string())?;
+    if response.status == 404 {
+        return Err(format!("crossref knows no work under doi {doi}"));
+    }
+    if response.status != 200 {
+        return Err(format!("crossref answered {}", response.status));
+    }
+    let Some(value) = json::parse(&response.body) else {
+        return Err("crossref answered non-JSON".to_owned());
+    };
+    let Some(work) = value.get("message") else {
+        return Err("crossref answered without a message".to_owned());
+    };
+
+    let Some(title) = text_of(work, "title") else {
+        return Err("the record carries no title; refusing to invent one".to_owned());
+    };
+    let authors = authors_of(work);
+    let year = year_of(work);
+    let kind = work.get("type").and_then(Value::text).unwrap_or("");
+    let (bib_type, venue_field) = entry_type(kind);
+    let venue = text_of(work, "container-title")
+        .or_else(|| text_of(work, "publisher"))
+        .unwrap_or_default();
+
+    let key = key_override.map_or_else(
+        || {
+            let family = authors
+                .first()
+                .map_or("anon", |(_, family)| family.as_str());
+            let normalized: String = family
+                .chars()
+                .filter(char::is_ascii_alphanumeric)
+                .collect::<String>()
+                .to_lowercase();
+            match year {
+                Some(year) => format!("{normalized}{year}"),
+                None => normalized,
+            }
+        },
+        str::to_owned,
+    );
+
+    let mut bibtex = String::new();
+    let day = now.get(..10).unwrap_or(now);
+    let _ = writeln!(bibtex, "% transcribed from crossref on {day} — doi:{doi}");
+    let _ = writeln!(bibtex, "@{bib_type}{{{key},");
+    let _ = writeln!(bibtex, "  title = {{{title}}},");
+    if !authors.is_empty() {
+        let joined: Vec<String> = authors
+            .iter()
+            .map(|(given, family)| format!("{given} {family}").trim().to_owned())
+            .collect();
+        let _ = writeln!(bibtex, "  author = {{{}}},", joined.join(" and "));
+    }
+    if !venue.is_empty() {
+        let _ = writeln!(bibtex, "  {venue_field} = {{{venue}}},");
+    }
+    if let Some(year) = year {
+        let _ = writeln!(bibtex, "  year = {{{year}}},");
+    }
+    for (crossref_name, bib_name) in [("volume", "volume"), ("page", "pages")] {
+        if let Some(found) = text_of(work, crossref_name)
+            && !found.is_empty()
+        {
+            let _ = writeln!(bibtex, "  {bib_name} = {{{found}}},");
+        }
+    }
+    let _ = writeln!(bibtex, "  doi = {{{doi}}}");
+    bibtex.push('}');
+
+    Ok(Materialized { key, bibtex })
+}

--- a/crates/xtex-verify/tests/materialize.rs
+++ b/crates/xtex-verify/tests/materialize.rs
@@ -1,0 +1,144 @@
+//! The constructive half, against a canned source: every field in the
+//! produced entry is the source's, the provenance comment is dated, and
+//! a DOI the source does not know is a refusal — never an invention.
+
+use std::cell::RefCell;
+use std::time::Duration;
+
+use xtex_verify::materialize::entry_from_doi;
+use xtex_verify::transport::{Response, Transport, TransportError};
+
+struct Canned {
+    status: u16,
+    body: &'static str,
+    asked: RefCell<Vec<String>>,
+}
+
+impl Transport for Canned {
+    fn get(&self, url: &str, _agent: &str, _timeout: Duration) -> Result<Response, TransportError> {
+        self.asked.borrow_mut().push(url.to_owned());
+        Ok(Response {
+            status: self.status,
+            body: self.body.as_bytes().to_vec(),
+            location: None,
+        })
+    }
+}
+
+const WORK: &str = r#"{"message":{
+  "type":"journal-article",
+  "title":["A Very Exact Result"],
+  "author":[{"given":"Ada","family":"Lovelace"},{"given":"Alan","family":"Turing"}],
+  "container-title":["Annals of Certainty"],
+  "issued":{"date-parts":[[2021,3]]},
+  "volume":"7","page":"11-29",
+  "DOI":"10.1000/exact"
+}}"#;
+
+#[test]
+fn every_field_in_the_entry_is_the_sources() {
+    let canned = Canned {
+        status: 200,
+        body: WORK,
+        asked: RefCell::new(Vec::new()),
+    };
+    let entry = entry_from_doi(
+        &canned,
+        "test",
+        Duration::from_secs(1),
+        "10.1000/exact",
+        None,
+        "2026-09-01T12:00:00Z",
+    )
+    .expect("materializes");
+    assert_eq!(entry.key, "lovelace2021");
+    let expected = "% transcribed from crossref on 2026-09-01 — doi:10.1000/exact\n\
+@article{lovelace2021,\n\
+\x20 title = {A Very Exact Result},\n\
+\x20 author = {Ada Lovelace and Alan Turing},\n\
+\x20 journal = {Annals of Certainty},\n\
+\x20 year = {2021},\n\
+\x20 volume = {7},\n\
+\x20 pages = {11-29},\n\
+\x20 doi = {10.1000/exact}\n\
+}";
+    assert_eq!(entry.bibtex, expected);
+    assert!(
+        canned.asked.borrow()[0].starts_with("https://api.crossref.org/works/10.1000/exact"),
+        "asked {:?}",
+        canned.asked.borrow()
+    );
+}
+
+#[test]
+fn an_unknown_doi_is_a_refusal_never_an_invention() {
+    let canned = Canned {
+        status: 404,
+        body: "{}",
+        asked: RefCell::new(Vec::new()),
+    };
+    let refusal = entry_from_doi(
+        &canned,
+        "test",
+        Duration::from_secs(1),
+        "10.1000/ghost",
+        None,
+        "2026-09-01T12:00:00Z",
+    )
+    .expect_err("a 404 must refuse");
+    assert!(refusal.contains("knows no work"), "{refusal}");
+}
+
+#[test]
+fn a_record_without_a_title_is_refused() {
+    let canned = Canned {
+        status: 200,
+        body: r#"{"message":{"type":"journal-article","author":[{"given":"A","family":"B"}]}}"#,
+        asked: RefCell::new(Vec::new()),
+    };
+    let refusal = entry_from_doi(
+        &canned,
+        "test",
+        Duration::from_secs(1),
+        "10.1000/untitled",
+        None,
+        "2026-09-01T12:00:00Z",
+    )
+    .expect_err("no title, no entry");
+    assert!(refusal.contains("refusing to invent"), "{refusal}");
+}
+
+#[test]
+fn a_proceedings_paper_wears_inproceedings_and_a_chosen_key_wins() {
+    let canned = Canned {
+        status: 200,
+        body: r#"{"message":{
+          "type":"proceedings-article",
+          "title":["Measured Doors"],
+          "author":[{"given":"Grace","family":"Hopper"}],
+          "container-title":["Proc. of Certainty"],
+          "issued":{"date-parts":[[2019]]}
+        }}"#,
+        asked: RefCell::new(Vec::new()),
+    };
+    let entry = entry_from_doi(
+        &canned,
+        "test",
+        Duration::from_secs(1),
+        "10.1000/doors",
+        Some("doors2019"),
+        "2026-09-01T12:00:00Z",
+    )
+    .expect("materializes");
+    assert_eq!(entry.key, "doors2019");
+    assert!(
+        entry.bibtex.contains("@inproceedings{doors2019,"),
+        "{}",
+        entry.bibtex
+    );
+    assert!(
+        entry.bibtex.contains("booktitle = {Proc. of Certainty}"),
+        "{}",
+        entry.bibtex
+    );
+}

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -107,7 +107,30 @@ else — reachability, expiry, drift — is advisory. The WebAssembly surface ex
 (`xtex_claims`, `xtex_check_with_record`), so an editor in a browser replays the same record with the
 same answers; the parity suite holds it to that.
 
-## 5 · What this refuses to be
+## 5 · The provider: offering instead of checking
+
+```sh
+xtex-verify materialize 10.1000/xyz [--key=name]
+```
+
+The constructive half. Instead of checking an entry someone typed, the provider **transcribes** the
+entry from the DOI's live record and prints it, dated:
+
+```bibtex
+% transcribed from crossref on 2026-09-01 — doi:10.1000/xyz
+@article{lovelace2021,
+  title = {A Very Exact Result},
+  author = {Ada Lovelace and Alan Turing},
+  ...
+```
+
+An entry nobody typed cannot carry an invented field — the classic fabricated reference is composed
+from memory, and this path has no memory to compose from. A DOI the source does not know is a refusal,
+never a guess; a record without a title is refused, never completed. Editors expose the same operation
+(in Vitela: *Add entry from DOI* in the submission report), and once the entry is in the project the
+deterministic check owns it like any other.
+
+## 6 · What this refuses to be
 
 - **Not a compile-time network.** `--verify-external` inside the pipeline was considered and rejected:
   hundreds of citations would make compilation minutes long, and a timeout would turn weather into build


### PR DESCRIPTION
The constructive half of #139: `xtex-verify materialize <doi>` transcribes the entry from the DOI's live record — dated provenance comment, full author list from the source, honest refusals (unknown DOI, titleless record). The editors' half ships in Vitela (Add entry from DOI in the submission report).

Closes #139.