### PR TITLE
One situation, one note, every surface

### DIFF
--- a/crates/xtex-verify/src/run.rs
+++ b/crates/xtex-verify/src/run.rs
@@ -309,7 +309,11 @@ pub fn verify(
                             failure_note: None,
                         }
                     }
-                    None => unverified(claim, run, "no source answered for this entry"),
+                    None => unverified(
+                        claim,
+                        run,
+                        "not found at the registries — books published before DOIs often are not registered; the entry may still be correct",
+                    ),
                 }
             }
             ClaimKind::Url | ClaimKind::Doi | ClaimKind::Repository => {


### PR DESCRIPTION
The terminal verifier's unverified note now matches the browser verifier's plain-language wording — same situation, same sentence, whichever surface wrote the record.