### PR TITLE
The word before a reference is a checked side

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,10 @@ number matters less than its trend: a file that was 60% checked and is now 30% g
 parser cannot model.
 
 The check that types buy, and that no LaTeX tool performs: `@ref(fig:main)` pointing at a `\table(fig:main)`
-— the prefix demands a figure, the declaration is a table. LaTeX compiles it and prints "Table" wherever a
-`\cref` reads the counter, whatever the sentence around it says; the sentence itself is not read by any
-tool, ExactTeX included. See [`docs/checking.md`](docs/checking.md).
+— the prefix demands a figure, the declaration is a table. Its sibling: `Figure~@ref(tab:main)` on a
+table — the sentence says figure, the declaration says table. LaTeX compiles both and prints the wrong
+word. See [`docs/checking.md`](docs/checking.md) and
+[`docs/decisions/0019`](docs/decisions/0019-prose-is-a-checked-side.md).
 
 ---
 

--- a/crates/xtex-core/src/check.rs
+++ b/crates/xtex-core/src/check.rs
@@ -167,8 +167,42 @@ pub fn check_with_labels(
             blame: Blame::XtexConstruct,
         });
     }
+    for (name, reference, prose, declaration) in table.prose_mismatches() {
+        diagnostics.push(Diagnostic {
+            code: "XT1020",
+            entity: prose.class,
+            name: Some(name.to_owned()),
+            source: reference.payload.source,
+            span: prose.span,
+            message: format!(
+                "prose says `{}` but `{name}` is {} {}",
+                prose.word,
+                article(declaration.class.name()),
+                declaration.class.name()
+            ),
+            related: vec![Related {
+                source: declaration.payload.source,
+                span: declaration.payload.span,
+                message: format!("{} declared here", declaration.class.name()),
+            }],
+            severity: Severity::Error,
+            blame: Blame::XtexConstruct,
+        });
+    }
     missing_citation_diagnostics(table, bibliography, &mut diagnostics);
     diagnostics
+}
+
+/// `a` or `an`, for a class name in a sentence.
+const fn article(word: &str) -> &'static str {
+    if matches!(
+        word.as_bytes().first(),
+        Some(b'a' | b'e' | b'i' | b'o' | b'u')
+    ) {
+        "an"
+    } else {
+        "a"
+    }
 }
 
 /// Checks typed blocks in every source belonging to one document root.
@@ -869,6 +903,37 @@ mod tests {
                      $@eqref(m)$ % @eqref(c)\n\\texttt{@eqref(t)} \\verb|@eqref(v)| @home(x)";
         let found = document_diagnostics(quiet);
         assert!(found.is_empty(), "{found:?}");
+    }
+
+    #[test]
+    fn a_prose_word_contradicting_the_target_is_an_error_at_the_word() {
+        let found = diagnostics(
+            "\\table(tab:main) { caption = {T} } Figure~@ref(tab:main)",
+            &Bibliography::Complete(BTreeSet::default()),
+        );
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert_eq!(found[0].code, "XT1020");
+        assert_eq!(found[0].severity, Severity::Error);
+        assert_eq!(
+            found[0].message,
+            "prose says `Figure` but `tab:main` is a table"
+        );
+        assert_eq!(found[0].span.len(), "Figure".len());
+        assert_eq!(found[0].related.len(), 1);
+        assert!(found[0].related[0].message.contains("table declared here"));
+    }
+
+    #[test]
+    fn prefix_and_prose_are_two_facts_and_may_both_fire() {
+        // `Figure~@ref(fig:main)` on a table: the prefix demands a figure
+        // (XT1004) and so does the word (XT1020). Two contradictions, two
+        // diagnostics, neither hiding the other.
+        let found = diagnostics(
+            "\\table(fig:main) { caption = {T} } Figure~@ref(fig:main)",
+            &Bibliography::Complete(BTreeSet::default()),
+        );
+        let codes: Vec<_> = found.iter().map(|d| d.code).collect();
+        assert_eq!(codes, ["XT1004", "XT1020"], "{found:?}");
     }
 
     #[test]

--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -103,6 +103,81 @@ pub struct Reference {
     pub payload: Payload,
     /// The whole construct, which is what a diagnostic points at.
     pub construct: Span,
+    /// The entity-kind word written immediately before a reference, when
+    /// there is one: `Figure~@ref(x)` carries `Figure`. See
+    /// [`prose_word_before`] and `docs/decisions/0019`.
+    pub prose: Option<ProseWord>,
+}
+
+/// An entity-kind word the author wrote before a reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProseWord {
+    /// The word as written, for the diagnostic to quote.
+    pub word: &'static str,
+    /// The class the word names.
+    pub class: EntityClass,
+    /// The word's bytes in the source, for the diagnostic to quote.
+    pub span: Span,
+}
+
+/// The words the check reads, and the class each names.
+///
+/// A fixed vocabulary, deliberately: the capitalised forms authors put
+/// before a reference, their plurals, and the abbreviations LaTeX
+/// manuals use. Lower case is not matched — "figure" mid-sentence is
+/// prose about figures, not a label for the next reference — and a class
+/// the symbol table cannot assign (theorem, listing) has no word here,
+/// because a word with no class to compare against could never fire.
+const PROSE_WORDS: &[(&str, EntityClass)] = &[
+    ("Figure", EntityClass::Figure),
+    ("Figures", EntityClass::Figure),
+    ("Fig.", EntityClass::Figure),
+    ("Figs.", EntityClass::Figure),
+    ("Table", EntityClass::Table),
+    ("Tables", EntityClass::Table),
+    ("Tab.", EntityClass::Table),
+    ("Section", EntityClass::Section),
+    ("Sections", EntityClass::Section),
+    ("Sec.", EntityClass::Section),
+    ("Equation", EntityClass::Equation),
+    ("Equations", EntityClass::Equation),
+    ("Eq.", EntityClass::Equation),
+    ("Algorithm", EntityClass::Algorithm),
+    ("Algorithms", EntityClass::Algorithm),
+    ("Alg.", EntityClass::Algorithm),
+    ("Appendix", EntityClass::Appendix),
+    ("Appendices", EntityClass::Appendix),
+];
+
+/// The entity-kind word immediately before a construct starting at `at`.
+///
+/// Immediately: separated by nothing, one space, or one or more `~`. A word
+/// further away is not about this reference, and a word after a line
+/// ending is not either. The byte before the word must not be a letter,
+/// so `Subfigure` does not end in a `figure` this reads. A construct is
+/// only recognised in prose, so a word inside a comment or verbatim text
+/// never precedes one.
+#[must_use]
+pub fn prose_word_before(bytes: &[u8], at: usize) -> Option<ProseWord> {
+    let mut end = at;
+    if bytes.get(end.wrapping_sub(1)) == Some(&b' ') {
+        end -= 1;
+    }
+    while end > 0 && bytes[end - 1] == b'~' {
+        end -= 1;
+    }
+    let (word, class) = PROSE_WORDS
+        .iter()
+        .find(|(word, _)| bytes[..end].ends_with(word.as_bytes()))?;
+    let start = end - word.len();
+    if start > 0 && bytes[start - 1].is_ascii_alphanumeric() {
+        return None;
+    }
+    Some(ProseWord {
+        word,
+        class: *class,
+        span: Span::new(u32::try_from(start).ok()?, u32::try_from(end).ok()?),
+    })
 }
 
 /// Something the table cannot accept.
@@ -235,6 +310,7 @@ impl SymbolTable {
                                 kind,
                                 payload,
                                 construct,
+                                prose: None,
                             },
                         ));
                     }
@@ -275,45 +351,58 @@ impl SymbolTable {
                         },
                     );
                 }
-                EntryToken::Ref => {
-                    // `@cref(a, b)` names two identifiers and each is checked
-                    // on its own, like a citation's keys. The other reference
-                    // commands take one, so their whole payload is the name:
-                    // `\autoref{a,b}` is one undefined reference in LaTeX
-                    // too, and this reports it as one.
-                    let list = sources
-                        .get(node.source())
-                        .and_then(|source| source.slice(construct))
-                        .is_some_and(crate::scanner::names_a_list);
-                    let names = if list {
-                        keys_of(sources, payload)
-                    } else {
-                        text_of(sources, payload)
-                            .filter(|text| !text.is_empty())
-                            .into_iter()
-                            .collect()
-                    };
-                    if names.is_empty() {
-                        self.errors.push(SymbolError::Malformed {
-                            source: node.source(),
-                            construct,
-                        });
-                        return;
-                    }
-                    for name in names {
-                        self.references.push((
-                            name,
-                            Reference {
-                                kind,
-                                payload,
-                                construct,
-                            },
-                        ));
-                    }
-                }
+                EntryToken::Ref => self.merge_reference(sources, node.source(), construct, payload),
                 _ => {}
             }
         });
+    }
+
+    /// Adds one reference construct's names to the table.
+    ///
+    /// `@cref(a, b)` names two identifiers and each is checked on its own,
+    /// like a citation's keys. The other reference commands take one, so
+    /// their whole payload is the name: `\autoref{a,b}` is one undefined
+    /// reference in LaTeX too, and this reports it as one.
+    fn merge_reference(
+        &mut self,
+        sources: &Sources,
+        source: SourceId,
+        construct: Span,
+        payload: Payload,
+    ) {
+        let list = sources
+            .get(source)
+            .and_then(|s| s.slice(construct))
+            .is_some_and(crate::scanner::names_a_list);
+        let names = if list {
+            keys_of(sources, payload)
+        } else {
+            text_of(sources, payload)
+                .filter(|text| !text.is_empty())
+                .into_iter()
+                .collect()
+        };
+        if names.is_empty() {
+            self.errors
+                .push(SymbolError::Malformed { source, construct });
+            return;
+        }
+        // The word before the construct applies to every name it lists:
+        // "Figures~@cref(a, b)" says both are figures.
+        let prose = sources
+            .get(source)
+            .and_then(|s| prose_word_before(s.bytes(), construct.start()));
+        for name in names {
+            self.references.push((
+                name,
+                Reference {
+                    kind: EntryToken::Ref,
+                    payload,
+                    construct,
+                    prose,
+                },
+            ));
+        }
     }
 
     /// Declaration of `name`, if one exists.
@@ -405,6 +494,23 @@ impl SymbolTable {
                 name.as_str(),
                 reference,
                 demand,
+                declaration,
+            ))
+        })
+    }
+
+    /// References whose preceding entity-kind word contradicts the known
+    /// class of their target. `docs/decisions/0019`.
+    pub fn prose_mismatches(
+        &self,
+    ) -> impl Iterator<Item = (&str, &Reference, ProseWord, &Declaration)> {
+        self.references.iter().filter_map(|(name, reference)| {
+            let prose = reference.prose?;
+            let declaration = self.declarations.get(name)?;
+            (!prose.class.is_consistent_with(declaration.class)).then_some((
+                name.as_str(),
+                reference,
+                prose,
                 declaration,
             ))
         })
@@ -737,6 +843,102 @@ mod tests {
             "\\table(fig:x) { caption = {X} } @cref(fig:x) @autoref(fig:x) @pageref(fig:x)",
         )]);
         assert_eq!(t.inconsistent_references().count(), 3);
+    }
+
+    fn prose_mismatch_names(text: &str) -> Vec<String> {
+        let (_, t) = table(&[("a.xtex", text)]);
+        t.prose_mismatches()
+            .map(|(name, _, _, _)| name.to_owned())
+            .collect()
+    }
+
+    #[test]
+    fn a_prose_word_naming_another_class_than_the_target_is_a_mismatch() {
+        let table_decl = "\\table(tab:main) { caption = {T} }";
+        assert_eq!(
+            prose_mismatch_names(&format!("{table_decl} Figure~@ref(tab:main)")),
+            ["tab:main"]
+        );
+        // Nothing, one space, or tildes between the word and the construct.
+        for form in [
+            "Figure@ref(tab:main)",
+            "Figure @ref(tab:main)",
+            "Figure~~@ref(tab:main)",
+        ] {
+            assert_eq!(
+                prose_mismatch_names(&format!("{table_decl} {form}")),
+                ["tab:main"],
+                "{form}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_prose_word_matching_the_target_is_silent() {
+        assert!(
+            prose_mismatch_names("\\table(tab:main) { caption = {T} } Table~@ref(tab:main)")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn plurals_and_abbreviations_name_the_same_class() {
+        let decl = "\\table(tab:a) { caption = {A} } \\table(tab:b) { caption = {B} }";
+        assert_eq!(
+            prose_mismatch_names(&format!("{decl} Figures~@cref(tab:a, tab:b)")),
+            ["tab:a", "tab:b"]
+        );
+        assert_eq!(
+            prose_mismatch_names(&format!("{decl} Fig.~@ref(tab:a)")),
+            ["tab:a"]
+        );
+        assert_eq!(
+            prose_mismatch_names(&format!("{decl} Figs.~@Cref(tab:a,tab:b)")),
+            ["tab:a", "tab:b"]
+        );
+        assert!(
+            prose_mismatch_names(&format!(
+                "{decl} Tab.~@ref(tab:a) Tables~@cref(tab:a, tab:b)"
+            ))
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn an_unknown_open_target_never_fires() {
+        // A `\label` supplies no class, and neither does an `@id` on
+        // unmodelled LaTeX; both sides must be known.
+        let (_, t) = table(&[(
+            "a.xtex",
+            "\\newtheorem{X}{Open}\n@id(tab:x) Figure~@ref(tab:x)",
+        )]);
+        assert_eq!(
+            t.declaration("tab:x").map(|d| d.class),
+            Some(EntityClass::UnknownOpen),
+            "the control must be a declared, unknown-open target"
+        );
+        assert_eq!(t.prose_mismatches().count(), 0);
+        assert!(prose_mismatch_names("\\label{tab:x} Figure~@ref(tab:x)").is_empty());
+    }
+
+    #[test]
+    fn no_word_or_a_word_that_is_not_immediately_before_is_silent() {
+        let decl = "\\table(tab:x) { caption = {T} }";
+        for text in [
+            "see @ref(tab:x)",
+            "Figure 3 and @ref(tab:x)",
+            "Figure~\n@ref(tab:x)",
+            "figure~@ref(tab:x)",
+            "Subfigure~@ref(tab:x)",
+            "% Figure\n@ref(tab:x)",
+            "\\emph{Figure}~@ref(tab:x)",
+            "@cref(tab:x)",
+        ] {
+            assert!(
+                prose_mismatch_names(&format!("{decl} {text}")).is_empty(),
+                "{text}"
+            );
+        }
     }
 
     #[test]

--- a/crates/xtex-lsp/tests/protocol.rs
+++ b/crates/xtex-lsp/tests/protocol.rs
@@ -281,6 +281,24 @@ fn a_cleveref_reference_is_hovered_defined_and_renamed_like_ref() {
 }
 
 #[test]
+fn a_prose_word_contradicting_the_target_is_published_as_an_error() {
+    let frames = talk(&[
+        open_with(
+            "file:///w.xtex",
+            "\\table(tab:main) { caption = {T} }\nFigure~@ref(tab:main).\n",
+        ),
+        EXIT.to_owned(),
+    ]);
+    let published = &frames[0];
+    assert!(published.contains("XT1020"), "{published}");
+    assert!(
+        published.contains("prose says `Figure` but `tab:main` is a table"),
+        "{published}"
+    );
+    assert!(published.contains(r#""severity":1"#), "{published}");
+}
+
+#[test]
 fn a_construct_shaped_word_is_published_as_a_warning_not_an_error() {
     // XT2002 is an advisory: the CLI exits 0 on it, so the editor shows a
     // warning squiggle — severity 2 — never an error one.

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -668,7 +668,7 @@ fn failure_paths_fail_identically_in_both_builds() {
     // (`{,"span"`) until the first real document met it.
     std::fs::write(
         broken.join("main.xtex"),
-        "@id(dup:x) y @id(dup:x).\nVer @cite(clave) y @ref(sec:x).\n@import(\"dark.xtex\")\n\\bibliography{ausente}\n",
+        "@id(dup:x) y @id(dup:x).\nVer @cite(clave) y @ref(sec:x).\n@import(\"dark.xtex\")\n\\bibliography{ausente}\n\\table(tab:t) { caption = {T} }\nFigure~@ref(tab:t).\n",
     )
     .expect("writes");
     std::fs::write(
@@ -712,5 +712,12 @@ fn failure_paths_fail_identically_in_both_builds() {
     assert!(
         wasm_json.contains("XT1001") && wasm_json.contains("first declared here"),
         "the duplicate must carry its related entry: {wasm_json}"
+    );
+    // The prose word before a reference is a checked side (decisions/0019),
+    // and both builds report it the same way.
+    assert!(
+        wasm_json.contains("XT1020")
+            && wasm_json.contains("prose says `Figure` but `tab:t` is a table"),
+        "the prose-word mismatch must be reported: {wasm_json}"
     );
 }

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -93,6 +93,16 @@ Two ways the demand is absent, and both are silence rather than error:
 Full record, including the two rejected alternatives:
 [`decisions/0003`](decisions/0003-the-prefix-is-the-demand.md).
 
+### The word before the reference is a second demand
+
+`Figure~@ref(tab:main)` says two things about `tab:main`: the prefix says table, the sentence says figure.
+The sentence is read too, under the same both-sides-known rule: when the word immediately before a
+reference construct is one of a fixed vocabulary (`Figure`, `Fig.`, `Tables`, `Sec.`, … — the list is in
+[`grammar.md`](grammar.md) §4) and the target's declared class is known and differs, that is `XT1020`, at
+the word. Nothing fires for a lower-case word, a word not immediately before, a `\label` target, or an
+`@id` on unmodelled LaTeX. The reasoning, and what would reverse it:
+[`decisions/0019`](decisions/0019-prose-is-a-checked-side.md).
+
 ---
 
 ## 3 · When the compiler may fail
@@ -116,14 +126,16 @@ error.
 | `XT1012` | A sidecar record whose revision construct no longer exists | any |
 | `XT1013` | A sidecar that cannot be read, or that names a different document | any |
 | `XT1014` | An explicit inline construct (`@id`, a reference or citation command, `@import`) whose closing `)` is not found before line end | any |
+| `XT1020` | An entity-kind word immediately before a reference construct names class A, and the target's known class is B, A ≠ B | both known |
 
 Two properties hold across the whole table and are tested as properties, not as examples:
 
 1. **Every row requires an explicit construct, or ExactTeX's own sidecar.** There is no row that ordinary
    LaTeX can reach. `XT1010`–`XT1013` are about a `.xtexrev` file, which ExactTeX writes and owns; a renamed
    `.tex` has none, so they cannot fire on one. See [`revisions.md`](revisions.md) §5.
-2. **Every row requires both sides known.** `XT1004` cannot fire when either side is `?O`, and `XT1005`
-   cannot fire when the bibliography is `Unavailable`. Uncertainty on either side means silence.
+2. **Every row requires both sides known.** `XT1004` and `XT1020` cannot fire when either side is `?O`,
+   and `XT1005` cannot fire when the bibliography is `Unavailable`. Uncertainty on either side means
+   silence.
 
 ### Exit codes
 

--- a/docs/decisions/0019-prose-is-a-checked-side.md
+++ b/docs/decisions/0019-prose-is-a-checked-side.md
@@ -1,0 +1,78 @@
+# 0019 · The word before a reference is a checked side
+
+**Status:** accepted, 2026-09-01. Decided by the maintainer after Stage 0b's second measurement.
+
+---
+
+## The gap this closes
+
+`decisions/0003` gave a reference a demand: the prefix before the first `:`. `@ref(fig:main)` demands a
+figure, and pointing it at a `\table(fig:main)` is `XT1004`. That closed the case the motivating failure
+was drawn from — a figure renamed into a table with its label kept.
+
+It did not close the case the sentence around the reference makes. `Table~@ref(fig:main)` on a table is
+correct by the prefix and wrong to a reader only if the prefix is what they read; `Figure~@ref(tab:main)`
+on a table passes `XT1004`, compiles, and prints "Figure 3" above a table. Stage 0b
+(`tests/experiments/0b-error-classes/`) measured this pair against tectonic, chktex, chklref, texlab and
+`xtex check`, and none of the five reported it — `xtex` included, which the experiment's own results file
+had first mis-described as caught. The prefix check reads the identifier; nothing read the prose.
+
+## The decision
+
+**The entity-kind word written immediately before a reference is a second demand, checked exactly as the
+prefix is.** `Figure~@ref(tab:main)` on a declared table is `XT1020`:
+
+```
+error[XT1020]: prose says `Figure` but `tab:main` is a table
+```
+
+Both sides must be known, as for `XT1004`: the word must be one the vocabulary names, and the target's
+class must come from a typed block or an `@id` the symbol table classifies. A `\label`, an `@id` on
+unmodelled LaTeX, an absent word, a lower-case word or a word further than one separator away is silence.
+
+## What "immediately before" means
+
+The word ends at the construct's `@`, or one space before it, or one or more `~` before it — the three ways
+a LaTeX author binds the word to the number. A line ending between them, a bracketed `\emph{Figure}`, or
+"Figure 3 and @ref(…)" is not a binding, and the check does not guess.
+
+The byte before the word is not a letter, so `Subfigure~@ref(…)` ends in a `figure` this does not read.
+
+The vocabulary is fixed and small: the capitalised words, their plurals, and the abbreviations LaTeX
+manuals use — `Figure`, `Figures`, `Fig.`, `Figs.`, `Table`, `Tables`, `Tab.`, `Section`, `Sections`,
+`Sec.`, `Equation`, `Equations`, `Eq.`, `Algorithm`, `Algorithms`, `Alg.`, `Appendix`, `Appendices`. A
+class the symbol table cannot assign — theorem, lemma, definition, listing — has no word, because a word
+with no class to compare against could never fire and would only look like a check.
+
+A `cref`-family reference generates its own word, so it is usually preceded by none, and then nothing is
+checked. When an author writes one anyway — `Figure~@cref(tab:x)` — the word is read like any other, and a
+list gets the word for every name in it: `Figures~@cref(tab:a, tab:b)` says both are figures.
+
+## Why prose participates at all
+
+Every other check reads what the author declared: an identifier, a block field, a bibliography key. Prose
+is what the compiler otherwise transports without reading, and this record is the one place it reads a
+word of it. Three things make that admissible here and nowhere else:
+
+1. The word is bound to an explicit construct. The check fires only at a reference the author wrote as
+   ExactTeX syntax; the same word before a plain `\ref{}` is transported and never read.
+2. Both sides are declared. The target's class is the author's own declaration; the word is the author's
+   own sentence. The compiler compares two things the author wrote and invents neither.
+3. The defect is silent everywhere else. It compiles, it typesets a wrong word, and Stage 0b showed no tool
+   reports it. A check that catches what nothing else catches is worth a fixed vocabulary of eighteen words.
+
+## What was rejected
+
+| Option | |
+|---|---|
+| **The word before the reference is a demand** | chosen |
+| Read the word after the reference too (`@ref(x) shows the table`) | rejected: the binding is loose, and a false error on correct prose is worse than silence |
+| A configurable vocabulary in `xtex.toml` | deferred: no measured corpus has asked for a word the fixed list lacks |
+| Advisory rather than error | rejected: both sides are known, which is the `XT1004` condition for an error; an advisory here would say the compiler had grounds and declined to use them |
+
+## What would reverse it
+
+A measured corpus in which the fixed vocabulary produces false errors on correct prose — a field where
+"Table" precedes references to things declared as something else — would move the check behind
+configuration or to advisory. `tests/experiments/0b-error-classes/cases/prose-word/` holds the pair and
+its clean control.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -188,6 +188,14 @@ one identifier, and their payload is one name as written: `\autoref{a,b}` is a s
 under `hyperref` — compiled to check, not recalled — so `@autoref(a, b)` is reported as the single undeclared
 identifier `a, b`, which is what TeX sees.
 
+**The entity-kind word before a reference is read.** `Figure~@ref(tab:main)`, with `tab:main` declared as
+a table, is `XT1020`: the word names one class and the declaration another. The word must be immediately
+before the construct — nothing, one space or tildes between them — and one of a fixed vocabulary: `Figure`,
+`Figures`, `Fig.`, `Figs.`, `Table`, `Tables`, `Tab.`, `Section`, `Sections`, `Sec.`, `Equation`,
+`Equations`, `Eq.`, `Algorithm`, `Algorithms`, `Alg.`, `Appendix`, `Appendices`. Lower case is not read,
+a target whose class is unknown never fires, and a `cref`-family reference is read only when an author
+wrote a word before it anyway. [`decisions/0019`](decisions/0019-prose-is-a-checked-side.md).
+
 A word after `@` that is none of these — `@eqref(eq:x)`, `@nameref(sec:a)`, `@citeyear(k)` — is not a
 construct. The bytes are transported, which puts them into the PDF as literal text with exit 0, so the
 checker reports the shape as advisory `XT2002` ([`checking.md`](checking.md) §4) and names the commands it
@@ -409,6 +417,9 @@ Fixtures must include:
 9. Every reference command, and a `cref` list, lowering to the command named (`emission/08`).
 10. An `@word(…)` in prose that is no construct, reported as advisory `XT2002`, beside the §3 shapes that
     are ordinary bytes and report nothing (`checking/05`).
+11. `Figure~@ref(tab:main)` on a declared table, reported as `XT1020`, beside a matching word, a plural,
+    an abbreviation, a lower-case word, a word not immediately before, and an unknown-class target, each
+    silent (`checking/07`).
 
 ### Bibliography discovery and citation checking
 

--- a/tests/experiments/0b-error-classes/RESULTS.md
+++ b/tests/experiments/0b-error-classes/RESULTS.md
@@ -1,7 +1,7 @@
 # Stage 0b — what existing tools say about each Class-A defect
 
-Measured 2026-09-01 on macOS (Darwin 25.4.0); the wrong-class pair rebuilt, the clean controls added and
-every row re-measured the same day.
+Measured 2026-09-01 on macOS (Darwin 25.4.0); the wrong-class pair rebuilt, the prose-word pair and the
+clean controls added, and every row re-measured the same day.
 Tools: Tectonic 0.16.9 · ChkTeX v1.7.9 - Copyright 1995-96 Jens T. Berger Thielemann. · texlab 5.26.0 · chklref 3.1.2 · xtex-cli built from the checkout that carries this file.
 Protocol: for each defect class, the minimal LaTeX carrying it (`cases/<name>/main.tex`)
 ran through each tool; the annotated twin (`main.xtex`) ran through `xtex check`. Beside each pair sits
@@ -25,22 +25,28 @@ Failure criterion: four or more already detected as hard error.
 | Missing citation | exit 0, "??" | style note only (`~` spacing) | own report: empty; relays "Citation undefined", which the clean control relays too | ERROR "Undefined reference" | **hard error XT1005**, names the key |
 | Duplicate identifier | exit 0, silent to terminal | silent | own report: empty; relays "Label `sec:x' multiply defined", absent from the clean control | ERROR "Duplicate label" ×2 | **hard error XT1001**, points at the first declaration |
 | Reference prefix demands one class, target declares another (identifier-class mismatch) | **undetected** | **undetected** | **undetected** (relays only the first-pass "undefined", as on the clean control) | **undetected** | **hard error XT1004**: "requires figure, but its target is table", declaration linked |
+| Prose says Figure, target is a table (prose-word mismatch) | **undetected** | **undetected** | **undetected** (relays only the first-pass "undefined", as on the clean control) | **undetected** | **hard error XT1020**: "prose says `Figure` but `tab:main` is a table", declaration linked |
 | Missing figure file | **hard error** (TeX itself) | silent | own report: empty; relays "! Package pdftex.def Error: File not found", absent from the clean control | silent | **hard error XT1006**, before TeX runs |
 | Invalid unit | **hard error** (TeX: "Illegal unit") | silent | own report: empty; relays "! Illegal unit of measure", absent from the clean control | silent | **hard error XT1007**, names the field, lists valid shapes |
 
-The wrong-class pair encodes the defect xtex actually checks. `main.tex` is a table labelled `fig:main` and
-referenced as `Table~\ref{fig:main}`; `main.xtex` is `\table(fig:main)` referenced as `Table~@ref(fig:main)`.
-The prefix `fig:` demands a figure, the declaration is a table, and that contradiction is what `XT1004`
-reports (`docs/decisions/0003`). **A prose-word check — the sentence says "Figure" while the target is a
-table — is not implemented by any tool in this table, xtex included.** An earlier version of this row
-compared two different defects: the `.tex` carried the prose-word mismatch and the `.xtex` carried the
-prefix mismatch.
+Two rows, two defects, each a matched pair. The wrong-class pair encodes the prefix defect: `main.tex` is a
+table labelled `fig:main` and referenced as `Table~\ref{fig:main}`; `main.xtex` is `\table(fig:main)`
+referenced as `Table~@ref(fig:main)`. The prefix `fig:` demands a figure, the declaration is a table, and
+that contradiction is `XT1004` (`docs/decisions/0003`). The prose-word pair encodes the defect the sentence
+makes: `main.tex` is a table labelled `tab:main` and referenced as `Figure~\ref{tab:main}`; `main.xtex` is
+`\table(tab:main)` referenced as `Figure~@ref(tab:main)`. The word says figure, the declaration says table,
+and that contradiction is `XT1020` (`docs/decisions/0019`). An earlier version of this file had one row
+comparing the two defects with each other: the `.tex` carried the prose-word mismatch and the `.xtex` the
+prefix mismatch. When that was corrected, the prose-word defect was caught by no tool in this table, xtex
+included; `XT1020` was then added as a language feature, and this row is its measurement.
 
 ## Clean controls
 
 Each `clean.*` twin is the same document with the defect removed: the reference resolves, the key is in
-`refs.bib`, the labels differ, the prefix matches the declaration, the figure file exists (a 724-byte PDF
-under `figures/`), the unit is `cm`. Expected: zero diagnostics everywhere.
+`refs.bib`, the labels differ, the prefix matches the declaration, the word matches the declaration, the
+figure file exists (a 724-byte PDF under `figures/`), the unit is `cm`. Expected: zero diagnostics
+everywhere. The wrong-class and prose-word controls are the same document — `\table(tab:main)` referenced
+as `Table~@ref(tab:main)` — because removing either defect lands on it.
 
 | Case | tectonic | chktex | chklref | texlab | xtex check |
 |---|---|---|---|---|---|
@@ -48,12 +54,13 @@ under `figures/`), the unit is `cm`. Expected: zero diagnostics everywhere.
 | missing-cite | exit 0 | style note (`~` spacing), the same one as on the defective twin | own report: empty (the uncited `real1984` is not listed either); relays first-pass "Citation `real1984' undefined" | silent | exit 0, no diagnostics |
 | duplicate-label | exit 0 | silent | own report: empty; relays first-pass "undefined" for both labels | silent | exit 0, no diagnostics |
 | wrong-class | exit 0 | silent | own report: empty; relays first-pass "Reference `tab:main' undefined" | silent | exit 0, no diagnostics |
+| prose-word | exit 0 | silent | own report: empty; relays first-pass "Reference `tab:main' undefined" | silent | exit 0, no diagnostics |
 | missing-figure | exit 0 | silent | own report: empty; relays nothing | silent | exit 0, no diagnostics |
 | invalid-unit | exit 0 | silent | own report: empty; relays nothing | silent | exit 0, no diagnostics |
 
 What actually happened, against the expectation of silence: tectonic, texlab and xtex are silent on all
-six. chktex's one note is a spacing style rule that fires on `\cite` with or without the defect. chklref's
-own report is empty on all six, but the engine warnings it relays are not: every clean document that
+seven. chktex's one note is a spacing style rule that fires on `\cite` with or without the defect. chklref's
+own report is empty on all seven, but the engine warnings it relays are not: every clean document that
 contains a `\ref` or `\cite` is reported "undefined" on that single pass, because chklref runs pdflatex
 once with no `.aux` and the engine cannot resolve anything on a first pass. A relayed "undefined" is
 therefore not evidence about the document. The relayed lines that *do* separate defect from control are
@@ -64,8 +71,10 @@ and "Illegal unit".
 
 - **The prediction held on its core claim**: the identifier-class mismatch is invisible
   to every existing tool — it is exactly the check that typed declarations buy. The
-  row now names the defect honestly; the prose-word version of the defect is checked by
-  nobody, xtex included.
+  row names the defect honestly, and the prose-word defect has its own row: invisible to
+  every existing tool as well, and caught by xtex only since `XT1020` made the word before a
+  reference a checked side (`docs/decisions/0019`). Before that, this experiment's own result
+  file had described the prose-word defect as caught when it was not.
 - **The prediction was wrong on one count, recorded as such**: the invalid unit
   is a HARD TeX error, not a soft warning. Hard-error count in existing tools: 2
   (< 4), so the stage's failure criterion is not met.
@@ -81,5 +90,5 @@ and "Illegal unit".
   prints progress notes to the terminal, ships a PDF containing "??", and the
   only trace of the problem is one line inside main.log.
 - **No false positives on the controls** from the two checkers that gate or squiggle: xtex and texlab
-  report nothing on any clean twin. The claim rests on six minimal documents and says nothing about
+  report nothing on any clean twin. The claim rests on seven minimal documents and says nothing about
   larger ones.

--- a/tests/experiments/0b-error-classes/cases/prose-word/clean.tex
+++ b/tests/experiments/0b-error-classes/cases/prose-word/clean.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\begin{document}
+\begin{table}[ht]
+\centering
+\begin{tabular}{c} a \end{tabular}
+\caption{A table}\label{tab:main}
+\end{table}
+Table~\ref{tab:main} shows the layout.
+\end{document}

--- a/tests/experiments/0b-error-classes/cases/prose-word/clean.xtex
+++ b/tests/experiments/0b-error-classes/cases/prose-word/clean.xtex
@@ -1,0 +1,11 @@
+\documentclass{article}
+\begin{document}
+\table(tab:main) {
+  placement = ht
+  caption = {A table}
+  body = {
+    \begin{tabular}{c} a \end{tabular}
+  }
+}
+Table~@ref(tab:main) shows the layout.
+\end{document}

--- a/tests/experiments/0b-error-classes/cases/prose-word/main.tex
+++ b/tests/experiments/0b-error-classes/cases/prose-word/main.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\begin{document}
+\begin{table}[ht]
+\centering
+\begin{tabular}{c} a \end{tabular}
+\caption{A table}\label{tab:main}
+\end{table}
+Figure~\ref{tab:main} shows the layout.
+\end{document}

--- a/tests/experiments/0b-error-classes/cases/prose-word/main.xtex
+++ b/tests/experiments/0b-error-classes/cases/prose-word/main.xtex
@@ -1,0 +1,11 @@
+\documentclass{article}
+\begin{document}
+\table(tab:main) {
+  placement = ht
+  caption = {A table}
+  body = {
+    \begin{tabular}{c} a \end{tabular}
+  }
+}
+Figure~@ref(tab:main) shows the layout.
+\end{document}

--- a/tests/experiments/0b-error-classes/run.sh
+++ b/tests/experiments/0b-error-classes/run.sh
@@ -12,7 +12,7 @@ set -uo pipefail
 stem="${1:-main}"
 cd "$(dirname "$0")/cases"
 xtex="$(cd ../../../.. && pwd)/target/debug/xtex"
-for case in broken-ref missing-cite duplicate-label wrong-class missing-figure invalid-unit; do
+for case in broken-ref missing-cite duplicate-label wrong-class prose-word missing-figure invalid-unit; do
   echo "=== $case ($stem)"
   cd "$case"
   # tectonic: exit code + errors/warnings in output

--- a/tests/fixtures/checking/07-prose-word-class/checked.txt
+++ b/tests/fixtures/checking/07-prose-word-class/checked.txt
@@ -1,0 +1,3 @@
+XT1020|figure|tab:a|32|6|prose says `Figure` but `tab:a` is a table
+XT1020|figure|tab:a|69|5|prose says `Figs.` but `tab:a` is a table
+XT1020|figure|tab:a|69|5|prose says `Figs.` but `tab:a` is a table

--- a/tests/fixtures/checking/07-prose-word-class/expect.txt
+++ b/tests/fixtures/checking/07-prose-word-class/expect.txt
@@ -1,0 +1,7 @@
+transport: lowered
+scanner: table ref ref ref ref ref id ref
+constructs: one table, one `@id` on unmodelled LaTeX and six references.
+  `Figure~@ref(tab:a)` and each name of `Figs.~@cref(tab:a, tab:a)` contradict
+  the table and are XT1020 at the word; the matching word, the lower-case word,
+  the word not immediately before, and the word before the unknown-open target
+  are silent

--- a/tests/fixtures/checking/07-prose-word-class/input.xtex
+++ b/tests/fixtures/checking/07-prose-word-class/input.xtex
@@ -1,0 +1,4 @@
+\table(tab:a) { caption = {A} }
+Figure~@ref(tab:a) Table~@ref(tab:a) Figs.~@cref(tab:a, tab:a) figure~@ref(tab:a)
+Figure 3 and @ref(tab:a) \newtheorem{X}{Open}
+@id(tab:open) Figure~@ref(tab:open)


### PR DESCRIPTION
Fixes #150

## What changes

**XT1020 — the word before a reference is a checked side.** `Reference` carries the entity-kind word written immediately before the construct (`symbols::prose_word_before`: nothing, one space, or tildes between them; the byte before the word is not a letter). `SymbolTable::prose_mismatches` yields references whose word's class contradicts the target's *known* class, and `check_with_labels` reports each as `XT1020`, error, at the word, with "table declared here" linked. Both sides known or silence, mirroring XT1004: a `\label` target, an `@id` on unmodelled LaTeX, a lower-case word, a word not immediately before, or no word never fires. Plurals and abbreviations map to the class (eighteen words, fixed). A `cref`-family reference is read only when a word precedes it; a list gets the word for every name. XT1004 and XT1020 are two facts and may both fire on `Figure~@ref(fig:main)` pointing at a table.

Since `check_with_labels` answers the CLI, the LSP and the WebAssembly build, all three surfaces carry it by construction; the parity suite's failure-path project now includes the mismatch and asserts both builds report it, and an LSP protocol test asserts it is published as an error.

**Decision record** `docs/decisions/0019-prose-is-a-checked-side.md`: why prose participates (bound to an explicit construct, both sides declared, silent everywhere else — 0b's measurement), the rejected alternatives (word after the reference, configurable vocabulary, advisory), and what would reverse it. Docs: grammar §4 and fixture list, checking §2 (second demand) and §3 (table row), README flagship paragraph.

**Stage 0b**: new `cases/prose-word/` matched pair (`\label{tab:main}` + `Figure~\ref{tab:main}` vs `\table(tab:main)` + `Figure~@ref(tab:main)`) with a clean control; run.sh includes it; RESULTS.md has both honest rows, the clean-control row, and a reading that says the prose-word defect was caught by nothing until XT1020 existed, and that the earlier results file had described it as caught when it was not.

## Honest limitations

- The vocabulary is fixed and English. A document whose prose uses another word ("Listing", "Theorem", "Panel") or another language is not read, and a class the symbol table cannot assign has no word by design.
- Only the word *before* the reference is read. `@ref(x) shows the figure` is not bound and not checked.
- `Figure~@ref(x)` where `x` is only a `\label` stays silent: the on-ramp rule (a `\label` supplies no class) wins over the new check, as documented.

## Test plan

```
cargo test --workspace -- --nocapture   → exit 0, 0 lines matching ^skipped:
cargo clippy --workspace --all-targets -- -D warnings   → clean
cargo fmt --all --check   → clean
cargo test --manifest-path crates/xtex-verify/Cargo.toml   → 12 passed
cargo clippy --manifest-path crates/xtex-verify/Cargo.toml --all-targets -- -D warnings   → clean
```

Unit tests in `symbols.rs` (positive with the three bindings, negative, plural, abbreviation, cref list, unknown-open target with the declaration asserted `UnknownOpen`, `\label` target, no-word / not-immediately-before / lower-case / `Subfigure` / comment / `\emph{Figure}` / bare `@cref`), in `check.rs` (message, span at the word, related entry; XT1004 and XT1020 both firing), fixture `checking/07-prose-word-class`, wasm parity failure-path assertion, LSP protocol test.

Stage 0b re-run (`run.sh main`, `run.sh clean`, texlab probes): the new row's xtex output

```
error[XT1020]: prose says `Figure` but `tab:main` is a table
  --> main.xtex:10:1
  entity: figure
  name: tab:main
  --> main.xtex:3:8: table declared here
```

and every other row byte-identical to the run recorded in #149.
