### PR TITLE
Five defects the corpus campaign found, each with its reproducer

### DIFF
--- a/crates/xtex-core/src/bibliography.rs
+++ b/crates/xtex-core/src/bibliography.rs
@@ -535,7 +535,7 @@ fn scan_bib_entries(bytes: &[u8]) -> Result<Vec<(String, Span)>, String> {
                 continue;
             }
         };
-        let entry_line = line_at(bytes, cursor);
+        let entry_open = cursor;
         cursor += 1;
         // `@comment` is the one entry type BibTeX does not read. It skips to the
         // next `@` and resumes there, so an unbalanced brace inside a comment is
@@ -553,7 +553,7 @@ fn scan_bib_entries(bytes: &[u8]) -> Result<Vec<(String, Span)>, String> {
             cursor,
             opener.0,
             opener.1,
-            entry_line,
+            entry_open,
             entry_type == b"preamble",
         )?;
         let key_start = skip_space(bytes, cursor);
@@ -577,24 +577,29 @@ fn scan_bib_entries(bytes: &[u8]) -> Result<Vec<(String, Span)>, String> {
     Ok(keys)
 }
 
+/// Offsets are remembered and lines computed only on the error path. Each
+/// `line_at` walks the file from its start, and computing one per opening
+/// brace made reading a bibliography cost entries × braces × bytes — sixty
+/// seconds on a 1.6 MB file with 2,313 entries (arXiv 2212.13773, corpus
+/// E1), paid by every check of a document that merely declared it.
 fn entry_end(
     bytes: &[u8],
     mut at: usize,
     open: u8,
     close: u8,
-    entry_line: usize,
+    entry_open: usize,
     mut value_position: bool,
 ) -> Result<usize, String> {
-    let mut braces = Vec::new();
-    let mut quote = None;
+    let mut braces: Vec<usize> = Vec::new();
+    let mut quote: Option<usize> = None;
     while let Some(&byte) = bytes.get(at) {
         if quote.is_some() && byte == b'"' && braces.is_empty() {
             quote = None;
         } else if quote.is_none() && value_position && byte == b'"' && braces.is_empty() {
-            quote = Some(line_at(bytes, at));
+            quote = Some(at);
             value_position = false;
         } else if byte == b'{' {
-            braces.push(line_at(bytes, at));
+            braces.push(at);
         } else if byte == b'}' && !braces.is_empty() {
             braces.pop();
         } else if byte == close && braces.is_empty() && quote.is_none() {
@@ -608,16 +613,21 @@ fn entry_end(
         }
         at += 1;
     }
-    if let Some(line) = quote {
+    if let Some(offset) = quote {
         Err(format!(
-            "a quoted value opened at line {line} is never closed"
+            "a quoted value opened at line {} is never closed",
+            line_at(bytes, offset)
         ))
-    } else if let Some(line) = braces.first() {
-        Err(format!("a value opened at line {line} is never closed"))
+    } else if let Some(offset) = braces.first() {
+        Err(format!(
+            "a value opened at line {} is never closed",
+            line_at(bytes, *offset)
+        ))
     } else {
         let delimiter = char::from(open);
         Err(format!(
-            "an entry delimiter `{delimiter}` opened at line {entry_line} is never closed"
+            "an entry delimiter `{delimiter}` opened at line {} is never closed",
+            line_at(bytes, entry_open)
         ))
     }
 }
@@ -866,6 +876,35 @@ mod tests {
         assert_eq!(
             keys.iter().map(String::as_str).collect::<Vec<_>>(),
             ["real"]
+        );
+    }
+
+    #[test]
+    fn reading_a_large_bibliography_is_linear_in_its_size() {
+        use std::fmt::Write as _;
+        // The E1 reproducer: 2,313 entries and 1.6 MB took sixty seconds
+        // because a line number was computed per opening brace. Five
+        // thousand entries of a realistic size must read in a small
+        // fraction of that; the bound is loose enough for a slow runner and
+        // tight enough that the quadratic version cannot pass it.
+        let abstract_text =
+            "This is a filler sentence that makes the entry about as long as a real one. "
+                .repeat(7);
+        let mut bib = String::new();
+        for i in 0..5_000 {
+            let _ = write!(
+                bib,
+                "@article{{k{i},\n  author = {{Author {i}}},\n  title = {{Title {{{i}}}}},\n  journal = {{J}},\n  year = {{2020}},\n  abstract = {{{abstract_text}}}\n}}\n\n"
+            );
+        }
+        assert!(bib.len() > 3_000_000, "{}", bib.len());
+        let started = std::time::Instant::now();
+        let keys = keys_in_bib(bib.as_bytes()).expect("a valid bibliography");
+        let elapsed = started.elapsed();
+        assert_eq!(keys.len(), 5_000);
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "reading 5,000 entries took {elapsed:?}"
         );
     }
 

--- a/crates/xtex-core/src/check.rs
+++ b/crates/xtex-core/src/check.rs
@@ -654,6 +654,27 @@ mod label_tests {
     }
 
     #[test]
+    fn a_reference_to_a_label_inside_a_display_body_resolves() {
+        assert!(
+            diagnose("\\begin{align} y &= 2 \\label{eq:b} \\end{align}\nSee @ref(eq:b).")
+                .is_empty()
+        );
+        assert!(diagnose("\\[ w \\label{eq:d} \\] See @ref(eq:d).").is_empty());
+    }
+
+    #[test]
+    fn an_id_inside_a_display_body_declares_an_equation_for_its_references() {
+        assert!(
+            diagnose("\\begin{align} y &= 2 @id(eq:b) \\end{align}\nSee @ref(eq:b).").is_empty()
+        );
+        // And the class is known: a figure prefix on it is XT1004.
+        assert_eq!(
+            diagnose("\\begin{equation} y @id(fig:b) \\end{equation}\nSee @ref(fig:b)."),
+            ["fig:b"]
+        );
+    }
+
+    #[test]
     fn a_reference_to_nothing_still_fails() {
         // The fix widened what resolves. It must not have weakened what fails.
         assert_eq!(

--- a/crates/xtex-core/src/labels.rs
+++ b/crates/xtex-core/src/labels.rs
@@ -183,6 +183,31 @@ mod tests {
     }
 
     #[test]
+    fn labels_inside_display_bodies_and_captions_are_declarations() {
+        // Where equations and floats are actually labelled: before
+        // `\end{align}`, inside `\[ \]`, inside the caption, in the float
+        // body. Corpus E2 found 17 references to such labels reported as
+        // undeclared across 6 papers.
+        let text = "\\begin{equation} x = 1 \\label{eq:a} \\end{equation}\n\
+                    \\begin{align} y &= 2 \\label{eq:b} \\\\ z &= 3 \\label{eq:c} \\end{align}\n\
+                    \\[ w = 4 \\label{eq:d} \\]\n\
+                    \\begin{figure}\\caption{A figure \\label{fig:in}}\\label{fig:out}\\end{figure}\n";
+        let found = built(text);
+        for name in ["eq:a", "eq:b", "eq:c", "eq:d", "fig:in", "fig:out"] {
+            assert!(found.contains(name), "{name} missing from {found:?}");
+        }
+    }
+
+    #[test]
+    fn labels_inside_comments_verbatim_and_inline_math_declare_nothing() {
+        let text = "% \\label{c}\n\\begin{verbatim}\n\\label{v}\n\\end{verbatim}\n$\\label{m}$\n\\newcommand{\\x}{\\label{d}}\n";
+        let found = built(text);
+        for name in ["c", "v", "m", "d"] {
+            assert!(!found.contains(name), "{name} declared by {found:?}");
+        }
+    }
+
+    #[test]
     fn a_computed_label_option_makes_the_inventory_unavailable() {
         // What cannot be read might declare a label, so nothing may be called
         // absent. The same all-or-nothing rule as the bibliography.

--- a/crates/xtex-core/src/lib.rs
+++ b/crates/xtex-core/src/lib.rs
@@ -272,11 +272,31 @@ fn emit_nodes(
                 end: span.end(),
             })?;
         match node {
-            Node::Construct { kind, .. } => emit_construct(*kind, bytes, view, out),
+            Node::Construct { kind, .. } => {
+                let base = sources
+                    .get(node.source())
+                    .map_or(&[][..], |source| directory_of(source.name().as_bytes()));
+                emit_construct(*kind, bytes, base, view, out);
+            }
             Node::Opaque { .. } | Node::Malformed { .. } => out.extend_from_slice(bytes),
         }
     }
     Ok(())
+}
+
+/// The directory part of a source name, with its trailing `/`, or nothing
+/// for a name at the root.
+///
+/// Source names are root-relative — `sections/intro.xtex` — and an
+/// `@import` inside that file resolves relative to it. TeX resolves the
+/// emitted `\input` from the root's directory instead, so the emitter has
+/// to put the directory back: `@import("nested.xtex")` in `sections/intro`
+/// emits `\input{sections/nested.tex}`. Emitting the path as written
+/// produced an `\input` that LaTeX could not find (corpus E2).
+fn directory_of(name: &[u8]) -> &[u8] {
+    name.iter()
+        .rposition(|byte| *byte == b'/')
+        .map_or(&[][..], |slash| &name[..=slash])
 }
 
 fn documentclass_end(bytes: &[u8]) -> Option<usize> {
@@ -314,7 +334,13 @@ fn documentclass_end(bytes: &[u8]) -> Option<usize> {
     )
 }
 
-fn emit_construct(kind: EntryToken, bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
+fn emit_construct(
+    kind: EntryToken,
+    bytes: &[u8],
+    base: &[u8],
+    view: RevisionView,
+    out: &mut Vec<u8>,
+) {
     match kind {
         EntryToken::Id => emit_inline(bytes, b"\\label{", out),
         // A reference or citation construct is the LaTeX command it names,
@@ -335,19 +361,25 @@ fn emit_construct(kind: EntryToken, bytes: &[u8], view: RevisionView, out: &mut 
             }
             out.push(b'}');
         }
-        EntryToken::Import => emit_import(bytes, view, out),
+        EntryToken::Import => emit_import(bytes, base, view, out),
         EntryToken::Add | EntryToken::Del | EntryToken::Sub | EntryToken::Note => {
-            emit_revision(kind, bytes, view, out);
+            emit_revision(kind, bytes, base, view, out);
         }
         EntryToken::Raw => {
             let open = bytes.iter().position(|byte| *byte == b'{').unwrap_or(0);
             out.extend_from_slice(&bytes[open + 1..bytes.len() - 1]);
         }
-        EntryToken::Figure | EntryToken::Table => emit_block(kind, bytes, view, out),
+        EntryToken::Figure | EntryToken::Table => emit_block(kind, bytes, base, view, out),
     }
 }
 
-fn emit_revision(kind: EntryToken, bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
+fn emit_revision(
+    kind: EntryToken,
+    bytes: &[u8],
+    base: &[u8],
+    view: RevisionView,
+    out: &mut Vec<u8>,
+) {
     let Some(open) = bytes.iter().position(|byte| *byte == b'{') else {
         return;
     };
@@ -364,24 +396,24 @@ fn emit_revision(kind: EntryToken, bytes: &[u8], view: RevisionView, out: &mut V
     match (kind, view) {
         (EntryToken::Add, RevisionView::Final)
         | (EntryToken::Del | EntryToken::Sub, RevisionView::Original) => {
-            emit_fragment(left, view, out);
+            emit_content(left, base, view, out);
         }
-        (EntryToken::Sub, RevisionView::Final) => emit_fragment(right, view, out),
+        (EntryToken::Sub, RevisionView::Final) => emit_content(right, base, view, out),
         (EntryToken::Add, RevisionView::Marked) => {
             out.extend_from_slice(b"\\textcolor{blue}{");
-            emit_fragment(left, view, out);
+            emit_content(left, base, view, out);
             out.push(b'}');
         }
         (EntryToken::Del, RevisionView::Marked) => {
             out.extend_from_slice(b"\\textcolor{red}{\\sout{");
-            emit_fragment(left, view, out);
+            emit_content(left, base, view, out);
             out.extend_from_slice(b"}}");
         }
         (EntryToken::Sub, RevisionView::Marked) => {
             out.extend_from_slice(b"\\textcolor{red}{\\sout{");
-            emit_fragment(left, view, out);
+            emit_content(left, base, view, out);
             out.extend_from_slice(b"}}\\textcolor{blue}{");
-            emit_fragment(right, view, out);
+            emit_content(right, base, view, out);
             out.push(b'}');
         }
         _ => {}
@@ -402,11 +434,7 @@ fn trim_end(mut bytes: &[u8]) -> &[u8] {
     bytes
 }
 
-fn emit_fragment(bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
-    emit_content(bytes, view, out);
-}
-
-fn emit_content(bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
+fn emit_content(bytes: &[u8], base: &[u8], view: RevisionView, out: &mut Vec<u8>) {
     let mut covered_until = 0usize;
     for piece in scanner::scan(bytes) {
         let piece_span = match piece {
@@ -423,7 +451,7 @@ fn emit_content(bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
         covered_until = piece_span.end();
         let fragment = &bytes[piece_span.start()..piece_span.end()];
         match piece {
-            Piece::Construct { kind, .. } => emit_construct(kind, fragment, view, out),
+            Piece::Construct { kind, .. } => emit_construct(kind, fragment, base, view, out),
             // A quarantined region is transported like any other opaque one.
             // Giving up on recognising it never changes a byte of it.
             Piece::Text(_)
@@ -463,13 +491,14 @@ fn emit_keys(keys: &[u8], out: &mut Vec<u8>) {
     }
 }
 
-fn emit_import(bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
+fn emit_import(bytes: &[u8], base: &[u8], view: RevisionView, out: &mut Vec<u8>) {
     let first_quote = bytes.iter().position(|byte| *byte == b'"').unwrap_or(0);
     let last_quote = bytes
         .iter()
         .rposition(|byte| *byte == b'"')
         .unwrap_or(first_quote);
     out.extend_from_slice(b"\\input{");
+    out.extend_from_slice(base);
     let path = &bytes[first_quote + 1..last_quote];
     let stem = path.strip_suffix(b".xtex").unwrap_or(path);
     out.extend_from_slice(stem);
@@ -480,7 +509,7 @@ fn emit_import(bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
     }
 }
 
-fn emit_block(token: EntryToken, bytes: &[u8], view: RevisionView, out: &mut Vec<u8>) {
+fn emit_block(token: EntryToken, bytes: &[u8], base: &[u8], view: RevisionView, out: &mut Vec<u8>) {
     let (kind, entry_len, environment) = match token {
         EntryToken::Figure => (BlockKind::Figure, b"\\figure(".len(), b"figure".as_slice()),
         EntryToken::Table => (BlockKind::Table, b"\\table(".len(), b"table".as_slice()),
@@ -553,15 +582,15 @@ fn emit_block(token: EntryToken, bytes: &[u8], view: RevisionView, out: &mut Vec
     }
     if let Some(caption) = field(b"caption") {
         out.extend_from_slice(b"  \\caption{");
-        emit_braced_content(bytes, caption.value, view, out);
+        emit_braced_content(bytes, caption.value, base, view, out);
         out.extend_from_slice(b"}\n");
     }
     if let Some(body) = field(b"body") {
-        emit_braced_content(bytes, body.value, view, out);
+        emit_braced_content(bytes, body.value, base, view, out);
         out.push(b'\n');
     }
     if let Some(trailing) = field(b"trailing") {
-        emit_braced_content(bytes, trailing.value, view, out);
+        emit_braced_content(bytes, trailing.value, base, view, out);
         out.push(b'\n');
     }
     out.extend_from_slice(b"  \\label{");
@@ -571,9 +600,15 @@ fn emit_block(token: EntryToken, bytes: &[u8], view: RevisionView, out: &mut Vec
     out.push(b'}');
 }
 
-fn emit_braced_content(bytes: &[u8], value: Value, view: RevisionView, out: &mut Vec<u8>) {
+fn emit_braced_content(
+    bytes: &[u8],
+    value: Value,
+    base: &[u8],
+    view: RevisionView,
+    out: &mut Vec<u8>,
+) {
     let span = value.span();
-    emit_content(&bytes[span.start() + 1..span.end() - 1], view, out);
+    emit_content(&bytes[span.start() + 1..span.end() - 1], base, view, out);
 }
 
 fn emit_percentage(bytes: &[u8], span: source::Span, out: &mut Vec<u8>) {
@@ -731,6 +766,32 @@ mod tests {
     /// Bytes chosen to break anything that decodes, normalises or re-encodes:
     /// a lone `0xFF`, Latin-1 text, a CRLF, a trailing tab and no final newline.
     const AWKWARD: &[u8] = b"\\section{Caf\xE9}\r\n%% comment\t\n\\ref{a}\xFF  ";
+
+    #[test]
+    fn a_nested_import_emits_the_path_tex_resolves_from_the_root() {
+        // `sections/intro.xtex` importing `nested.xtex` finds
+        // `sections/nested.xtex`; the emitted `\input` must say so, because
+        // TeX resolves it from the root's directory, not the file's.
+        let mut sources = Sources::new();
+        let id = sources.add(
+            "sections/intro.xtex",
+            b"\\section{S}\n@import(\"nested.xtex\")\n@add(c) {@import(\"deeper/x.xtex\")}"
+                .to_vec(),
+        );
+        let document = parse(&sources, id);
+        let mut out = Vec::new();
+        emit(&sources, &document, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("\\input{sections/nested.tex}"), "{text}");
+        assert!(text.contains("\\input{sections/deeper/x.tex}"), "{text}");
+
+        // A root-level file gains no prefix.
+        let root = sources.add("main.xtex", b"@import(\"sections/intro.xtex\")".to_vec());
+        let document = parse(&sources, root);
+        let mut out = Vec::new();
+        emit(&sources, &document, &mut out).unwrap();
+        assert_eq!(out, b"\\input{sections/intro.tex}");
+    }
 
     #[test]
     fn untouched_latex_comes_out_byte_identical() {

--- a/crates/xtex-core/src/project.rs
+++ b/crates/xtex-core/src/project.rs
@@ -150,7 +150,6 @@ fn check_project_inner(
             continue;
         }
         let document = parse(&sources, id);
-        table.merge(&sources, &document);
         match crate::labels::inventory(&sources, &document, id) {
             crate::labels::Inventory::Complete(found) => labels.extend(found),
             // One file that went dark makes the root's inventory a subset, and
@@ -200,6 +199,8 @@ fn check_project_inner(
         }
         documents.push(document);
     }
+
+    merge_all(&mut table, &sources, &documents);
 
     let bibliography = assemble(&declared, |name| loader.read_aux(root, name));
     // The author's own `\label` commands resolve `@ref` too, so annotating a
@@ -381,6 +382,69 @@ pub fn literal_import(
         .flatten()
 }
 
+/// Merges every document into one table, after all are loaded: a file
+/// imported after `\appendix` begins in the appendices, and only its
+/// importer can say so.
+fn merge_all(table: &mut SymbolTable, sources: &Sources, documents: &[crate::document::Document]) {
+    let in_appendix = appendix_flags(sources, documents);
+    for document in documents {
+        table.merge_from(sources, document, in_appendix.contains(&document.source()));
+    }
+}
+
+/// The documents that begin inside the appendices: those imported after
+/// `\appendix` in their importer, or by a document that itself began there.
+///
+/// `documents` are in load order, importer before imported, so one pass
+/// settles every file. An import is matched to its document by the
+/// root-relative name the loader gave it — the importer's directory joined
+/// with the literal path — and a path that matches nothing (a computed one,
+/// or one that failed to load) marks nothing.
+#[must_use]
+pub fn appendix_flags(
+    sources: &Sources,
+    documents: &[crate::document::Document],
+) -> BTreeSet<SourceId> {
+    let mut flagged = BTreeSet::new();
+    for document in documents {
+        let id = document.source();
+        let Some(source) = sources.get(id) else {
+            continue;
+        };
+        let switch = if flagged.contains(&id) {
+            Some(0)
+        } else {
+            crate::symbols::appendix_switch_at(source.bytes())
+        };
+        let Some(switch) = switch else {
+            continue;
+        };
+        let directory = source
+            .name()
+            .rfind('/')
+            .map_or("", |slash| &source.name()[..=slash]);
+        let mut after = Vec::new();
+        document.walk(|node| {
+            if let Node::Construct {
+                kind: EntryToken::Import,
+                span,
+                ..
+            } = node
+                && span.start() > switch
+                && let Some(path) = literal_import(sources, id, *span)
+            {
+                after.push(format!("{directory}{path}"));
+            }
+        });
+        for name in after {
+            if let Some(imported) = sources.iter().find(|s| s.name() == name) {
+                flagged.insert(imported.id());
+            }
+        }
+    }
+    flagged
+}
+
 fn merge_declared(target: &mut Declared, found: Declared) {
     target.resources.extend(found.resources);
     target.inline_keys.extend(found.inline_keys);
@@ -502,15 +566,61 @@ pub struct Analysed {
 pub fn analyse(loader: &impl SourceLoader, root: &str) -> Result<Analysed, IoError> {
     let (sources, documents, names) = load_imports(loader, root)?;
     let mut table = SymbolTable::new();
-    for document in &documents {
-        table.merge(&sources, document);
-    }
+    merge_all(&mut table, &sources, &documents);
     Ok(Analysed {
         sources,
         documents,
         names,
         table,
     })
+}
+
+#[cfg(test)]
+mod appendix_tests {
+    use super::*;
+    use crate::io::Memory;
+
+    fn codes(files: &[(&str, &str)]) -> Vec<String> {
+        let mut store = Memory::new();
+        for (name, text) in files {
+            store = store.with_input(*name, text.as_bytes().to_vec());
+        }
+        let (_, diagnostics, _, _) =
+            check_project(&store, "main.xtex", crate::symbols::PrefixMap::default())
+                .expect("loads");
+        diagnostics
+            .iter()
+            .map(|d| format!("{} {}", d.code, d.name.as_deref().unwrap_or("-")))
+            .collect()
+    }
+
+    #[test]
+    fn a_file_imported_after_the_appendix_switch_declares_appendices() {
+        // The corpus shape: `\appendix` in the root, the appendices in their
+        // own files, `app:` labels on their sections. Correct, and it must
+        // check clean; the same file imported before the switch is not.
+        let after = codes(&[
+            (
+                "main.xtex",
+                "\\section{A}@id(sec:a)\n\\appendix\n@import(\"back/app.xtex\")\n@ref(app:b) @ref(app:c)\n",
+            ),
+            (
+                "back/app.xtex",
+                "\\section{B}@id(app:b)\n@import(\"more.xtex\")\n",
+            ),
+            ("back/more.xtex", "\\subsection{C}@id(app:c)\n"),
+        ]);
+        assert!(after.is_empty(), "{after:?}");
+
+        let before = codes(&[
+            (
+                "main.xtex",
+                "@import(\"back/app.xtex\")\n\\appendix\n@ref(app:b)\n",
+            ),
+            ("back/app.xtex", "\\section{B}@id(app:b)\n"),
+        ]);
+        assert_eq!(before, ["XT1004 app:b"]);
+    }
 }
 
 #[cfg(test)]

--- a/crates/xtex-core/src/scanner/mod.rs
+++ b/crates/xtex-core/src/scanner/mod.rs
@@ -27,7 +27,8 @@ mod tests;
 
 pub use boundaries::{CommentRule, balanced_end, balanced_end_with};
 pub use queries::{construct_shaped_text, split_keys};
-pub use queries::{listing_header_labels, readable_content, readable_for, substitution_separator};
+pub use queries::{is_display_math_region, readable_content};
+pub use queries::{listing_header_labels, readable_for, substitution_separator};
 pub use tables::{
     DEFAULT_CITE_COMMANDS, DEFAULT_REF_COMMANDS, DEFAULT_VERBATIM_ENVIRONMENTS,
     DEFINITION_COMMANDS, LIST_REF_COMMANDS,
@@ -249,7 +250,10 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                     && at == *start
                 {
                     enter!(at);
-                    region = Region::Environment { name: name.clone() };
+                    region = Region::Environment {
+                        name: name.clone(),
+                        math: true,
+                    };
                     display_opening = None;
                     continue;
                 }
@@ -414,6 +418,11 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
             }
 
             Region::DisplayMath { dollars } => {
+                if let Some(resume) = display_body_id(bytes, at, excluded_start, &mut pieces) {
+                    at = resume;
+                    excluded_start = at;
+                    continue;
+                }
                 if *dollars {
                     if bytes[at] == b'$'
                         && !is_escaped(bytes, at)
@@ -445,7 +454,14 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
                 }
             }
 
-            Region::Environment { name } => {
+            Region::Environment { name, math } => {
+                if *math
+                    && let Some(resume) = display_body_id(bytes, at, excluded_start, &mut pieces)
+                {
+                    at = resume;
+                    excluded_start = at;
+                    continue;
+                }
                 if let Some(end) = environment_end(bytes, at, name) {
                     at = end;
                     pieces.push(Piece::Excluded(span(excluded_start, at)));
@@ -566,6 +582,32 @@ pub fn scan(bytes: &[u8]) -> Vec<Piece> {
     }
 
     pieces
+}
+
+/// An `@id(…)` inside a display-math body, if one starts at `at`.
+///
+/// The bytes before it become their own excluded piece, the construct is
+/// recognised, and scanning resumes after it with the region unchanged.
+/// Only `@id`: a reference or citation inside a formula stays formula.
+fn display_body_id(
+    bytes: &[u8],
+    at: usize,
+    excluded_start: usize,
+    pieces: &mut Vec<Piece>,
+) -> Option<usize> {
+    let (EntryToken::Id, after_open) = entry_token_at(bytes, at)? else {
+        return None;
+    };
+    let close = close_paren(bytes, after_open)?;
+    if at > excluded_start {
+        pieces.push(Piece::Excluded(span(excluded_start, at)));
+    }
+    pieces.push(Piece::Construct {
+        kind: EntryToken::Id,
+        span: span(at, close + 1),
+        children: Vec::new(),
+    });
+    Some(close + 1)
 }
 
 fn block_children(bytes: &[u8], block: &crate::blocks::Block) -> Vec<Piece> {

--- a/crates/xtex-core/src/scanner/queries.rs
+++ b/crates/xtex-core/src/scanner/queries.rs
@@ -2,7 +2,7 @@
 
 use super::boundaries::{balanced_end, is_escaped};
 use super::regions::{Extent, command_extent};
-use super::tables::{DEFINITION_COMMANDS, looks_like_a_construct_word};
+use super::tables::{DEFINITION_COMMANDS, DISPLAY_MATH_ENVIRONMENTS, looks_like_a_construct_word};
 use super::{EntryToken, Piece, scan};
 use crate::source::Span;
 
@@ -37,18 +37,59 @@ pub fn readable_for(bytes: &[u8], commands: &[&str]) -> Vec<Span> {
     spans
 }
 
+/// Whether a region is a display-math body: it opens with `\[`, `$$` or the
+/// `\begin{…}` of a display environment, or it closes with that
+/// environment's `\end{…}`.
+///
+/// Both ends are checked because the scanner's excluded piece for an
+/// environment begins after the header slot (grammar §4) and so does not
+/// carry its own `\begin`; it does carry the `\end`.
+#[must_use]
+pub fn is_display_math_region(region: &[u8]) -> bool {
+    if region.starts_with(b"\\[") || region.starts_with(b"$$") {
+        return true;
+    }
+    if let Some(rest) = region.strip_prefix(b"\\begin{")
+        && let Some(close) = rest.iter().position(|byte| *byte == b'}')
+        && is_display_math_name(&rest[..close])
+    {
+        return true;
+    }
+    let Some(open) = region
+        .windows(b"\\end{".len())
+        .rposition(|w| w == b"\\end{")
+    else {
+        return false;
+    };
+    region.ends_with(b"}")
+        && is_display_math_name(&region[open + b"\\end{".len()..region.len() - 1])
+}
+
+fn is_display_math_name(name: &[u8]) -> bool {
+    DISPLAY_MATH_ENVIRONMENTS
+        .iter()
+        .any(|(known, _)| known.as_bytes() == name)
+}
+
 /// Regions holding content a reader may search.
 ///
-/// Prose, plus every excluded region except a definition's. A command's
-/// arguments are an exclusion region so that *constructs* are not recognised
-/// there; a reader looking for the author's own `\label` is asking a different
-/// question, and the answer differs only for definitions.
+/// Prose, plus every excluded region except a definition's, plus display-math
+/// bodies. A command's arguments are an exclusion region so that *constructs*
+/// are not recognised there; a reader looking for the author's own `\label`
+/// is asking a different question, and the answer differs only for
+/// definitions. A display body is excluded for the same reason and read for
+/// the same one: `\label{eq:x}` before `\end{align}` is where equations are
+/// labelled, and an inventory that skipped it called correct references
+/// undeclared (corpus E2, 17 labels in 6 papers).
 #[must_use]
 pub fn readable_content(bytes: &[u8]) -> Vec<Span> {
     let mut spans = Vec::new();
     for piece in scan(bytes) {
         match piece {
             Piece::Text(span) => spans.push(span),
+            Piece::Excluded(span) if is_display_math_region(&bytes[span.start()..span.end()]) => {
+                spans.push(span);
+            }
             Piece::Arguments(span) => {
                 let region = &bytes[span.start()..span.end()];
                 let defines = region.strip_prefix(b"\\").is_some_and(|rest| {

--- a/crates/xtex-core/src/scanner/regions.rs
+++ b/crates/xtex-core/src/scanner/regions.rs
@@ -30,7 +30,12 @@ pub(crate) enum Region {
     /// From a verbatim command plus a delimiter byte to its next occurrence.
     Verb { delimiter: u8 },
     /// An environment body whose bytes are copied through its matching end.
-    Environment { name: Vec<u8> },
+    ///
+    /// `math` marks a display-math body, inside which `@id(` is still
+    /// recognised — an equation is labelled from inside its own body far
+    /// more often than from the header slot (17 such labels across 6 papers
+    /// in corpus E2). A verbatim body recognises nothing.
+    Environment { name: Vec<u8>, math: bool },
     /// From `\makeatletter` to `\makeatother`.
     InternalMacros,
     /// From `\csname` to `\endcsname`.
@@ -188,6 +193,25 @@ pub(crate) fn command_extent(bytes: &[u8], at: usize) -> Extent {
     let name = &bytes[name_start..name_end];
     let mut cursor = name_end;
 
+    // `\newif\iffoo` *defines* a conditional; the `\iffoo` after it opens
+    // nothing and has no `\fi`. Read as an opener it quarantined the rest of
+    // the file — the TACL template does this at line 52, and every construct
+    // after it went dark with exit 0 (arXiv 2301.00303, corpus E2). The
+    // defined name is claimed here as the command's argument.
+    if name == b"newif" {
+        let next = skip_ascii_whitespace(bytes, cursor);
+        if bytes.get(next) == Some(&b'\\') {
+            let mut end = next + 1;
+            while bytes.get(end).is_some_and(u8::is_ascii_alphabetic) {
+                end += 1;
+            }
+            if end > next + 1 {
+                return Extent::Through(end);
+            }
+        }
+        return Extent::Through(cursor);
+    }
+
     if let Some(signature) = signature_of(name) {
         // A signature is a claim about this call, and the call can refute it.
         // 15 of the built-in commands carry a different signature under another
@@ -326,6 +350,7 @@ pub(crate) fn region_opening_at(bytes: &[u8], at: usize) -> Option<(Region, usiz
                     return Some((
                         Region::Environment {
                             name: name.to_vec(),
+                            math: false,
                         },
                         consumed,
                     ));

--- a/crates/xtex-core/src/scanner/tests.rs
+++ b/crates/xtex-core/src/scanner/tests.rs
@@ -140,14 +140,16 @@ fn math_hides_a_construct_and_prose_after_it_does_not() {
 
 #[test]
 fn display_math_environments_hide_commands_and_constructs() {
+    // Every construct but `@id`: an equation is labelled from inside its
+    // body, so the declaration is recognised there and nothing else is.
     for (name, signature) in DISPLAY_MATH_ENVIRONMENTS {
         let argument = if signature.is_empty() { "" } else { "{2}" };
         let input = format!(
-            "\\begin{{{name}}}{argument} X \\in [A,B) @id(hidden) @ref(hidden) \\bigg \\end{{{name}}} @ref(after)"
+            "\\begin{{{name}}}{argument} X \\in [A,B) @id(inside) @ref(hidden) \\bigg \\end{{{name}}} @ref(after)"
         );
         assert_eq!(
             constructs(input.as_bytes()),
-            [EntryToken::Ref],
+            [EntryToken::Id, EntryToken::Ref],
             "{name} did not hide its body"
         );
         assert!(
@@ -157,6 +159,29 @@ fn display_math_environments_hide_commands_and_constructs() {
             "{name} quarantined a bounded display"
         );
     }
+}
+
+#[test]
+fn an_id_inside_a_display_body_is_a_declaration_and_the_rest_stays_formula() {
+    for input in [
+        &b"\\begin{equation}\n x = 1 @id(eq:a) @ref(no)\n\\end{equation} @ref(after)"[..],
+        b"\\begin{align}\n y &= 2 @id(eq:a) \\\\ z &= 3 @cite(no)\n\\end{align} @ref(after)",
+        b"\\[ z = 3 @id(eq:a) @ref(no) \\] @ref(after)",
+        b"$$ z = 3 @id(eq:a) $$ @ref(after)",
+    ] {
+        assert_eq!(
+            constructs(input),
+            [EntryToken::Id, EntryToken::Ref],
+            "{}",
+            String::from_utf8_lossy(input)
+        );
+    }
+    // Inline math and verbatim bodies recognise nothing, as before.
+    assert_eq!(constructs(b"$ @id(no) $ @ref(after)"), [EntryToken::Ref]);
+    assert_eq!(
+        constructs(b"\\begin{verbatim}\n@id(no)\n\\end{verbatim} @ref(after)"),
+        [EntryToken::Ref]
+    );
 }
 
 #[test]
@@ -178,6 +203,24 @@ fn an_unterminated_display_environment_quarantines_to_eof() {
     let pieces = scan(input);
     assert_eq!(constructs(input), []);
     assert!(matches!(pieces.last(), Some(Piece::Quarantined(span)) if span.end() == input.len()));
+}
+
+#[test]
+fn newif_defines_a_conditional_and_does_not_open_one() {
+    // The E2 reproducer: `\newif\iffoo` in a preamble sent the rest of the
+    // file to quarantine with no diagnostic. The definition claims its name;
+    // a later use of the defined conditional is still a real region.
+    let input = b"\\documentclass{article}\n\\newif\\iffoo\n\\begin{document}\n\\section{A}@id(sec:a)\nSee @ref(sec:a).\n\\end{document}\n";
+    assert_eq!(constructs(input), [EntryToken::Id, EntryToken::Ref]);
+    assert!(
+        !scan(input)
+            .iter()
+            .any(|piece| matches!(piece, Piece::Quarantined(_)))
+    );
+    let used = b"\\newif\\iffoo \\iffoo @ref(hidden) \\fi @ref(after)";
+    assert_eq!(constructs(used), [EntryToken::Ref]);
+    let bare = b"\\newif @ref(after)";
+    assert_eq!(constructs(bare), [EntryToken::Ref]);
 }
 
 #[test]

--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -283,6 +283,24 @@ impl SymbolTable {
     /// imported file: the scope is the root, so the two share one namespace and
     /// a clash between them is a real clash.
     pub fn merge(&mut self, sources: &Sources, document: &Document) {
+        self.merge_from(sources, document, false);
+    }
+
+    /// As [`merge`](Self::merge), for a document that begins inside the
+    /// appendices.
+    ///
+    /// `\appendix` is a switch, not a scope: everything after it is an
+    /// appendix, including the files imported after it. A file that begins
+    /// after the switch has no `\appendix` of its own, so its importer has to
+    /// say so. See [`appendix_switch_at`].
+    pub fn merge_from(&mut self, sources: &Sources, document: &Document, in_appendix: bool) {
+        let switch = if in_appendix {
+            Some(0)
+        } else {
+            sources
+                .get(document.source())
+                .and_then(|source| appendix_switch_at(source.bytes()))
+        };
         document.walk(|node| {
             let (kind, construct) = match node {
                 Node::Construct { kind, span, .. } => (*kind, *span),
@@ -339,7 +357,12 @@ impl SymbolTable {
                     let class = match kind {
                         EntryToken::Figure => EntityClass::Figure,
                         EntryToken::Table => EntityClass::Table,
-                        EntryToken::Id => attached_class(sources, payload.source, construct),
+                        EntryToken::Id => attached_class(
+                            sources,
+                            payload.source,
+                            construct,
+                            switch.is_some_and(|at| at < construct.start()),
+                        ),
                         _ => EntityClass::UnknownOpen,
                     };
                     self.declarations.insert(
@@ -528,10 +551,76 @@ pub fn demand_of(name: &str) -> EntityClass {
     PrefixMap::default().demand_of(name)
 }
 
-fn attached_class(sources: &Sources, source: SourceId, construct: Span) -> EntityClass {
+/// Where `\appendix` switches a file into its appendices, if it does.
+///
+/// The first `\appendix` control word in readable content — not one in a
+/// comment, a verbatim body or a macro definition. After it, sectioning
+/// commands declare appendices: authors label them `app:x`, and reading
+/// them as sections raised 98 false `XT1004` on three correct papers
+/// (corpus E2: 2212.13570, 2212.14882, 2603.02873).
+#[must_use]
+pub fn appendix_switch_at(bytes: &[u8]) -> Option<usize> {
+    let needle = b"\\appendix";
+    for span in crate::scanner::readable_content(bytes) {
+        let region = &bytes[span.start()..span.end()];
+        let mut from = 0usize;
+        while let Some(hit) = region[from..]
+            .windows(needle.len())
+            .position(|window| window == needle)
+            .map(|at| from + at)
+        {
+            let after = region.get(hit + needle.len());
+            if !after.is_some_and(u8::is_ascii_alphabetic) {
+                return Some(span.start() + hit);
+            }
+            from = hit + 1;
+        }
+    }
+    None
+}
+
+/// Whether `at` sits inside a display-math body that opened before it and
+/// has not closed: a `\begin{align}` with no `\end{align}` between, or a
+/// `\[` with no `\]` between.
+fn inside_display_math(bytes: &[u8], at: usize) -> bool {
+    let before = &bytes[..at];
+    let last_open = before
+        .windows(b"\\begin{".len())
+        .rposition(|window| window == b"\\begin{");
+    if let Some(open) = last_open {
+        let rest = &before[open + b"\\begin{".len()..];
+        if let Some(close) = rest.iter().position(|byte| *byte == b'}') {
+            let name = &rest[..close];
+            let mut end = b"\\end{".to_vec();
+            end.extend_from_slice(name);
+            end.push(b'}');
+            let closed = rest.windows(end.len()).any(|window| window == end);
+            if !closed && crate::scanner::is_display_math_region(&before[open..]) {
+                return true;
+            }
+        }
+    }
+    if let Some(open) = before.windows(2).rposition(|window| window == b"\\[") {
+        let closed = before[open..].windows(2).any(|window| window == b"\\]");
+        if !closed {
+            return true;
+        }
+    }
+    false
+}
+
+fn attached_class(
+    sources: &Sources,
+    source: SourceId,
+    construct: Span,
+    in_appendix: bool,
+) -> EntityClass {
     let Some(bytes) = sources.get(source).map(crate::source::Source::bytes) else {
         return EntityClass::UnknownOpen;
     };
+    if inside_display_math(bytes, construct.start()) {
+        return EntityClass::Equation;
+    }
     let mut start = construct.start();
     let mut lines = 0usize;
     while start > 0 && construct.start() - start < 256 && bytes[start - 1].is_ascii_whitespace() {
@@ -555,7 +644,11 @@ fn attached_class(sources: &Sources, source: SourceId, construct: Span) -> Entit
         b"\\part",
     ] {
         if last_command_with_balanced_argument(before, command) {
-            return EntityClass::Section;
+            return if in_appendix {
+                EntityClass::Appendix
+            } else {
+                EntityClass::Section
+            };
         }
     }
     for (environment, class) in [
@@ -970,6 +1063,78 @@ mod tests {
     fn an_id_takes_a_known_attachment_class() {
         let (_, t) = table(&[("a.xtex", "\\section{X}\n@id(sec:x)")]);
         assert_eq!(t.declaration("sec:x").unwrap().class, EntityClass::Section);
+    }
+
+    #[test]
+    fn a_section_after_the_appendix_switch_is_an_appendix() {
+        let text = "\\section{A}@id(sec:a) @ref(app:a)\n\\appendix\n\\section{B}@id(app:b)\n\\subsection{C}@id(app:c)\n@ref(app:b) @ref(app:c) @ref(sec:a)";
+        let (_, t) = table(&[("a.xtex", text)]);
+        assert_eq!(t.declaration("sec:a").unwrap().class, EntityClass::Section);
+        assert_eq!(t.declaration("app:b").unwrap().class, EntityClass::Appendix);
+        assert_eq!(t.declaration("app:c").unwrap().class, EntityClass::Appendix);
+        assert_eq!(t.inconsistent_references().count(), 0);
+
+        // Before the switch, `app:` on a section is still the mismatch.
+        let (_, t) = table(&[("a.xtex", "\\section{A}@id(app:a) @ref(app:a)\n\\appendix")]);
+        assert_eq!(t.inconsistent_references().count(), 1);
+
+        // A commented-out switch switches nothing.
+        let (_, t) = table(&[("a.xtex", "% \\appendix\n\\section{A}@id(app:a) @ref(app:a)")]);
+        assert_eq!(t.inconsistent_references().count(), 1);
+        assert_eq!(appendix_switch_at(b"\\appendixname"), None);
+    }
+
+    #[test]
+    fn a_file_imported_after_the_switch_begins_in_the_appendices() {
+        let mut sources = Sources::new();
+        let mut t = SymbolTable::new();
+        let id = sources.add("app.xtex", b"\\section{B}@id(app:b) @ref(app:b)".to_vec());
+        let document = parse(&sources, id);
+        t.merge_from(&sources, &document, true);
+        assert_eq!(t.declaration("app:b").unwrap().class, EntityClass::Appendix);
+        assert_eq!(t.inconsistent_references().count(), 0);
+    }
+
+    #[test]
+    fn an_id_inside_a_display_body_declares_an_equation() {
+        for text in [
+            "\\begin{equation}\n x = 1 @id(eq:x)\n\\end{equation}",
+            "\\begin{align}\n y &= 2 \\\\\n z &= 3 @id(eq:x)\n\\end{align}",
+            "\\begin{align*} y = 2 @id(eq:x) \\end{align*}",
+            "\\[ z = 3 @id(eq:x) \\]",
+        ] {
+            let (_, t) = table(&[("a.xtex", text)]);
+            assert_eq!(
+                t.declaration("eq:x").map(|d| d.class),
+                Some(EntityClass::Equation),
+                "{text}"
+            );
+        }
+        // A closed display before the construct does not enclose it.
+        let (_, t) = table(&[(
+            "a.xtex",
+            "\\begin{equation} x \\end{equation}\n\\newtheorem{X}{Y}\n@id(eq:x)",
+        )]);
+        assert_eq!(
+            t.declaration("eq:x").unwrap().class,
+            EntityClass::UnknownOpen
+        );
+    }
+
+    #[test]
+    fn an_id_inside_a_caption_is_declared() {
+        // Recognised because a caption is prose; its class is open because
+        // the caption's float is not read. Declared is what keeps a
+        // reference to it from being a false XT1003.
+        let (_, t) = table(&[(
+            "a.xtex",
+            "\\begin{figure}\\caption{A figure @id(fig:c)}\\end{figure} @ref(fig:c)",
+        )]);
+        assert_eq!(
+            t.declaration("fig:c").map(|d| d.class),
+            Some(EntityClass::UnknownOpen)
+        );
+        assert_eq!(t.unresolved_references().count(), 0);
     }
 
     #[test]

--- a/crates/xtex-core/tests/fixtures.rs
+++ b/crates/xtex-core/tests/fixtures.rs
@@ -240,12 +240,22 @@ fn emission_fixtures_match_their_expected_output() {
         let want =
             fs::read(&expected).unwrap_or_else(|e| panic!("{name}: cannot read emitted.tex ({e})"));
 
-        let mut store = Memory::new().with_input(name.clone(), raw);
-        transport(&name, &store.clone(), &mut store)
+        // Named as a root-level file: an `@import` is emitted with its
+        // source's directory in front, and the label's group is not one.
+        let file = format!(
+            "{}.xtex",
+            input
+                .parent()
+                .and_then(Path::file_name)
+                .map(|n| n.to_string_lossy())
+                .unwrap_or_default()
+        );
+        let mut store = Memory::new().with_input(file.clone(), raw);
+        transport(&file, &store.clone(), &mut store)
             .unwrap_or_else(|e| panic!("{name}: emission failed ({e})"));
 
         assert_eq!(
-            String::from_utf8_lossy(store.output(&name).unwrap_or_default()),
+            String::from_utf8_lossy(store.output(&file).unwrap_or_default()),
             String::from_utf8_lossy(&want),
             "{name}: emitted output differs from emitted.tex"
         );

--- a/crates/xtex-wasm/tests/parity.mjs
+++ b/crates/xtex-wasm/tests/parity.mjs
@@ -72,6 +72,9 @@ const checkJson = call("xtex_check_json", project);
 JSON.parse(new TextDecoder().decode(checkJson));
 writeFileSync(`${outDir}/wasm.json`, checkJson);
 writeFileSync(`${outDir}/wasm.map`, call("xtex_source_map", project));
+// A nested file emitted as the bundle's root keeps its root-relative name,
+// so its own `@import` must come out as the path TeX resolves from the root.
+writeFileSync(`${outDir}/wasm.nested.tex`, call("xtex_emit", bundle(projectDir, "sections/model.xtex")));
 
 // The claims inventory parses as JSON, and the record-aware check with NO
 // record must equal the plain check byte for byte — the record is opt-in

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -242,6 +242,76 @@ fn a_multi_file_bundle_equals_the_cli_run_on_the_same_project_on_disk() {
 }
 
 #[test]
+fn a_nested_import_emits_the_same_root_relative_input_from_the_cli_and_the_module() {
+    // `sections/model.xtex` imports `deeper.xtex`, found beside it. The CLI's
+    // build writes `build/sections/model.tex`; the module emits the same file
+    // as a bundle root under its root-relative name. Both must say
+    // `\input{sections/deeper.tex}`, which is what TeX resolves from the
+    // root — corpus E2 found the module and the CLI emitting `\input{deeper.tex}`.
+    let repo = repo();
+    let Some(module) = built_module(&repo) else {
+        return;
+    };
+    let project = repo.join("tests/fixtures/wasm/project");
+    let out = repo.join("target/wasm-parity/nested");
+    run_module(&repo, &module, &project, "main.xtex", &out);
+    let wasm_nested = std::fs::read(out.join("wasm.nested.tex")).expect("the module emitted");
+
+    // The CLI builds into a copy, so the fixture directory stays clean.
+    let scratch = repo.join("target/wasm-parity/nested-src");
+    if scratch.exists() {
+        std::fs::remove_dir_all(&scratch).expect("a fresh scratch copy");
+    }
+    copy_tree(&project, &scratch);
+    let built = Command::new(env!("CARGO"))
+        .args([
+            "run",
+            "--quiet",
+            "-p",
+            "xtex-cli",
+            "--",
+            "build",
+            "main.xtex",
+        ])
+        .current_dir(&scratch)
+        .output()
+        .expect("the CLI runs");
+    assert!(
+        built.status.success(),
+        "{}",
+        String::from_utf8_lossy(&built.stderr)
+    );
+    let cli_nested =
+        std::fs::read(scratch.join("build/sections/model.tex")).expect("the CLI built");
+    assert_eq!(
+        cli_nested, wasm_nested,
+        "the two hosts emit one nested file differently"
+    );
+    assert!(
+        String::from_utf8_lossy(&cli_nested).contains("\\input{sections/deeper.tex}"),
+        "{}",
+        String::from_utf8_lossy(&cli_nested)
+    );
+    assert!(
+        scratch.join("build/sections/deeper.tex").is_file(),
+        "the nested import is built too"
+    );
+}
+
+fn copy_tree(from: &Path, to: &Path) {
+    std::fs::create_dir_all(to).expect("a target directory");
+    for entry in std::fs::read_dir(from).expect("readable") {
+        let path = entry.expect("an entry").path();
+        let target = to.join(path.file_name().expect("a name"));
+        if path.is_dir() {
+            copy_tree(&path, &target);
+        } else {
+            std::fs::copy(&path, &target).expect("copied");
+        }
+    }
+}
+
+#[test]
 fn editor_queries_answer_project_wide_and_identically_in_both_builds() {
     let repo = repo();
     let Some(module) = built_module(&repo) else {
@@ -417,7 +487,12 @@ fn a_rename_plans_and_applies_identically_and_reports_what_it_left_alone() {
     ] {
         rewritten = rewritten.with_input(name, bytes);
     }
-    for name in ["appendix.tex", "refs.bib", "figures/plot.pdf"] {
+    for name in [
+        "appendix.tex",
+        "refs.bib",
+        "figures/plot.pdf",
+        "sections/deeper.xtex",
+    ] {
         rewritten = rewritten.with_input(
             name,
             std::fs::read(project.join(name)).expect("fixture file"),

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -59,8 +59,10 @@ LaTeX can ever fail. `?O` does not mean *invalid*. It means *the compiler has no
 ### How a reference states what it wants
 
 A comparison needs two sides. The declaration supplies one: `\figure(fig:main)` is a `Figure` by its
-keyword, and an `@id` takes the class of the construct it attached to — `\section` gives `Section`,
-`\begin{algorithm}` gives `Algorithm`, anything unmodelled gives `?O`.
+keyword, and an `@id` takes the class of the construct it attached to — `\section` gives `Section`, or
+`Appendix` after the `\appendix` switch; `\begin{algorithm}` gives `Algorithm`; an `@id` inside a
+display-math body gives `Equation`; anything unmodelled gives `?O`. [`grammar.md`](grammar.md) §4 has the
+switch and the body rule.
 
 The reference supplies the other, and **it does so through the prefix before the first `:`**.
 `@ref(fig:main)` demands a `Figure`; pointing it at a `\table(fig:main)` is `XT1004`.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -121,6 +121,8 @@ Fixtures must pin these decisions:
 3. `@ref(a)` in prose begins a reference.
 4. `\figure(a) { ... }` begins a block, while `\figure { ... }` does not.
 5. Every entry token inside each exclusion region in §8 remains ordinary bytes.
+6. `\newif\iffoo` followed by constructs that stay recognised, and a later `\iffoo … \fi` that hides
+   one (`exclusions/17`).
 
 ---
 
@@ -355,11 +357,30 @@ imposing a project-wide one on separately emitted documents.
 `@id(sec:intro)` emits `\label{sec:intro}` at the annotation's source position, and nothing else — no
 wrapper, no support command.
 
+**`@import` resolves relative to the file that contains it and emits the path TeX resolves from the
+root.** `sections/intro.xtex` importing `nested.xtex` reads `sections/nested.xtex` and emits
+`\input{sections/nested.tex}`, because TeX resolves `\input` from the root document's directory, never from
+the including file's. Writing `@import("sections/nested.xtex")` inside `sections/intro.xtex` therefore
+resolves to `sections/sections/nested.xtex` and is `XT1009`. (Corpus E2, `repro-nested-import`: the path
+had been emitted as written, and LaTeX could not find it.)
+
+**`\appendix` is a switch.** An `@id` attached to a sectioning command after `\appendix` — in the same
+file, or in a file imported after it, transitively — declares an `Appendix`; before it, a `Section`. The
+switch is read in readable content only, so a commented-out `\appendix` switches nothing. Authors label
+appendix sections `app:x`, and reading them as sections reported 98 false `XT1004` on three correct papers
+(corpus E2).
+
+**A display-math body declares.** `@id(eq:x)` inside `\begin{equation}…\end{equation}`, the other display
+environments of §8, `\[ … \]` or `$$ … $$` is recognised and declares an `Equation`; every other entry
+token inside a formula stays formula. The label inventory reads `\label` in the same bodies. An equation
+is labelled from inside its own body far more often than from the header slot — 17 references to such
+labels were reported undeclared across 6 papers in corpus E2.
+
 Before checking each root builds a **label inventory**. `\label` is a built-in known command with signature
 `m`, so its mandatory argument is selectable under §8 even though its bytes are otherwise opaque. A label
 enters the inventory only when it is tokenized as `\label` under default category codes, occurs outside every
-§8 exclusion region, has one balanced braced argument, and that argument is an `ident` after trimming ASCII
-whitespace.
+§8 exclusion region except a display-math body, has one balanced braced argument, and that argument is an
+`ident` after trimming ASCII whitespace.
 
 The inventory also reads `label` from the header options of a `lstlisting` environment, because `listings`
 runs `\label` internally for it — `\begin{lstlisting}[…, label={lst:x}]` declares `lst:x` with no `\label`
@@ -414,6 +435,9 @@ Fixtures must include:
 7. An unterminated inline construct followed by a valid construct on the next line; the second remains
    recognizable.
 8. Empty and non-ASCII identifiers, which are hard errors inside the explicit construct.
+8a. `@id` inside an `align` body and inside `\[ \]`, each declaring an equation, beside a reference in
+    the same body that stays formula (`inline/09`); a section labelled `app:` before and after
+    `\appendix` (`checking/08`).
 9. Every reference command, and a `cref` list, lowering to the command named (`emission/08`).
 10. An `@word(…)` in prose that is no construct, reported as advisory `XT2002`, beside the §3 shapes that
     are ordinary bytes and report nothing (`checking/05`).
@@ -863,7 +887,7 @@ entry token are ordinary bytes.
 |---|---|---|
 | Comment | unescaped `%` under current default category codes | line ending or end of file |
 | Inline math | unescaped `$` not followed by `$` | next corresponding unescaped `$` |
-| Display math | `$$` or `\[`; for a display-math environment, the first byte after the header slot in §4 | corresponding `$$`, `\]` or matching `\end{name}` |
+| Display math | `$$` or `\[`; for a display-math environment, the first byte after the header slot in §4 | corresponding `$$`, `\]` or matching `\end{name}` — `@id(` alone is recognised inside (§4) |
 | Verbatim command | a known verbatim command and its delimiter byte | next occurrence of that delimiter |
 | Verbatim environment | a configured verbatim `\begin{name}` | its line-exact `\end{name}` |
 | Listing | `\begin{lstlisting}` or a configured listing name | its line-exact terminator |
@@ -871,6 +895,11 @@ entry token are ordinary bytes.
 | Raw escape | complete `latex` entry through its opening `{` | matching `}` |
 | Command argument | an argument start selected by a known signature — except a text-bearing argument, whose interior is prose (see below) | that argument's specified boundary |
 | Quarantine | a hazard listed below | end of file |
+
+`\newif\iffoo` defines a conditional and opens no region: the `\if…` control word after `\newif` is the
+command's argument. Read as an opener it has no `\fi`, and the rest of the file went to quarantine with no
+diagnostic — the TACL template does this in its preamble (corpus E2, arXiv 2301.00303). A later `\iffoo …
+\fi` is a conditional region like any other.
 
 **Text-bearing arguments are prose.** A caption is a sentence, so the final mandatory argument of
 `\caption`, `\footnote`, `\footnotetext`, `\emph`, `\textbf`, `\textit`, `\underline`, `\mbox` and the
@@ -1045,9 +1074,10 @@ Subfigure panels are included at the light level because 34 `subfigure` environm
 No typed panel fields are specified because the available observations establish naming demand but not a
 stable field set.
 
-An appendix remains a section entity. The source must retain the manual kind word in prose. v0.1 does not
-add a separate appendix block because `@id` already provides naming and no appendix-specific checked field
-has been demonstrated.
+An appendix is a sectioning command after the `\appendix` switch (§4), and its `@id` declares the
+`Appendix` class. The source must retain the manual kind word in prose. v0.1 does not add a separate
+appendix block because `@id` already provides naming and no appendix-specific checked field has been
+demonstrated.
 
 ### Not admitted as separate entities
 

--- a/tests/fixtures/checking/08-appendix-sections/checked.txt
+++ b/tests/fixtures/checking/08-appendix-sections/checked.txt
@@ -1,0 +1,2 @@
+XT1003|section|sec:b|83|5|identifier `sec:b` is not declared
+XT1004|appendix|app:a|27|5|reference `app:a` requires appendix, but its target is section

--- a/tests/fixtures/checking/08-appendix-sections/expect.txt
+++ b/tests/fixtures/checking/08-appendix-sections/expect.txt
@@ -1,0 +1,5 @@
+transport: identical
+scanner: id ref id ref ref
+constructs: before `\appendix` a section labelled `app:` is XT1004; after it the
+  section is an appendix and `app:` matches, while `sec:` on it does not.
+  Corpus E2: 98 false XT1004 on three correct papers.

--- a/tests/fixtures/checking/08-appendix-sections/input.xtex
+++ b/tests/fixtures/checking/08-appendix-sections/input.xtex
@@ -1,0 +1,3 @@
+\section{A}@id(app:a) @ref(app:a)
+\appendix
+\section{B}@id(app:b) @ref(app:b) @ref(sec:b)

--- a/tests/fixtures/exclusions/17-newif-defines-a-conditional/expect.txt
+++ b/tests/fixtures/exclusions/17-newif-defines-a-conditional/expect.txt
@@ -1,0 +1,5 @@
+transport: identical
+scanner: id ref
+constructs: `\newif\iffoo` defines a conditional and opens no region, so the section
+  and the reference after it are recognised; the later `\iffoo … \fi` is a real
+  conditional region and hides its reference. Corpus E2, arXiv 2301.00303.

--- a/tests/fixtures/exclusions/17-newif-defines-a-conditional/input.xtex
+++ b/tests/fixtures/exclusions/17-newif-defines-a-conditional/input.xtex
@@ -1,0 +1,7 @@
+\documentclass{article}
+\newif\iffoo
+\begin{document}
+\section{A}@id(sec:a)
+See @ref(sec:a).
+\iffoo @ref(hidden) \fi
+\end{document}

--- a/tests/fixtures/inline/09-id-inside-a-display-body/expect.txt
+++ b/tests/fixtures/inline/09-id-inside-a-display-body/expect.txt
@@ -1,0 +1,4 @@
+transport: identical
+scanner: id id ref ref
+constructs: an `@id` inside a display body is a declaration of class equation; a
+  reference inside the same body stays formula. Corpus E2, 17 labels in 6 papers.

--- a/tests/fixtures/inline/09-id-inside-a-display-body/input.xtex
+++ b/tests/fixtures/inline/09-id-inside-a-display-body/input.xtex
@@ -1,0 +1,6 @@
+\begin{align}
+ y &= 2 @id(eq:a) \\
+ z &= 3 @ref(hidden)
+\end{align}
+\[ w = 4 @id(eq:b) \]
+See @ref(eq:a) and @ref(eq:b).

--- a/tests/fixtures/wasm/project/sections/deeper.xtex
+++ b/tests/fixtures/wasm/project/sections/deeper.xtex
@@ -1,0 +1,2 @@
+\subsection{Deeper}@id(sec:deeper)
+Anidado bajo el modelo.

--- a/tests/fixtures/wasm/project/sections/model.xtex
+++ b/tests/fixtures/wasm/project/sections/model.xtex
@@ -1,2 +1,3 @@
 \section{Model}@id(sec:model)
 El modelo cita a @cite(lamport1994).
+@import("deeper.xtex")


### PR DESCRIPTION
Fixes #153

Five defects found by the corpus campaign (50 arXiv papers, experiments E1/E2). Each reproducer became a failing test first; each fix names the paper that exposed it.

## The fixes

1. **`\newif` no longer quarantines the file** — arXiv 2301.00303 (TACL template, `\newif\iftaclinstructions` at line 52). `command_extent` treats the `\if…` control word after `\newif` as the command's argument instead of a conditional opener with no `\fi`. Test: `scanner::tests::newif_defines_a_conditional_and_does_not_open_one` (the reproducer, plus a later `\iffoo … \fi` that still hides its body, plus a bare `\newif`); fixture `exclusions/17`.

2. **Bibliography reading is linear** — arXiv 2212.13773 (`newref.bib`, 2,313 entries, 1.6 MB, 59.6 s). `entry_end` computed a line number per opening brace, each walking the file from its start. Offsets are kept; lines are computed only on the error path. Guard: `reading_a_large_bibliography_is_linear_in_its_size` — 5,000 entries, 3.4 MB, must read in under 2 s (measured 0.03 s in a debug build). The E1 reproducer re-run against the release binary of this branch:

   ```
   1000 entries  0.10 MB  0.24 s   (was 0.6 s)
   2000 entries  0.20 MB  0.00 s   (was 2.3 s)
   1000 entries  0.71 MB  0.00 s   (was 5.0 s)
   2000 entries  1.43 MB  0.01 s   (was 20.4 s)
   ```

3. **Nested `@import` emits the path TeX resolves from the root** — E2 `repro-nested-import`. `emit_import` prefixes the emitting source's directory: `sections/intro.xtex` importing `nested.xtex` emits `\input{sections/nested.tex}`. Resolution stays file-relative (documented in grammar §4, with the `XT1009` consequence of writing a root-relative path inside a subdirectory file). Parity: `a_nested_import_emits_the_same_root_relative_input_from_the_cli_and_the_module` builds the fixture project with the CLI in a scratch copy and emits the nested file through the module as a bundle root; the bytes must be equal and contain `\input{sections/deeper.tex}`. The fixture project gained `sections/deeper.xtex`.

4. **`\appendix` is a switch** — arXiv 2212.13570, 2212.14882, 2603.02873 (98 false XT1004). An `@id` on a sectioning command after `\appendix` declares `Appendix`; before it, `Section`. The switch is read in readable content only (a commented `\appendix` switches nothing) and propagates through imports: a file imported after the switch, transitively, begins in the appendices (`project::appendix_flags`, applied in `check_project` and `analyse`). Tests: `symbols` (same-file before/after, subsection, commented switch, `\appendixname`), `project::appendix_tests` (two-level import after the switch checks clean; the same file imported before the switch is XT1004), fixture `checking/08`.

5. **Display-math bodies declare** — 6 papers, 17 false XT1003. The scanner recognises `@id(` (and only `@id`) inside display-math environment bodies, `\[ \]` and `$$ $$`; the label inventory reads `\label` in the same bodies; `attached_class` returns `Equation` for a construct enclosed by an unclosed display opener. `\caption{}` interiors were already prose: an `@id` there is declared (class `?O`), a `\label` there is inventoried — both now pinned by tests. Verbatim, comments and inline math stay opaque. Tests: scanner (every display environment, `\[`, `$$`, and the inline/verbatim controls), `labels` (six positions found, four excluded positions not), `check` (an `@ref` to a `\label` inside `align` resolves; an `@id` inside `equation` carries the Equation class so a `fig:` prefix on it is XT1004), fixture `inline/09`.

## Honest limitations

- `@id` inside a `\caption{}` is declared with class `?O`, not the float's class: the caption's enclosing environment is not read. No false error results; no class check either.
- A `\label` in a `%` comment inside a display body is inventoried (the display body is read whole). The failure direction is a missed XT1003, never a false one.
- Labels inside unknown-command arguments (`\subfigure{…\label{}}`, `\parbox`) remain unread, as documented.
- The appendix switch matches imports by the loader's root-relative name; an import whose path the loader normalises differently (`./`, `..`) is not propagated and stays a Section.
- The emission fixture harness now names each fixture as a root-level file; before, its `group/name` label made an `@import` in a fixture emit with a spurious directory prefix.

## Test plan

```
cargo test --workspace -- --nocapture   → exit 0, 0 lines matching ^skipped:
cargo clippy --workspace --all-targets -- -D warnings   → clean
cargo fmt --all --check   → clean
cargo test --manifest-path crates/xtex-verify/Cargo.toml   → green
cargo clippy --manifest-path crates/xtex-verify/Cargo.toml --all-targets -- -D warnings   → clean
```
