### PR TITLE
Two regressions from the corpus fixes, and an unclosed bracket that went dark

### DIFF
--- a/crates/xtex-core/src/project.rs
+++ b/crates/xtex-core/src/project.rs
@@ -598,7 +598,7 @@ mod appendix_tests {
     fn a_file_imported_after_the_appendix_switch_declares_appendices() {
         // The corpus shape: `\appendix` in the root, the appendices in their
         // own files, `app:` labels on their sections. Correct, and it must
-        // check clean; the same file imported before the switch is not.
+        // check clean.
         let after = codes(&[
             (
                 "main.xtex",
@@ -612,14 +612,18 @@ mod appendix_tests {
         ]);
         assert!(after.is_empty(), "{after:?}");
 
-        let before = codes(&[
+        // The classes are what the switch says, which the figure prefix
+        // shows: it contradicts an appendix after the switch and a section
+        // before it alike, while `app:` on either is one family.
+        let classes = codes(&[
             (
                 "main.xtex",
-                "@import(\"back/app.xtex\")\n\\appendix\n@ref(app:b)\n",
+                "@import(\"front/b.xtex\")\n\\appendix\n@import(\"back/a.xtex\")\n@ref(fig:b) @ref(fig:a)\n",
             ),
-            ("back/app.xtex", "\\section{B}@id(app:b)\n"),
+            ("front/b.xtex", "\\section{B}@id(fig:b)\n"),
+            ("back/a.xtex", "\\section{A}@id(fig:a)\n"),
         ]);
-        assert_eq!(before, ["XT1004 app:b"]);
+        assert_eq!(classes, ["XT1004 fig:b", "XT1004 fig:a"]);
     }
 }
 

--- a/crates/xtex-core/src/scanner/boundaries.rs
+++ b/crates/xtex-core/src/scanner/boundaries.rs
@@ -171,6 +171,33 @@ pub(crate) fn delimited_end(bytes: &[u8], from: usize, open: u8, close: u8) -> O
     None
 }
 
+/// Offset just past the `]` closing an optional argument opened at `from`,
+/// when it closes before a blank line.
+///
+/// A `[` with no `]` before the end of the file, or one that would reach
+/// across a paragraph break, is not an optional argument; it is a bracket
+/// in prose. Read as an argument it had no boundary, and the rest of the
+/// file went opaque with no diagnostic — `\foo{}[never closed` hid a
+/// planted broken reference in a real paper (corpus E2). A real optional
+/// argument may span lines (`\caption[short\ntitle]{…}`), never a blank one.
+pub(crate) fn optional_argument_end(bytes: &[u8], from: usize) -> Option<usize> {
+    let end = delimited_end(bytes, from, b'[', b']')?;
+    let mut at = from;
+    while at < end {
+        if bytes[at] == b'\n' {
+            let mut next = at + 1;
+            while matches!(bytes.get(next), Some(b' ' | b'\t' | b'\r')) {
+                next += 1;
+            }
+            if bytes.get(next) == Some(&b'\n') {
+                return None;
+            }
+        }
+        at += 1;
+    }
+    Some(end)
+}
+
 pub(crate) fn skip_ascii_whitespace(bytes: &[u8], mut at: usize) -> usize {
     while matches!(bytes.get(at), Some(b' ' | b'\t')) {
         at += 1;

--- a/crates/xtex-core/src/scanner/mod.rs
+++ b/crates/xtex-core/src/scanner/mod.rs
@@ -25,6 +25,7 @@ mod tables;
 #[path = "tests.rs"]
 mod tests;
 
+pub(crate) use boundaries::is_escaped;
 pub use boundaries::{CommentRule, balanced_end, balanced_end_with};
 pub use queries::{construct_shaped_text, split_keys};
 pub use queries::{is_display_math_region, readable_content};
@@ -34,7 +35,7 @@ pub use tables::{
     DEFINITION_COMMANDS, LIST_REF_COMMANDS,
 };
 
-use boundaries::{close_import, close_paren, ident_end, is_escaped, span, span_at};
+use boundaries::{close_import, close_paren, ident_end, span, span_at};
 use queries::substitution_arrows;
 use regions::{
     Extent, Region, command_extent, display_math_environment_opening, entry_token_at,

--- a/crates/xtex-core/src/scanner/regions.rs
+++ b/crates/xtex-core/src/scanner/regions.rs
@@ -2,7 +2,8 @@
 
 use super::EntryToken;
 use super::boundaries::{
-    balanced_end, close_paren, delimited_end, is_escaped, skip_ascii_whitespace,
+    balanced_end, close_paren, delimited_end, is_escaped, optional_argument_end,
+    skip_ascii_whitespace,
 };
 use super::tables::AT_TOKENS;
 use super::tables::{
@@ -149,8 +150,9 @@ pub(crate) fn text_argument_interior(bytes: &[u8], at: usize) -> Option<(usize, 
                 }
             }
             Argument::Optional => {
-                if bytes.get(cursor) == Some(&b'[') {
-                    let end = delimited_end(bytes, cursor, b'[', b']')?;
+                if bytes.get(cursor) == Some(&b'[')
+                    && let Some(end) = optional_argument_end(bytes, cursor)
+                {
                     if first_optional.is_none() {
                         first_optional = Some((cursor + 1, end - 1));
                     }
@@ -230,11 +232,12 @@ pub(crate) fn command_extent(bytes: &[u8], at: usize) -> Extent {
                     }
                 }
                 Argument::Optional => {
-                    if bytes.get(cursor) == Some(&b'[') {
-                        match delimited_end(bytes, cursor, b'[', b']') {
-                            Some(end) => cursor = end,
-                            None => return Extent::Unbounded,
-                        }
+                    // A `[` that never closes, or closes past a blank line,
+                    // is prose and the argument is absent.
+                    if bytes.get(cursor) == Some(&b'[')
+                        && let Some(end) = optional_argument_end(bytes, cursor)
+                    {
+                        cursor = end;
                     }
                 }
                 Argument::Mandatory => {
@@ -276,22 +279,25 @@ pub(crate) fn command_extent(bytes: &[u8], at: usize) -> Extent {
     let mut groups = 0usize;
     loop {
         let next = skip_ascii_whitespace(bytes, cursor);
-        let (open, close) = match bytes.get(next) {
-            Some(b'{') => (b'{', b'}'),
-            Some(b'[') => (b'[', b']'),
+        let open = match bytes.get(next) {
+            Some(b'{') => b'{',
+            Some(b'[') => b'[',
             _ => break,
         };
         if groups == MAX_UNKNOWN_COMMAND_GROUPS {
             return Extent::Unbounded;
         }
-        let end = if open == b'{' {
-            balanced_end(bytes, next)
+        if open == b'{' {
+            match balanced_end(bytes, next) {
+                Some(end) => cursor = end,
+                None => return Extent::Unbounded,
+            }
         } else {
-            delimited_end(bytes, next, open, close)
-        };
-        match end {
-            Some(e) => cursor = e,
-            None => return Extent::Unbounded,
+            // An unclosed bracket is prose, not a group; the claim ends.
+            let Some(end) = optional_argument_end(bytes, next) else {
+                break;
+            };
+            cursor = end;
         }
         groups += 1;
     }
@@ -378,10 +384,9 @@ pub(crate) fn verbatim_command_opening(bytes: &[u8], at: usize) -> Option<(Regio
         }
         b"lstinline" => {
             if bytes.get(cursor) == Some(&b'[') {
-                cursor = match delimited_end(bytes, cursor, b'[', b']') {
-                    Some(end) => end,
-                    None => return Some((Region::Quarantine, cursor)),
-                };
+                // An unclosed option list is prose; this is then not a
+                // verbatim command and the ordinary path reads it.
+                cursor = optional_argument_end(bytes, cursor)?;
             }
             if bytes.get(cursor) == Some(&b'{') {
                 return None;

--- a/crates/xtex-core/src/scanner/tests.rs
+++ b/crates/xtex-core/src/scanner/tests.rs
@@ -206,6 +206,50 @@ fn an_unterminated_display_environment_quarantines_to_eof() {
 }
 
 #[test]
+fn an_unclosed_optional_bracket_is_prose_and_quarantines_nothing() {
+    // The corpus reproducer: `\foo{}[never closed` hid a planted broken
+    // reference — every construct after it was transported unread.
+    let input = b"A sample: \\foo{}[never closed\n\\section{A}@id(sec:a)\nSee @ref(sec:a) and @ref(sec:ghost).\n";
+    assert_eq!(
+        constructs(input),
+        [EntryToken::Id, EntryToken::Ref, EntryToken::Ref]
+    );
+    assert!(
+        !scan(input)
+            .iter()
+            .any(|piece| matches!(piece, Piece::Quarantined(_)))
+    );
+    // A bracket that closes only past a blank line is prose too, for a
+    // known signature as for an unknown command.
+    for input in [
+        &b"\\includegraphics[width=3cm\n\nSee @ref(after) ]"[..],
+        b"\\foo[a\n\nb] @ref(after)",
+        b"\\lstinline[never @ref(after)",
+    ] {
+        assert_eq!(
+            constructs(input),
+            [EntryToken::Ref],
+            "{}",
+            String::from_utf8_lossy(input)
+        );
+        assert!(
+            !scan(input)
+                .iter()
+                .any(|piece| matches!(piece, Piece::Quarantined(_)))
+        );
+    }
+    // A real optional argument may span a line, and still bounds its call.
+    assert_eq!(
+        constructs(b"\\caption[short\ntitle]{x @ref(inside)} @ref(after)"),
+        [EntryToken::Ref, EntryToken::Ref]
+    );
+    assert_eq!(
+        constructs(b"\\foo[a\nb @ref(hidden)] @ref(after)"),
+        [EntryToken::Ref]
+    );
+}
+
+#[test]
 fn newif_defines_a_conditional_and_does_not_open_one() {
     // The E2 reproducer: `\newif\iffoo` in a preamble sent the rest of the
     // file to quarantine with no diagnostic. The definition claims its name;

--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -47,11 +47,27 @@ pub enum EntityClass {
 
 impl EntityClass {
     /// Whether two classes can safely be used together.
+    ///
+    /// Equal classes, either side open, or both in the sectioning family:
+    /// an appendix is a section in LaTeX's own terms (the same `\section`
+    /// command, after the `\appendix` switch), so `sec:` on an appendix
+    /// and `app:` on a section after the switch are both consistent, and
+    /// so are the words "Section" and "Appendix" before either. Reading
+    /// them as distinct rejected 14 correct references in 3 corpus papers
+    /// the day after reading them as one had rejected 98. Figure, table,
+    /// equation and algorithm against the family stay errors.
     #[must_use]
     pub const fn is_consistent_with(self, other: Self) -> bool {
         matches!(self, Self::UnknownOpen)
             || matches!(other, Self::UnknownOpen)
             || self as u8 == other as u8
+            || (self.is_sectioning() && other.is_sectioning())
+    }
+
+    /// Section or appendix.
+    #[must_use]
+    pub const fn is_sectioning(self) -> bool {
+        matches!(self, Self::Section | Self::Appendix)
     }
 
     /// Stable spelling used by diagnostics.
@@ -600,11 +616,22 @@ fn inside_display_math(bytes: &[u8], at: usize) -> bool {
             }
         }
     }
-    if let Some(open) = before.windows(2).rposition(|window| window == b"\\[") {
-        let closed = before[open..].windows(2).any(|window| window == b"\\]");
-        if !closed {
-            return true;
+    // `\[` opens a display only when its backslash is not itself escaped:
+    // `\\[2pt]` is a tabular line break with spacing, and reading it as an
+    // opener classed every later declaration in the file as an equation
+    // (47 XT1004 and 61 XT1020 on correct documents, corpus E2 re-run).
+    let mut from = before.len();
+    while let Some(open) = before[..from]
+        .windows(2)
+        .rposition(|window| window == b"\\[")
+    {
+        if !crate::scanner::is_escaped(before, open) {
+            let closed = before[open..].windows(2).enumerate().any(|(at, window)| {
+                window == b"\\]" && !crate::scanner::is_escaped(before, open + at)
+            });
+            return !closed;
         }
+        from = open;
     }
     false
 }
@@ -1074,14 +1101,38 @@ mod tests {
         assert_eq!(t.declaration("app:c").unwrap().class, EntityClass::Appendix);
         assert_eq!(t.inconsistent_references().count(), 0);
 
-        // Before the switch, `app:` on a section is still the mismatch.
+        // Before the switch a section is a section; `app:` on it is
+        // consistent all the same, because the two are one family.
         let (_, t) = table(&[("a.xtex", "\\section{A}@id(app:a) @ref(app:a)\n\\appendix")]);
-        assert_eq!(t.inconsistent_references().count(), 1);
+        assert_eq!(t.declaration("app:a").unwrap().class, EntityClass::Section);
+        assert_eq!(t.inconsistent_references().count(), 0);
 
         // A commented-out switch switches nothing.
         let (_, t) = table(&[("a.xtex", "% \\appendix\n\\section{A}@id(app:a) @ref(app:a)")]);
-        assert_eq!(t.inconsistent_references().count(), 1);
+        assert_eq!(t.declaration("app:a").unwrap().class, EntityClass::Section);
         assert_eq!(appendix_switch_at(b"\\appendixname"), None);
+    }
+
+    #[test]
+    fn section_and_appendix_are_one_family_for_prefix_and_prose() {
+        let text = "\\section{M}@id(sec:m) Section~@ref(sec:m) Appendix~@ref(sec:m)\n\\appendix\n\
+                    \\section{E}@id(sec:e) Section~@ref(sec:e) @ref(app:e2)\n\\section{F}@id(app:f) Appendix~@ref(app:f) Section~@ref(app:f)";
+        let (_, t) = table(&[("a.xtex", text)]);
+        assert_eq!(t.declaration("sec:e").unwrap().class, EntityClass::Appendix);
+        assert_eq!(
+            t.inconsistent_references().count(),
+            0,
+            "sec: on an appendix is consistent"
+        );
+        assert_eq!(t.prose_mismatches().count(), 0);
+        // The family does not reach the other classes: both references
+        // carry the figure prefix, one carries the word.
+        let (_, t) = table(&[(
+            "a.xtex",
+            "\\appendix\n\\section{E}@id(fig:e) @ref(fig:e) Figure~@ref(fig:e)",
+        )]);
+        assert_eq!(t.inconsistent_references().count(), 2);
+        assert_eq!(t.prose_mismatches().count(), 1);
     }
 
     #[test]
@@ -1119,6 +1170,23 @@ mod tests {
             t.declaration("eq:x").unwrap().class,
             EntityClass::UnknownOpen
         );
+    }
+
+    #[test]
+    fn a_tabular_line_break_with_spacing_opens_no_display() {
+        // `\\[2pt]` is `\\` followed by an optional argument; the `\[`
+        // inside it is not the display opener. A section after it is a
+        // section, and a genuine display after it still declares an equation.
+        let text = "\\begin{tabular}{cc}\na & b \\\\[2pt]\nc & d\n\\end{tabular}\n\
+                    \\section{M}@id(sec:m) Section~@ref(sec:m)\n\
+                    \\[ x = 1 @id(eq:x) \\] @ref(eq:x)\n\
+                    a \\\\[4pt] b \\section{N}@id(sec:n)";
+        let (_, t) = table(&[("a.xtex", text)]);
+        assert_eq!(t.declaration("sec:m").unwrap().class, EntityClass::Section);
+        assert_eq!(t.declaration("eq:x").unwrap().class, EntityClass::Equation);
+        assert_eq!(t.declaration("sec:n").unwrap().class, EntityClass::Section);
+        assert_eq!(t.inconsistent_references().count(), 0);
+        assert_eq!(t.prose_mismatches().count(), 0);
     }
 
     #[test]

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -47,10 +47,16 @@ The term is from Malewski, Greenberg and Tanter, *Gradually Structured Data* (OO
 Comparison is **consistency**, not equality:
 
 ```
-Known(A) ~ Known(B)   if and only if A == B
+Known(A) ~ Known(B)   if and only if A == B, or both are Section or Appendix
 ?O       ~ T          for every T
 T        ~ ?O         for every T
 ```
+
+Section and Appendix are one family. An appendix is what LaTeX makes of the same `\section` command after
+the `\appendix` switch, so `sec:` on an appendix, `app:` on a section after the switch, and the words
+"Section" or "Appendix" before either are all consistent; Figure, Table, Equation and Algorithm against the
+family stay errors. Reading the two as distinct rejected 14 correct references in 3 corpus papers the day
+after reading them as one had rejected 98.
 
 The second and third lines are the whole checking policy in two symbols. `?O` is consistent with
 everything, so nothing involving unmodelled LaTeX can ever be inconsistent, so nothing involving unmodelled

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -366,7 +366,9 @@ had been emitted as written, and LaTeX could not find it.)
 
 **`\appendix` is a switch.** An `@id` attached to a sectioning command after `\appendix` — in the same
 file, or in a file imported after it, transitively — declares an `Appendix`; before it, a `Section`. The
-switch is read in readable content only, so a commented-out `\appendix` switches nothing. Authors label
+two are one family for every class comparison ([`checking.md`](checking.md) §2): `sec:` on an appendix is
+consistent, as is `app:` on a section after the switch. The switch is read in readable content only, so a
+commented-out `\appendix` switches nothing. Authors label
 appendix sections `app:x`, and reading them as sections reported 98 false `XT1004` on three correct papers
 (corpus E2).
 
@@ -895,6 +897,18 @@ entry token are ordinary bytes.
 | Raw escape | complete `latex` entry through its opening `{` | matching `}` |
 | Command argument | an argument start selected by a known signature — except a text-bearing argument, whose interior is prose (see below) | that argument's specified boundary |
 | Quarantine | a hazard listed below | end of file |
+
+**An unclosed `[` is prose.** An optional argument closes before a blank line, or it is not an argument: a
+`[` with no `]` before the end of the file, or one whose `]` lies past a paragraph break, is an ordinary
+bracket and the command's argument list ends before it. Read as an argument it had no boundary, and the rest
+of the file went opaque with no diagnostic — `\foo{}[never closed` hid a planted broken reference in a real
+paper (corpus E2). An unclosed `{` still quarantines: a brace is a group under any category code and a
+bracket is a character. Fixture `exclusions/18`.
+
+**`\\[2pt]` opens no display.** The display opener is `\[` only when its backslash is not itself escaped;
+`\\[2pt]` is a line break with spacing, and reading its bracket as an opener classed every later
+declaration in the file as an equation (corpus E2 re-run: 47 `XT1004` and 61 `XT1020` on correct documents).
+Fixture `checking/09`.
 
 `\newif\iffoo` defines a conditional and opens no region: the `\if…` control word after `\newif` is the
 command's argument. Read as an opener it has no `\fi`, and the rest of the file went to quarantine with no

--- a/tests/fixtures/checking/08-appendix-sections/checked.txt
+++ b/tests/fixtures/checking/08-appendix-sections/checked.txt
@@ -1,2 +1,1 @@
 XT1003|section|sec:b|83|5|identifier `sec:b` is not declared
-XT1004|appendix|app:a|27|5|reference `app:a` requires appendix, but its target is section

--- a/tests/fixtures/checking/08-appendix-sections/expect.txt
+++ b/tests/fixtures/checking/08-appendix-sections/expect.txt
@@ -1,5 +1,5 @@
 transport: identical
 scanner: id ref id ref ref
-constructs: before `\appendix` a section labelled `app:` is XT1004; after it the
-  section is an appendix and `app:` matches, while `sec:` on it does not.
-  Corpus E2: 98 false XT1004 on three correct papers.
+constructs: `app:` on a section before `\appendix` and on an appendix after it are
+  both consistent — one sectioning family — while `sec:b` is undeclared.
+  Corpus E2: 98 false XT1004 on three correct papers, then 14 the other way.

--- a/tests/fixtures/checking/09-linebreak-spacing-and-section-family/checked.txt
+++ b/tests/fixtures/checking/09-linebreak-spacing-and-section-family/checked.txt
@@ -1,0 +1,3 @@
+XT1003|appendix|app:e|162|5|identifier `app:e` is not declared
+XT1004|figure|fig:f|203|5|reference `fig:f` requires figure, but its target is appendix
+XT1020|figure|fig:f|191|6|prose says `Figure` but `fig:f` is an appendix

--- a/tests/fixtures/checking/09-linebreak-spacing-and-section-family/expect.txt
+++ b/tests/fixtures/checking/09-linebreak-spacing-and-section-family/expect.txt
@@ -1,0 +1,6 @@
+transport: identical
+scanner: id ref id ref ref id ref
+constructs: `\\[2pt]` opens no display, so sec:m is a section; after `\appendix`
+  the `sec:` prefix and the word Section on an appendix are consistent (one
+  sectioning family); `app:e` is undeclared; a figure prefix and the word
+  Figure on a section after the switch are still XT1004 and XT1020.

--- a/tests/fixtures/checking/09-linebreak-spacing-and-section-family/input.xtex
+++ b/tests/fixtures/checking/09-linebreak-spacing-and-section-family/input.xtex
@@ -1,0 +1,8 @@
+\begin{tabular}{cc}
+a & b \\[2pt]
+c & d
+\end{tabular}
+\section{M}@id(sec:m) Section~@ref(sec:m)
+\appendix
+\section{E}@id(sec:e) Section~@ref(sec:e) Appendix~@ref(app:e)
+\section{F}@id(fig:f) Figure~@ref(fig:f)

--- a/tests/fixtures/exclusions/18-unclosed-optional-bracket-is-prose/expect.txt
+++ b/tests/fixtures/exclusions/18-unclosed-optional-bracket-is-prose/expect.txt
@@ -1,0 +1,5 @@
+transport: identical
+scanner: id ref ref
+constructs: a `[` that never closes is prose, not an optional argument, so nothing
+  after it is quarantined and the broken reference to sec:ghost is reported.
+  Corpus E2 reproducer `unclosed-bracket.xtex`.

--- a/tests/fixtures/exclusions/18-unclosed-optional-bracket-is-prose/input.xtex
+++ b/tests/fixtures/exclusions/18-unclosed-optional-bracket-is-prose/input.xtex
@@ -1,0 +1,6 @@
+\documentclass{article}
+\begin{document}
+A sample: \foo{}[never closed
+\section{A}@id(sec:a)
+See @ref(sec:a) and @ref(sec:ghost).
+\end{document}


### PR DESCRIPTION
Fixes #155

Each reproducer became a failing test first.

## The fixes

1. **`\\[2pt]` opens no display** — regression from #154, 7 papers (2301.00152 alone 23 XT1004 + 24 XT1020). `symbols::inside_display_math` now applies the scanner's own backslash-parity rule: a `\[` whose backslash is escaped is a line break's optional argument, and the search continues to the previous `\[`. Test: `a_tabular_line_break_with_spacing_opens_no_display` — tabular with `\\[2pt]`, a section after it (Section, no XT1004, no XT1020 on `Section~@ref`), a genuine `\[ … @id(eq:x) \]` after that (Equation), and another `\\[4pt]` before a further section. Fixture `checking/09`.

2. **Section and Appendix are one family** — regression from #154, 14 references in 3 papers. `EntityClass::is_consistent_with` accepts both sides in `{Section, Appendix}`, so it covers XT1004 (prefix) and XT1020 (prose word) with one rule: `sec:` on an appendix, `app:` on a section, and the words "Section"/"Appendix" before either are consistent; Figure/Table/Equation/Algorithm against the family stay errors. Recorded in `docs/checking.md` §2 (the consistency rule now reads "A == B, or both are Section or Appendix", with the reason) and grammar §4. Consequence worth stating: `app:` on a section *before* `\appendix` is consistent too — the family rule is symmetric, and I chose the simple symmetric rule over a one-directional exception; the classes themselves still follow the switch (a fig: prefix on a section before the switch and on an appendix after it both fail, pinned in `project::appendix_tests`). Tests: `section_and_appendix_are_one_family_for_prefix_and_prose`; fixture `checking/08` updated.

3. **An unclosed `[` is prose** — leftover, `repro-newif-quarantine/unclosed-bracket.xtex`. New `optional_argument_end`: a `[` with no `]`, or whose `]` lies past a blank line, is not an optional argument. Applied to signature commands (the optional is absent), to unknown-command group claiming (the claim ends), to `\lstinline[` (not a verbatim command), and to text-bearing-argument interiors. An unclosed `{` still quarantines: a brace is a group under any category code, a bracket is a character. Tests: the reproducer (three constructs recognised, no quarantine), `\includegraphics[width=3cm` across a blank line, `\foo[a\n\nb]`, `\lstinline[never`, and the controls that a multi-line `\caption[short\ntitle]{…}` and a two-line `\foo[a\nb …]` still bound their calls. Fixture `exclusions/18`; grammar §8.

## Evidence from the reproducers (this branch's CLI)

```
linebreak-and-appendix.xtex   exit 0, no diagnostics   (was 2× XT1004 + 2× XT1020)
appendix-only.xtex            exit 0, no diagnostics   (was XT1004 sec:extra)
unclosed-bracket.xtex         exit 1, XT1003 sec:ghost (was exit 0, nothing checked)
```

## Test plan

```
cargo test --workspace -- --nocapture   → exit 0, 0 lines matching ^skipped:
cargo clippy --workspace --all-targets -- -D warnings   → clean
cargo fmt --all --check   → clean
cargo test --manifest-path crates/xtex-verify/Cargo.toml   → green
cargo clippy --manifest-path crates/xtex-verify/Cargo.toml --all-targets -- -D warnings   → clean
```
