### PR TITLE
The verifier folds author formatting and stops re-asking a settled no

### DIFF
--- a/crates/xtex-verify/src/compare.rs
+++ b/crates/xtex-verify/src/compare.rs
@@ -1,9 +1,20 @@
 //! Field comparison: the document's entry against the source's record.
 //!
-//! Normalization is deliberately blunt — lowercase, alphanumerics, single
-//! spaces — because the diffs it produces are read by a person, and a
-//! subtle matcher that silently forgives real differences would be the
-//! fabricated-author-list failure all over again, wearing a library.
+//! Normalization is deliberately blunt for titles and years — lowercase,
+//! alphanumerics, single spaces — because the diffs it produces are read by
+//! a person, and a subtle matcher that silently forgives real differences
+//! would be the fabricated-author-list failure all over again, wearing a
+//! library.
+//!
+//! Author lists are the exception, and the reason is measured: on ten real
+//! bibliographies (corpus E6, 2026-09-01) the blunt comparison flagged 229
+//! author lists at high severity, of which about 43 differed in a family
+//! name or a count. The rest were `Gr\'{e}goire` against `Grégoire`,
+//! `Hoare, C. A. R.` against `C. A. R. Hoare`, `van de Wetering` split at
+//! the wrong space, and lists the document cut with `and others`. A
+//! diagnostic that is wrong four times in five trains its reader to
+//! ignore the fifth — so a family-name comparison folds exactly those
+//! shapes, and nothing else, before a diff is allowed to stand.
 
 use xtex_core::verification::{DiffSeverity, FieldDiff};
 
@@ -31,32 +42,333 @@ pub fn normalize(text: &str) -> String {
     out.trim().to_owned()
 }
 
-/// Family names from a BibTeX author field (`and`-separated, either
-/// `Family, Given` or `Given Family`), normalized and sorted.
+/// Latin letters with diacritics, folded to their ASCII base.
+///
+/// A table rather than a Unicode library: the verifier has one network
+/// dependency and takes no other, and the letters that occur in author
+/// names are the Latin-1 and Latin Extended-A blocks plus a few from
+/// Extended-B and the Turkish dotless i. Combining marks (U+0300–U+036F)
+/// are dropped, which folds a decomposed `é` the same way.
+fn fold_char(character: char, out: &mut String) {
+    const TABLE: &[(&str, &str)] = &[
+        ("ÀÁÂÃÄÅĀĂĄǍ", "A"),
+        ("àáâãäåāăąǎ", "a"),
+        ("ÇĆĈĊČ", "C"),
+        ("çćĉċč", "c"),
+        ("ĎĐ", "D"),
+        ("ďđð", "d"),
+        ("ÈÉÊËĒĔĖĘĚ", "E"),
+        ("èéêëēĕėęě", "e"),
+        ("ĜĞĠĢ", "G"),
+        ("ĝğġģ", "g"),
+        ("ĤĦ", "H"),
+        ("ĥħ", "h"),
+        ("ÌÍÎÏĨĪĬĮİ", "I"),
+        ("ìíîïĩīĭįı", "i"),
+        ("Ĵ", "J"),
+        ("ĵ", "j"),
+        ("Ķ", "K"),
+        ("ķ", "k"),
+        ("ĹĻĽĿŁ", "L"),
+        ("ĺļľŀł", "l"),
+        ("ÑŃŅŇ", "N"),
+        ("ñńņňŉ", "n"),
+        ("ÒÓÔÕÖØŌŎŐǑ", "O"),
+        ("òóôõöøōŏőǒ", "o"),
+        ("ŔŖŘ", "R"),
+        ("ŕŗř", "r"),
+        ("ŚŜŞŠȘ", "S"),
+        ("śŝşšș", "s"),
+        ("ŢŤŦȚ", "T"),
+        ("ţťŧț", "t"),
+        ("ÙÚÛÜŨŪŬŮŰŲǓ", "U"),
+        ("ùúûüũūŭůűųǔ", "u"),
+        ("Ŵ", "W"),
+        ("ŵ", "w"),
+        ("ÝŶŸ", "Y"),
+        ("ýÿŷ", "y"),
+        ("ŹŻŽ", "Z"),
+        ("źżž", "z"),
+        ("Æ", "AE"),
+        ("æ", "ae"),
+        ("Œ", "OE"),
+        ("œ", "oe"),
+        ("ß", "ss"),
+        ("Þ", "Th"),
+        ("þ", "th"),
+    ];
+    if ('\u{300}'..='\u{36f}').contains(&character) {
+        return;
+    }
+    for (from, to) in TABLE {
+        if from.contains(character) {
+            out.push_str(to);
+            return;
+        }
+    }
+    out.push(character);
+}
+
+/// TeX accent and letter macros folded to plain letters: `Gr\'{e}goire`
+/// and `Gr{\'e}goire` both become `Gregoire`, `{\ae}` becomes `ae`,
+/// `{\o}` becomes `o`. Every other control word is dropped.
+fn fold_tex(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let mut out = String::new();
+    let mut at = 0usize;
+    while at < chars.len() {
+        let character = chars[at];
+        if character != '\\' {
+            if character != '{' && character != '}' {
+                fold_char(character, &mut out);
+            }
+            at += 1;
+            continue;
+        }
+        // A control symbol: one non-letter after the backslash. The accent
+        // symbols modify the next letter, which is kept; `\-` and `\&`
+        // and the rest are dropped.
+        let Some(&next) = chars.get(at + 1) else {
+            break;
+        };
+        if !next.is_ascii_alphabetic() {
+            at += 2;
+            continue;
+        }
+        let mut end = at + 1;
+        while end < chars.len() && chars[end].is_ascii_alphabetic() {
+            end += 1;
+        }
+        let word: String = chars[at + 1..end].iter().collect();
+        let replacement = match word.as_str() {
+            "i" => "i",
+            "j" => "j",
+            "ae" => "ae",
+            "AE" => "AE",
+            "oe" => "oe",
+            "OE" => "OE",
+            "o" => "o",
+            "O" => "O",
+            "l" => "l",
+            "L" => "L",
+            "aa" => "aa",
+            "AA" => "AA",
+            "ss" => "ss",
+            "dh" | "dj" => "d",
+            "DH" | "DJ" => "D",
+            "th" => "th",
+            "TH" => "Th",
+            "ng" => "n",
+            "NG" => "N",
+            // Everything else is dropped: the accent commands that are
+            // letters (`\c{c}`, `\v{s}`, `\H{o}`, `\u{a}`, `\k{e}`, `\d{a}`,
+            // `\b{a}`, `\r{a}`, `\t{oo}`), whose modified letter follows and
+            // is kept, and any control word that is not a letter at all.
+            _ => "",
+        };
+        out.push_str(replacement);
+        at = end;
+    }
+    out
+}
+
+/// One author's family name, as a comparison key: TeX folded, diacritics
+/// folded, punctuation and case dropped, suffixes removed.
+///
+/// `Family, Given` takes everything before the first comma; `Given Family`
+/// takes the last word and every lower-case particle before it (`van de
+/// Wetering`). A braced group is one word (`{Le Scao}`, `{Ortiz Su\'arez}`).
+fn family_key(author: &str) -> Option<String> {
+    let folded = fold_tex(author)
+        .replace(
+            ['\u{2010}', '\u{2011}', '\u{2012}', '\u{2013}', '\u{2014}'],
+            "-",
+        )
+        .replace(['\u{2019}', '\u{2018}'], "'");
+    let family: String = if let Some((before, _)) = folded.split_once(',') {
+        before.to_owned()
+    } else {
+        let words: Vec<&str> = folded.split_whitespace().collect();
+        let mut end = words.len();
+        while end > 0 && is_suffix(words[end - 1]) {
+            end -= 1;
+        }
+        if end == 0 {
+            return None;
+        }
+        let mut start = end - 1;
+        while start > 0 && is_particle(words[start - 1]) {
+            start -= 1;
+        }
+        words[start..end].join(" ")
+    };
+    let mut words: Vec<&str> = family.split_whitespace().collect();
+    while words.last().is_some_and(|word| is_suffix(word)) {
+        words.pop();
+    }
+    while words.first().is_some_and(|word| is_particle(word)) {
+        words.remove(0);
+    }
+    let key: String = words
+        .join("")
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .map(|c| c.to_ascii_lowercase())
+        .collect();
+    (!key.is_empty()).then_some(key)
+}
+
+fn is_suffix(word: &str) -> bool {
+    matches!(
+        word.trim_matches('.').to_ascii_lowercase().as_str(),
+        "jr" | "sr" | "ii" | "iii" | "iv"
+    )
+}
+
+fn is_particle(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "van"
+            | "von"
+            | "de"
+            | "der"
+            | "den"
+            | "del"
+            | "della"
+            | "di"
+            | "da"
+            | "du"
+            | "des"
+            | "le"
+            | "la"
+            | "of"
+            | "y"
+            | "ter"
+            | "ten"
+            | "af"
+            | "zu"
+    ) && word.chars().next().is_some_and(char::is_lowercase)
+}
+
+/// An author list read for comparison.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorList {
+    /// Family-name keys, in the order written.
+    pub names: Vec<String>,
+    /// Whether the list said it was cut short: `and others`, `et al.`.
+    pub truncated: bool,
+}
+
+/// Reads a BibTeX author field or a source's `and`-joined list.
+#[must_use]
+pub fn author_list(authors: &str) -> AuthorList {
+    let mut names = Vec::new();
+    let mut truncated = false;
+    let collapsed: String = authors.split_whitespace().collect::<Vec<_>>().join(" ");
+    for author in collapsed.split(" and ") {
+        let author = author.trim();
+        if author.is_empty() {
+            continue;
+        }
+        let lowered = author.to_ascii_lowercase();
+        if lowered == "others"
+            || lowered == "et al"
+            || lowered == "et al."
+            || lowered.ends_with(" et al")
+            || lowered.ends_with(" et al.")
+            || lowered.ends_with(" e al.")
+        {
+            truncated = true;
+            let head = author.rsplit_once(" e").map_or("", |(head, _)| head).trim();
+            if lowered.starts_with("et al") || lowered == "others" || head.is_empty() {
+                continue;
+            }
+            if let Some(key) = family_key(head) {
+                names.push(key);
+            }
+            continue;
+        }
+        if let Some(key) = family_key(author) {
+            names.push(key);
+        }
+    }
+    AuthorList { names, truncated }
+}
+
+/// Family names from a BibTeX author field, normalized and sorted.
+///
+/// Kept for callers that want the keys; [`authors_agree`] is the
+/// comparison.
 #[must_use]
 pub fn family_names(authors: &str) -> Vec<String> {
-    let mut names: Vec<String> = authors
-        .split(" and ")
-        .map(|author| {
-            let author = author.trim();
-            let family = author
-                .split_once(',')
-                .map_or_else(|| author.rsplit(' ').next().unwrap_or(author), |(f, _)| f);
-            normalize(family)
-        })
-        .filter(|name| !name.is_empty())
-        .collect();
+    let mut names = author_list(authors).names;
     names.sort_unstable();
     names
 }
 
+/// Registries cap the author lists they return; a document list longer
+/// than this many names is compared only over the source's length.
+const REGISTRY_CAP: usize = 50;
+
+/// Whether two family-name keys name the same family.
+///
+/// Equal keys, or one a suffix of the other: `nggomez` (from `Aidan
+/// N.Gomez`, the source's missing space) against `gomez`, and
+/// `bianchiberthouze` against `berthouze` — a hyphenated double family
+/// name against its second half. Four letters at least, so `li` inside
+/// `bianchili` is not a match.
+fn same_family(a: &str, b: &str) -> bool {
+    a == b || (a.len() >= 4 && b.len() >= 4 && (a.ends_with(b) || b.ends_with(a)))
+}
+
+/// Whether two author lists agree once formatting is folded.
+///
+/// Family names only, as sets. A list that ends in `and others` must be
+/// contained in the other; a source list at the registry cap is compared
+/// against the same number of names from the document; otherwise the two
+/// sets must match name for name.
+#[must_use]
+pub fn authors_agree(in_document: &str, in_source: &str) -> bool {
+    let document = author_list(in_document);
+    let source = author_list(in_source);
+    if document.names.is_empty() && source.names.is_empty() {
+        return true;
+    }
+    let (mut shorter, mut longer, prefix) = if document.truncated && !source.truncated {
+        (document.names.clone(), source.names.clone(), false)
+    } else if source.truncated && !document.truncated {
+        (source.names.clone(), document.names.clone(), false)
+    } else if source.names.len() >= REGISTRY_CAP && document.names.len() > source.names.len() {
+        (source.names.clone(), document.names.clone(), true)
+    } else if document.names.len() >= REGISTRY_CAP && source.names.len() > document.names.len() {
+        (document.names.clone(), source.names.clone(), true)
+    } else {
+        if document.names.len() != source.names.len() {
+            return false;
+        }
+        (document.names.clone(), source.names.clone(), false)
+    };
+    if prefix {
+        longer.truncate(shorter.len());
+    }
+    // Every name of the shorter list finds its own partner in the longer.
+    for name in shorter.drain(..) {
+        let Some(index) = longer.iter().position(|other| same_family(&name, other)) else {
+            return false;
+        };
+        longer.swap_remove(index);
+    }
+    true
+}
+
 /// One field's verdict: equal after normalization, or a diff carrying both
 /// sides. Authors are always high severity — the fabricated author list
-/// behind a valid DOI is exactly the failure verification exists to catch.
+/// behind a valid DOI is exactly the failure verification exists to catch —
+/// and a diff stands only if it survives the folding in [`authors_agree`].
 #[must_use]
 pub fn diff_field(name: &str, in_document: &str, in_source: &str) -> Option<FieldDiff> {
     let equal = if name == "author" || name == "authors" {
-        family_names(in_document) == family_names(in_source)
+        authors_agree(in_document, in_source)
     } else {
         normalize(in_document) == normalize(in_source)
     };
@@ -90,4 +402,192 @@ pub fn fingerprint(bytes: &[u8]) -> String {
         hash = hash.wrapping_mul(0x0100_0000_01b3);
     }
     format!("{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    //! Every case below is quoted from corpus E6's `out/diffs-all.csv`
+    //! (2026-09-01): the document's author field against the registry's
+    //! list, with the paper and key it came from.
+
+    use super::*;
+
+    #[test]
+    fn tex_accents_and_diacritics_fold_to_the_same_key() {
+        // 2412.19463 BBF21 / BGZ10 / Omer05 / Sab18; 2211.05100 OSCAR.
+        for (document, source) in [
+            (
+                "Barbosa, Manuel and Barthe, Gilles and Fan, Xiong and Gr\\'{e}goire, Benjamin",
+                "Manuel Barbosa and Gilles Barthe and Xiong Fan and Benjamin Grégoire",
+            ),
+            (
+                "Barthe, Gilles\nand Gr{\\'e}goire, Benjamin\nand Zanella B{\\'e}guelin, Santiago",
+                "Gilles Barthe and Benjamin Grégoire and Santiago Zanella Béguelin",
+            ),
+            ("{\\\"O}mer, Bernhard", "Bernhard Ömer"),
+            (
+                "Sabry, Amr\nand Valiron, Beno{\\^i}t\nand Vizzotto, Juliana Kaizer",
+                "Amr Sabry and Benoît Valiron and Juliana Kaizer Vizzotto",
+            ),
+            (
+                "Pedro Javier {Ortiz Su{\\'a}rez} and Beno{\\^\\i}t Sagot and Laurent Romary",
+                "Pedro Ortiz Suárez and Benoît Sagot and Laurent Romary",
+            ),
+            (
+                "Alejandro D{\\'{\\i}}az{-}Caro and\nMauricio Guillermo and\nAlexandre Miquel and\nBeno{\\^{\\i}}t Valiron",
+                "Alejandro Diaz-Caro and Mauricio Guillermo and Alexandre Miquel and Benoit Valiron",
+            ),
+            // 2301.01148 park2019critical: `Kj{\ae}rgaard` against `Kjærgaard`.
+            ("Kj{\\ae}rgaard, Mikkel Baun", "Mikkel Baun Kjærgaard"),
+            // 2212.13570 Pelliccione2017: a braced family with `\AA`.
+            ("{Magnus {\\AA}gren}, S.", "S. Magnus Ågren"),
+            // 2304.01373 ghorbani2021scaling: the Turkish dotless i.
+            ("Firat, Orhan", "Orhan Fırat"),
+        ] {
+            assert!(authors_agree(document, source), "{document} vs {source}");
+        }
+    }
+
+    #[test]
+    fn name_order_initials_particles_and_apostrophes_do_not_differ() {
+        for (document, source) in [
+            // 2412.19463 Hoare93: `Family, Initials` against `Initials Family`.
+            (
+                "Hoare, C. A. R.\nand Jifeng, He\nand Sampaio, A.",
+                "C. A. R. Hoare and Jifeng, He and Augusto Sampaio",
+            ),
+            // 2412.19463 zx_extract / DKP20: particles kept together.
+            (
+                "de Beaudrap, Niel and Kissinger, Aleks and van de Wetering, John",
+                "Niel de Beaudrap and Aleks Kissinger and John van de Wetering",
+            ),
+            // 2211.05100 scao2022what: a braced `{Le Scao}` against `Le Scao`.
+            (
+                "Teven {Le Scao} and Thomas Wang",
+                "Teven Le Scao and Thomas Wang",
+            ),
+            // 2412.19463 Panan06: the typographic apostrophe.
+            (
+                "Ellie D'Hondt and\nPrakash Panangaden",
+                "Ellie D’Hondt and Prakash Panangaden",
+            ),
+            // 2412.19463 Mathcomp: the SOURCE in `Family, Given`.
+            (
+                "Assia Mahboubi and\n Enrico Tassi",
+                "Assia Mahboubi and Tassi, Enrico",
+            ),
+            // 2301.00152 content_sel_summ: a suffix.
+            ("Daum{\\'e} III, Hal", "Hal Daumé"),
+            // 2401.00908 su2023roformer: `Ahmed Murtadha` against the
+            // source's `Murtadha, Ahmed` — the comma form is read as written.
+            (
+                "Ahmed Murtadha and Yunfeng Liu",
+                "Murtadha, Ahmed and Yunfeng Liu",
+            ),
+            // 2412.19463 RPZ17: a middle initial the document lacks.
+            (
+                "Robert Rand and Jennifer Paykin",
+                "Robert W. Rand and Jennifer Paykin",
+            ),
+            // 2412.19463 LZW19: tabs and line breaks between names.
+            (
+                "Liu, Junyi\n\tand Zhan, Bohua\n\tand Wang, Shuling",
+                "Junyi Liu and Bohua Zhan and Shuling Wang",
+            ),
+        ] {
+            assert!(authors_agree(document, source), "{document} vs {source}");
+        }
+    }
+
+    #[test]
+    fn hyphens_and_a_missing_space_at_the_source_are_folded() {
+        // 2211.05100 alyafeai2021masader: `AlShaibani` against `Al-shaibani`.
+        assert!(authors_agree(
+            "Maged Saeed AlShaibani",
+            "Maged S. Al-shaibani"
+        ));
+        // 2301.00304 Mathur_2020: a double family name against its half.
+        assert!(authors_agree("Nadia Berthouze", "Nadia Bianchi‐Berthouze"));
+        // 2211.05100 vaswani2017attention: `Aidan N.Gomez` at the source.
+        assert!(authors_agree("Gomez, Aidan N", "Aidan N.Gomez"));
+        // 2412.19463 rand2019reqwire: `{-}` and a Unicode hyphen.
+        assert!(authors_agree("Dong{-}Ho Lee", "Dong‐Ho Lee"));
+    }
+
+    #[test]
+    fn a_list_cut_with_others_is_a_prefix_not_a_difference() {
+        // 2301.00304 Park_2020: `Daniel S. Park et al` against the full list.
+        assert!(authors_agree(
+            "Daniel S. Park et al",
+            "Daniel S. Park and Yu Zhang and Ye Jia and Wei Han"
+        ));
+        assert!(authors_agree(
+            "Vaswani, Ashish and Shazeer, Noam and others",
+            "Ashish Vaswani and Noam Shazeer and Niki Parmar"
+        ));
+        // The cut list must still be contained: a wrong name in it differs.
+        assert!(!authors_agree(
+            "Vaswani, Ashish and Fabricated, X and others",
+            "Ashish Vaswani and Noam Shazeer and Niki Parmar"
+        ));
+        // A source cut at the registry cap is compared over its own length.
+        let fifty: Vec<String> = (0..50).map(|i| format!("Given Family{i}")).collect();
+        let document = format!("{} and Given Extra", fifty.join(" and "));
+        assert!(authors_agree(&document, &fifty.join(" and ")));
+    }
+
+    #[test]
+    fn substantive_differences_survive_the_folding() {
+        // 2304.01373 dai2021knowledge: the paper omits Baobao Chang.
+        assert!(!authors_agree(
+            "Dai, Damai and Dong, Li and Hao, Yaru and Sui, Zhifang and Wei, Furu",
+            "Damai Dai and Dong Li and Yaru Hao and Zhifang Sui and Baobao Chang and Furu Wei"
+        ));
+        // 2211.05100 mann1947controlling: the wrong authors entirely.
+        assert!(!authors_agree(
+            "Mann, H and Whitney, D",
+            "Yoav Benjamini and Yosef Hochberg"
+        ));
+        // 2301.00304 panayotov2015librispeech: one author of four, no `others`.
+        assert!(!authors_agree(
+            "Vassil Panayotov",
+            "Vassil Panayotov and Guoguo Chen and Daniel Povey and Sanjeev Khudanpur"
+        ));
+        // 2401.00908 kenton2019bert: a mangled field.
+        assert!(!authors_agree(
+            "Kenton, Jacob Devlin Ming-Wei Chang and Toutanova, Lee Kristina",
+            "Jacob Devlin and Ming-Wei Chang and Kenton Lee and Kristina Toutanova"
+        ));
+        // The canned fabrication the verifier tests use.
+        assert!(!authors_agree(
+            "Leslie Lamport",
+            "Leslie Lamport and X. Fabricated"
+        ));
+        // Short keys never match by suffix: `Li` is not `Bianchili`.
+        assert!(!authors_agree("Li, Wei", "Wei Bianchili"));
+        // 2401.00908 su2023roformer, 2212.14404 xing_normalized_2015: a
+        // name written `Bo Wen` in one place and `Wen Bo` in the other has
+        // no comma to say which word is the family. That is reported, not
+        // guessed — E6 classed it substantive too.
+        assert!(!authors_agree("Bo Wen", "Wen Bo"));
+        assert!(!authors_agree("Xing, Chao", "Xing Chao"));
+    }
+
+    #[test]
+    fn the_diff_keeps_both_sides_verbatim_at_high_severity() {
+        let diff = diff_field("author", "Mann, H and Whitney, D", "Yoav Benjamini").unwrap();
+        assert_eq!(diff.field, "authors");
+        assert_eq!(diff.in_document, "Mann, H and Whitney, D");
+        assert_eq!(diff.severity, DiffSeverity::High);
+        assert!(diff_field("author", "Gr\\'{e}goire, Benjamin", "Benjamin Grégoire").is_none());
+        assert!(diff_field("title", "The {TeX}book", "The TeXbook").is_none());
+    }
+
+    #[test]
+    fn family_names_are_the_sorted_keys() {
+        assert_eq!(
+            family_names("Zanella B{\\'e}guelin, Santiago and Barthe, Gilles"),
+            ["barthe", "zanellabeguelin"]
+        );
+    }
 }

--- a/crates/xtex-verify/src/run.rs
+++ b/crates/xtex-verify/src/run.rs
@@ -114,8 +114,37 @@ fn with_budget<T>(
     }
 }
 
+/// The note a registry's "nothing matched" is recorded with. Its first
+/// words are what [`is_settled_negative`] reads, so they are fixed here.
+pub const NOT_FOUND_NOTE: &str = "not found at the registries — books published before DOIs often are not registered; the entry may still be correct";
+
+/// Whether an unanswered-looking claim is in fact a settled negative: the
+/// source answered, and the answer was "no".
+///
+/// A registry that answers "nothing matched" has answered; a server that
+/// answers 404 has answered. Neither is a transport failure, and neither
+/// changes on the next run unless the entry changes or the freshness
+/// window elapses. Retrying them every run cost half of a full run,
+/// forever, on bibliographies where 39% of entries are not in Crossref
+/// (corpus E6: run 2 spent 325 of run 1's 688 requests re-asking 382
+/// claims that had been answered "not found"). A timeout, a refusal or a
+/// malformed answer keeps its failure note and is retried.
+#[must_use]
+pub fn is_settled_negative(recorded: &VerifiedClaim) -> bool {
+    let Some(note) = recorded.failure_note.as_deref() else {
+        return false;
+    };
+    match recorded.verdict {
+        Verdict::Bibliographic(BibVerdict::Unverified) => {
+            note.starts_with("not found at the registries")
+        }
+        Verdict::Reachability(Reachability::Unreachable) => note.starts_with("answered "),
+        _ => false,
+    }
+}
+
 /// True when the recorded claim still answers for the document's: same
-/// fields, young enough, and an answered verdict.
+/// fields, young enough, and either answered or a settled negative.
 fn still_fresh(claim: &Claim, recorded: &VerifiedClaim, now: &str, max_age_days: i64) -> bool {
     if recorded.fields != claim.fields {
         return false;
@@ -125,8 +154,8 @@ fn still_fresh(claim: &Claim, recorded: &VerifiedClaim, now: &str, max_age_days:
         Verdict::Bibliographic(BibVerdict::Unverified)
             | Verdict::Reachability(Reachability::Unreachable)
     );
-    if unanswered {
-        return false; // a failure is retried on the next run, always
+    if unanswered && !is_settled_negative(recorded) {
+        return false; // a transport failure is retried on the next run, always
     }
     match (super::civil(now), super::civil(&recorded.fetched_at)) {
         (Some(today), Some(then)) => today - then <= max_age_days,
@@ -309,11 +338,7 @@ pub fn verify(
                             failure_note: None,
                         }
                     }
-                    None => unverified(
-                        claim,
-                        run,
-                        "not found at the registries — books published before DOIs often are not registered; the entry may still be correct",
-                    ),
+                    None => unverified(claim, run, NOT_FOUND_NOTE),
                 }
             }
             ClaimKind::Url | ClaimKind::Doi | ClaimKind::Repository => {

--- a/crates/xtex-verify/tests/verifier.rs
+++ b/crates/xtex-verify/tests/verifier.rs
@@ -218,6 +218,145 @@ fn a_second_unchanged_run_touches_no_network_for_the_settled() {
     assert_eq!(record.claims.len(), claims.len());
 }
 
+const CROSSREF_NOTHING: &str = r#"{"message":{"items":[]}}"#;
+
+fn not_in_crossref() -> Claim {
+    bib(
+        "thesis",
+        &[
+            ("title", "A Thesis Nobody Registered"),
+            ("author", "A. Student"),
+            ("year", "2001"),
+        ],
+    )
+}
+
+#[test]
+fn a_registry_answering_not_found_is_an_answer_and_is_not_asked_again_inside_the_window() {
+    // Corpus E6: 382 claims answered "not found" were re-asked on every
+    // run, half of a full run forever. The answer is carried over like any
+    // other while the entry is unchanged and the window holds.
+    let canned = Canned {
+        answers: vec![("crossref", Ok((200, CROSSREF_NOTHING)))],
+        calls: RefCell::new(Vec::new()),
+    };
+    let claims = vec![not_in_crossref()];
+    let (written, calls) = run_with(&canned, &claims, None);
+    assert_eq!(calls.len(), 1, "{calls:?}");
+    let record = parse_record(written.as_bytes()).expect("parses");
+    assert_eq!(
+        record.claims[0].verdict,
+        Verdict::Bibliographic(BibVerdict::Unverified)
+    );
+    assert!(
+        record.claims[0]
+            .failure_note
+            .as_deref()
+            .is_some_and(|note| note.starts_with("not found at the registries"))
+    );
+
+    let second = Canned {
+        answers: vec![("crossref", Ok((200, CROSSREF_NOTHING)))],
+        calls: RefCell::new(Vec::new()),
+    };
+    let (rewritten, calls) = run_with(&second, &claims, Some(written.as_bytes()));
+    assert!(
+        calls.is_empty(),
+        "a settled negative was re-asked: {calls:?}"
+    );
+    let record = parse_record(rewritten.as_bytes()).expect("parses");
+    assert_eq!(record.claims.len(), 1);
+    assert_eq!(
+        record.claims[0].verdict,
+        Verdict::Bibliographic(BibVerdict::Unverified),
+        "the negative is carried over as recorded"
+    );
+}
+
+#[test]
+fn a_settled_negative_is_asked_again_when_the_entry_changes_or_the_window_elapses() {
+    let canned = Canned {
+        answers: vec![("crossref", Ok((200, CROSSREF_NOTHING)))],
+        calls: RefCell::new(Vec::new()),
+    };
+    let mut claims = vec![not_in_crossref()];
+    let (written, _) = run_with(&canned, &claims, None);
+
+    // The author edits the title: the old answer was about another text.
+    claims[0].fields[0].1 = "A Thesis, Registered After All".to_owned();
+    let edited = Canned {
+        answers: vec![("crossref", Ok((200, CROSSREF_NOTHING)))],
+        calls: RefCell::new(Vec::new()),
+    };
+    let (_, calls) = run_with(&edited, &claims, Some(written.as_bytes()));
+    assert_eq!(calls.len(), 1, "the changed entry pays: {calls:?}");
+
+    // The window elapses: the negative is stale like any verdict.
+    let claims = vec![not_in_crossref()];
+    let later = Canned {
+        answers: vec![("crossref", Ok((200, CROSSREF_NOTHING)))],
+        calls: RefCell::new(Vec::new()),
+    };
+    let mut persist = |_: &xtex_core::verification::VerificationRecord| {};
+    let mut progress = |_: &str| {};
+    let mut run = Run {
+        transport: &later,
+        user_agent: "test".to_owned(),
+        now: "2026-11-01T00:00:00Z".to_owned(),
+        max_age_days: 30,
+        timeout: Duration::from_millis(10),
+        persist: &mut persist,
+        progress: &mut progress,
+    };
+    let _ = verify(&mut run, &claims, Some(written.as_bytes()));
+    assert_eq!(
+        later.calls.borrow().len(),
+        1,
+        "past the window the negative is re-asked"
+    );
+}
+
+#[test]
+fn a_transport_failure_is_still_retried_on_the_next_run() {
+    // The other half of the rule: a timeout answered nothing, and the
+    // next run asks again.
+    let canned = Canned {
+        answers: vec![("crossref", Err("timeout"))],
+        calls: RefCell::new(Vec::new()),
+    };
+    let claims = vec![not_in_crossref()];
+    let (written, _) = run_with(&canned, &claims, None);
+    let record = parse_record(written.as_bytes()).expect("parses");
+    assert!(
+        record.claims[0]
+            .failure_note
+            .as_deref()
+            .is_some_and(|note| !note.starts_with("not found")),
+        "{:?}",
+        record.claims[0].failure_note
+    );
+    let second = Canned {
+        answers: vec![("crossref", Ok((200, CROSSREF_NOTHING)))],
+        calls: RefCell::new(Vec::new()),
+    };
+    let (_, calls) = run_with(&second, &claims, Some(written.as_bytes()));
+    assert_eq!(calls.len(), 1, "a transport failure is retried: {calls:?}");
+
+    // And a server that answered 404 has answered: not retried.
+    let gone = Canned {
+        answers: vec![("gone", Ok((404, "no such page")))],
+        calls: RefCell::new(Vec::new()),
+    };
+    let claims = vec![url_claim("https://example.org/gone")];
+    let (written, _) = run_with(&gone, &claims, None);
+    let again = Canned {
+        answers: vec![("gone", Ok((404, "no such page")))],
+        calls: RefCell::new(Vec::new()),
+    };
+    let (_, calls) = run_with(&again, &claims, Some(written.as_bytes()));
+    assert!(calls.is_empty(), "a 404 is an answer: {calls:?}");
+}
+
 #[test]
 fn an_edited_entry_is_refetched_and_the_rest_stay_skipped() {
     let canned = Canned {

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -59,8 +59,22 @@ asks the open sources about each claim and writes the record beside the root doc
 - The record is **persisted after every claim settles**, so an interrupted run keeps everything it
   obtained and the next run completes the holes.
 
-A timeout is never conflated with nonexistence: a claim the network failed to answer is recorded as
-unanswered **with the failure note**, and is always retried on the next run.
+A timeout is never conflated with nonexistence, and nonexistence is never conflated with a timeout. A
+claim the network failed to answer — a timeout, a refusal, a malformed reply — is recorded as unanswered
+**with the failure note** and is retried on the next run, always. A registry that answered "nothing
+matched", or a server that answered 404, has answered: that negative is recorded with its note and carried
+over like any verdict while the entry is unchanged and inside the freshness window, and re-asked only
+after it. On ten real bibliographies (corpus E6) 39% of entries are absent from Crossref and OpenAlex;
+re-asking them every run had cost half of a full run, forever.
+
+Author lists are compared by family name after folding what formatting varies and truth does not: TeX
+accent macros and diacritics (`Gr\'{e}goire`, `Grégoire`), `Family, Given` against `Given Family`,
+particles (`van de Wetering`), suffixes, hyphens and typographic apostrophes, and a list cut with `and
+others` or `et al.`, which must be contained in the other. Initials against full given names never
+differ, because given names are not compared. A diff that survives that folding is a diff in a family
+name or in the count, and it stays high severity — the fabricated author list behind a valid DOI is the
+failure verification exists to catch. Measured on the same ten bibliographies, the blunt comparison had
+flagged 229 author lists of which about 43 differed in substance.
 
 ## 3 · The record
 


### PR DESCRIPTION
Fixes #157

Both changes are in `crates/xtex-verify` (excluded from the workspace) and `docs/verification.md`; the compiler's replay is untouched.

## Author comparison (`compare.rs`)

`authors_agree` replaces the sorted-family-name equality. It reads both lists into family-name keys after folding: TeX accent macros and letter macros (`\'{e}`, `{\"o}`, `\c{c}`, `\^\i`, `{\ae}`, `{\AA}`), diacritics to ASCII by a table (Latin-1, Latin Extended-A, dotless i, combining marks dropped — no Unicode dependency), `{-}` and Unicode hyphens, typographic apostrophes, `Family, Given` vs `Given Family` (a braced group is one word), lower-case particles kept with the family (`van de Wetering`, `de Beaudrap`), suffixes (`III`, `Jr.`) dropped, case and punctuation dropped. Keys are compared as sets; two keys also match when one is a suffix of the other of at least four letters (`bianchiberthouze`/`berthouze`, the source's `Aidan N.Gomez`/`gomez`). A list ending in `and others` / `et al.` must be contained in the other; a source list at the registry cap (50) is compared over its own length; otherwise the sets must match name for name. Authors stay High severity. Given names are never compared, so initials vs full names cannot differ.

Every test case is a quoted E6 row (paper and key in the comments): the folds that must agree, and the substantive differences that must survive — `dai2021knowledge` (an omitted author), `mann1947controlling` (wrong authors), `vatistas1986reverse`, `panayotov2015librispeech` (one of four, no `others`), `kenton2019bert` (a mangled field), the canned `X. Fabricated`, and `Bo Wen` vs `Wen Bo`, which has no comma to say which word is the family and is reported rather than guessed.

## Retry semantics (`run.rs`)

`is_settled_negative`: an Unverified claim whose note begins "not found at the registries", or an Unreachable claim whose note begins "answered <status>", is an answer. `still_fresh` carries it over like any verdict while the entry's fields are unchanged and the freshness window holds; past the window, or after an edit, it is re-asked. A timeout, refusal or malformed reply keeps its failure note and is retried on the next run, always — the instability harness (transport failures) passes unchanged. The not-found note is now a named constant, since its first words are what the rule reads; records written by earlier versions carry the same text.

Tests in `tests/verifier.rs`: a registry "nothing matched" is not re-asked inside the window; it is re-asked after an edit and after the window; a transport failure is retried; a 404 is an answer.

## Before/after over E6's own outputs (offline, deterministic)

Recomputed from `E6-external-verification/out/diffs-all.csv` and the ten `run1.xtexverified` records with the new code (a scratch program over the crate; no network run was made — the records hold both sides of every diff, which is all the comparison needs):

| paper | author diffs before | after |
|---|---|---|
| 2211.05100 | 55 | 7 |
| 2212.13570 | 11 | 2 |
| 2212.14404 | 2 | 1 |
| 2301.00152 | 22 | 1 |
| 2301.00304 | 29 | 4 |
| 2301.01148 | 20 | 5 |
| 2301.01596 | 3 | 1 |
| 2304.01373 | 35 | 11 |
| 2401.00908 | 25 | 6 |
| 2412.19463 | 27 | 1 |
| **total** | **229** | **39** |

The 39 survivors include every one of E6's five hand-checked real errors (dai2021knowledge, mann1947controlling, vatistas1986reverse, panayotov2015librispeech, kenton2019bert) and the two version-drift cases (Feng23a, su2021roformer), which no normalization should absorb.

| | unanswered in run 1 | settled negatives, carried over now | transport failures, still retried |
|---|---|---|---|
| ten papers | 383 | 376 | 7 |

Run 2 would re-ask 7 claims instead of 383 (E6 measured 325 requests for them).

The corpus twins themselves were not modified or re-run; a live re-run on the merge commit is the corpus agent's, with its pinned binary.

## Browser verifier

The same rules go into the web repository's `src/lib/verify.ts` as a separate commit there, after its gate battery.

## Test plan

```
cargo test --manifest-path crates/xtex-verify/Cargo.toml     → 22 passed (7 lib, 2 instability, 4 materialize, 9 verifier)
cargo clippy --manifest-path crates/xtex-verify/Cargo.toml --all-targets -- -D warnings   → clean
cargo fmt --manifest-path crates/xtex-verify/Cargo.toml -- --check   → clean
cargo test --workspace -- --nocapture   → exit 0, no skip lines (untouched, for hygiene)
```
