### PR TITLE
An identifier anywhere inside a float takes the float's class

### DIFF
--- a/crates/xtex-core/src/scanner/mod.rs
+++ b/crates/xtex-core/src/scanner/mod.rs
@@ -27,7 +27,7 @@ mod tests;
 
 pub use boundaries::{CommentRule, balanced_end, balanced_end_with};
 pub(crate) use boundaries::{is_escaped, optional_argument_end};
-pub use queries::{construct_shaped_text, split_keys};
+pub use queries::{closed_environments, construct_shaped_text, split_keys};
 pub use queries::{is_display_math_region, readable_content};
 pub use queries::{listing_header_labels, readable_for, substitution_separator};
 pub use tables::{

--- a/crates/xtex-core/src/scanner/queries.rs
+++ b/crates/xtex-core/src/scanner/queries.rs
@@ -109,6 +109,88 @@ pub fn readable_content(bytes: &[u8]) -> Vec<Span> {
     spans
 }
 
+/// Every environment the scanner read both ends of: the span of its name,
+/// and the span from its `\begin` through its `\end`.
+///
+/// A `\begin` or `\end` counts only where the scanner read it as a command,
+/// so one inside a comment, a verbatim body or a macro definition opens or
+/// closes nothing. A display-math body is an excluded region that carries
+/// its own `\end`, and closes here too. An environment whose `\end` was
+/// never read — the author never wrote it, or the file went to quarantine
+/// before it — has no extent the scanner located, and is left out. An
+/// `@id` takes the class of the float around it from this list, which is
+/// what keeps a second walk over the bytes from meeting a `\begin{figure}`
+/// the scanner had excluded.
+#[must_use]
+pub fn closed_environments(bytes: &[u8]) -> Vec<(Span, Span)> {
+    let mut open: Vec<(Span, usize)> = Vec::new();
+    let mut closed = Vec::new();
+    for piece in scan(bytes) {
+        let (span, at) = match piece {
+            Piece::Arguments(span) => (span, span.start()),
+            Piece::Excluded(span) if is_display_math_region(&bytes[span.start()..span.end()]) => {
+                let Some(end) = bytes[span.start()..span.end()]
+                    .windows(b"\\end{".len())
+                    .rposition(|w| w == b"\\end{")
+                else {
+                    continue;
+                };
+                (span, span.start() + end)
+            }
+            _ => continue,
+        };
+        if let Some(name) = environment_name(bytes, at, b"\\begin") {
+            open.push((name, span.start()));
+        } else if let Some(name) = environment_name(bytes, at, b"\\end") {
+            let wanted = &bytes[name.start()..name.end()];
+            // The innermost open environment of that name. Anything opened
+            // after it and still open was never closed, and is dropped. The
+            // body ends at the `}` closing the name: `\end` has no signature,
+            // so its piece also claims any braced group that follows it.
+            if let Some(index) = open
+                .iter()
+                .rposition(|(opened, _)| &bytes[opened.start()..opened.end()] == wanted)
+            {
+                let (opened, begin) = open[index];
+                open.truncate(index);
+                closed.push((
+                    opened,
+                    Span::new(
+                        u32::try_from(begin).unwrap_or(u32::MAX),
+                        u32::try_from(name.end() + 1).unwrap_or(u32::MAX),
+                    ),
+                ));
+            }
+        }
+    }
+    closed
+}
+
+/// The name in `\begin{name}` or `\end{name}` at `at`, given the keyword.
+fn environment_name(bytes: &[u8], at: usize, keyword: &[u8]) -> Option<Span> {
+    let mut cursor = at + keyword.len();
+    if bytes.get(at..cursor)? != keyword {
+        return None;
+    }
+    while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+        cursor += 1;
+    }
+    if bytes.get(cursor) != Some(&b'{') {
+        return None;
+    }
+    let start = cursor + 1;
+    let end = start
+        + bytes[start..]
+            .iter()
+            .position(|byte| matches!(byte, b'}' | b'{' | b'\n' | b'\r'))?;
+    (bytes[end] == b'}' && end > start).then(|| {
+        Span::new(
+            u32::try_from(start).unwrap_or(u32::MAX),
+            u32::try_from(end).unwrap_or(u32::MAX),
+        )
+    })
+}
+
 /// The comma-separated keys in a construct payload, as byte ranges relative
 /// to the payload, untrimmed.
 ///

--- a/crates/xtex-core/src/scanner/tests.rs
+++ b/crates/xtex-core/src/scanner/tests.rs
@@ -339,6 +339,42 @@ fn a_verb_delimiter_may_be_the_sigil_itself() {
 }
 
 #[test]
+fn closed_environments_are_the_ones_the_scanner_read_both_ends_of() {
+    let text = b"\\begin{figure}[t] % \\end{figure}\n\\begin{tabular}{cc} a \\end{tabular}{claimed}\n\
+                 \\begin{align} x \\end{align}\n\\end{figure}\n\\begin{table}\n\\caption{never closed}";
+    let found: Vec<(&[u8], &[u8])> = closed_environments(text)
+        .into_iter()
+        .map(|(name, body)| {
+            (
+                &text[name.start()..name.end()],
+                &text[body.start()..body.end()],
+            )
+        })
+        .collect();
+    assert_eq!(
+        found,
+        [
+            (
+                b"tabular".as_slice(),
+                b"\\begin{tabular}{cc} a \\end{tabular}".as_slice()
+            ),
+            (b"align", b"\\begin{align} x \\end{align}"),
+            (
+                b"figure",
+                &text[..text.len() - b"\n\\begin{table}\n\\caption{never closed}".len()]
+            ),
+        ],
+        "a group after `\\end{{tabular}}` is claimed by the command and is not body"
+    );
+    // A `\\begin` inside a verbatim body opens nothing, and one in a comment
+    // (above) closes nothing.
+    assert!(
+        closed_environments(b"\\begin{verbatim}\n\\begin{figure}\n\\end{verbatim}\n\\end{figure}")
+            .is_empty()
+    );
+}
+
+#[test]
 fn verbatim_environments_hide_constructs() {
     for name in [
         "verbatim",

--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -317,6 +317,9 @@ impl SymbolTable {
                 .get(document.source())
                 .and_then(|source| appendix_switch_at(source.bytes()))
         };
+        let floats = sources
+            .get(document.source())
+            .map_or_else(Vec::new, |source| float_bodies(source.bytes()));
         document.walk(|node| {
             let (kind, construct) = match node {
                 Node::Construct { kind, span, .. } => (*kind, *span),
@@ -378,6 +381,7 @@ impl SymbolTable {
                             payload.source,
                             construct,
                             switch.is_some_and(|at| at < construct.start()),
+                            &floats,
                         ),
                         _ => EntityClass::UnknownOpen,
                     };
@@ -636,11 +640,60 @@ fn inside_display_math(bytes: &[u8], at: usize) -> bool {
     false
 }
 
+/// The environments whose whole body classes an `@id` inside it.
+///
+/// The label of a real float follows its `\caption`, or its
+/// `\includegraphics` lines, or closes the environment; only the header
+/// slot was read, so after `xtex adopt` every `fig:` and `alg:` identifier
+/// in a converted paper was unknown-open, and `@ref(fig:x)` on a table
+/// declared that way was never `XT1004` (issue #161). Nested `subfigure`,
+/// `minipage` and `tabular` bodies belong to the float around them; a
+/// display body inside a float keeps its own class.
+const FLOAT_ENVIRONMENTS: &[(&str, EntityClass)] = &[
+    ("figure", EntityClass::Figure),
+    ("figure*", EntityClass::Figure),
+    ("table", EntityClass::Table),
+    ("table*", EntityClass::Table),
+    ("algorithm", EntityClass::Algorithm),
+    ("algorithm*", EntityClass::Algorithm),
+];
+
+/// Every closed float in `bytes`, with the class it gives and its span.
+fn float_bodies(bytes: &[u8]) -> Vec<(EntityClass, Span)> {
+    crate::scanner::closed_environments(bytes)
+        .into_iter()
+        .filter_map(|(name, body)| {
+            let name = &bytes[name.start()..name.end()];
+            FLOAT_ENVIRONMENTS
+                .iter()
+                .find(|(known, _)| known.as_bytes() == name)
+                .map(|(_, class)| (*class, body))
+        })
+        .collect()
+}
+
+/// The class of the innermost float whose body holds `at`.
+fn enclosing_float(floats: &[(EntityClass, Span)], at: usize) -> Option<EntityClass> {
+    floats
+        .iter()
+        .filter(|(_, body)| body.start() <= at && at < body.end())
+        .min_by_key(|(_, body)| body.len())
+        .map(|(class, _)| *class)
+}
+
+/// The class an `@id` at `construct` declares.
+///
+/// In order: a display-math body around it; the construct it attaches
+/// backwards to within the bounded whitespace of `docs/grammar.md` §4 — a
+/// sectioning command, a closed display, an environment header; then the
+/// float whose body holds it. An `@id` on nothing the compiler models is
+/// unknown-open.
 fn attached_class(
     sources: &Sources,
     source: SourceId,
     construct: Span,
     in_appendix: bool,
+    floats: &[(EntityClass, Span)],
 ) -> EntityClass {
     let Some(bytes) = sources.get(source).map(crate::source::Source::bytes) else {
         return EntityClass::UnknownOpen;
@@ -648,20 +701,28 @@ fn attached_class(
     if inside_display_math(bytes, construct.start()) {
         return EntityClass::Equation;
     }
-    let mut start = construct.start();
+    header_class(bytes, construct.start(), in_appendix)
+        .or_else(|| enclosing_float(floats, construct.start()))
+        .unwrap_or(EntityClass::UnknownOpen)
+}
+
+/// The class of the attachable construct within the bounded whitespace
+/// before `at`, if there is one.
+fn header_class(bytes: &[u8], at: usize, in_appendix: bool) -> Option<EntityClass> {
+    let mut start = at;
     let mut lines = 0usize;
-    while start > 0 && construct.start() - start < 256 && bytes[start - 1].is_ascii_whitespace() {
+    while start > 0 && at - start < 256 && bytes[start - 1].is_ascii_whitespace() {
         start -= 1;
         if bytes[start] == b'\n' {
             lines += 1;
             if lines > 2 {
-                return EntityClass::UnknownOpen;
+                return None;
             }
         }
     }
     let before = &bytes[..start];
     if before.ends_with(b"\\]") || before.ends_with(b"$$") {
-        return EntityClass::Equation;
+        return Some(EntityClass::Equation);
     }
     for command in [
         b"\\section".as_slice(),
@@ -671,11 +732,11 @@ fn attached_class(
         b"\\part",
     ] {
         if last_command_with_balanced_argument(before, command) {
-            return if in_appendix {
+            return Some(if in_appendix {
                 EntityClass::Appendix
             } else {
                 EntityClass::Section
-            };
+            });
         }
     }
     for (environment, class) in [
@@ -691,10 +752,10 @@ fn attached_class(
         if before.ends_with(opening.as_bytes())
             || before.ends_with(format!("\\begin{{{environment}*}}").as_bytes())
         {
-            return class;
+            return Some(class);
         }
     }
-    EntityClass::UnknownOpen
+    None
 }
 
 fn last_command_with_balanced_argument(bytes: &[u8], command: &[u8]) -> bool {
@@ -1093,6 +1154,64 @@ mod tests {
     }
 
     #[test]
+    fn an_id_anywhere_inside_a_float_takes_the_floats_class() {
+        // The label of a real float follows its caption, its graphics
+        // lines, or closes the environment; only the header slot was read,
+        // so every one of these was unknown-open (issue #161).
+        for (text, class) in [
+            (
+                "\\begin{figure}\n\\centering\n\\includegraphics{y.png}\n\\caption{A}@id(x)\n\\end{figure}",
+                EntityClass::Figure,
+            ),
+            (
+                "\\begin{table*}\n\\caption{A}\n\\begin{tabular}{cc}\na & b @id(x)\n\\end{tabular}\n\\end{table*}",
+                EntityClass::Table,
+            ),
+            (
+                "\\begin{algorithm}[H]\n\\caption{A}\n\\begin{algorithmic}\n\\State x\n\\end{algorithmic}\n@id(x)\n\\end{algorithm}",
+                EntityClass::Algorithm,
+            ),
+            (
+                "\\begin{figure*}\n\\begin{minipage}{0.5\\linewidth}\n\\begin{subfigure}{\\linewidth}\n\\caption{L}@id(x)\n\\end{subfigure}\n\\end{minipage}\n\\end{figure*}",
+                EntityClass::Figure,
+            ),
+            // The header slot and a display body keep their precedence.
+            (
+                "\\begin{table}@id(x)\n\\caption{A}\n\\end{table}",
+                EntityClass::Table,
+            ),
+            (
+                "\\begin{table}\n\\caption{A}\n\\begin{equation} y @id(x) \\end{equation}\n\\end{table}",
+                EntityClass::Equation,
+            ),
+        ] {
+            let (_, t) = table(&[("a.xtex", text)]);
+            assert_eq!(t.declaration("x").map(|d| d.class), Some(class), "{text}");
+        }
+        // Prose between two floats, a float whose `\end` is never read, and
+        // a `\begin{figure}` in a comment or a listing class nothing.
+        for text in [
+            "\\begin{figure}\\caption{A}\\end{figure}\n@id(x)\n\\begin{table}\\caption{B}\\end{table}",
+            "\\begin{figure}\n\\caption{A}@id(x)\n",
+            "% \\begin{figure}\n\\caption{A}@id(x)",
+            "\\begin{lstlisting}\n\\begin{figure}\n\\end{lstlisting}\n@id(x)",
+        ] {
+            let (_, t) = table(&[("a.xtex", text)]);
+            assert_eq!(
+                t.declaration("x").map(|d| d.class),
+                Some(EntityClass::UnknownOpen),
+                "{text}"
+            );
+        }
+        // Inside a listing the construct is not live text at all.
+        let (_, t) = table(&[(
+            "a.xtex",
+            "\\begin{figure}\n\\begin{lstlisting}\n@id(x)\n\\end{lstlisting}\n\\end{figure}",
+        )]);
+        assert!(t.declaration("x").is_none());
+    }
+
+    #[test]
     fn a_section_after_the_appendix_switch_is_an_appendix() {
         let text = "\\section{A}@id(sec:a) @ref(app:a)\n\\appendix\n\\section{B}@id(app:b)\n\\subsection{C}@id(app:c)\n@ref(app:b) @ref(app:c) @ref(sec:a)";
         let (_, t) = table(&[("a.xtex", text)]);
@@ -1191,16 +1310,16 @@ mod tests {
 
     #[test]
     fn an_id_inside_a_caption_is_declared() {
-        // Recognised because a caption is prose; its class is open because
-        // the caption's float is not read. Declared is what keeps a
-        // reference to it from being a false XT1003.
+        // Recognised because a caption is prose, and classed by the float
+        // around the caption. Declared is what keeps a reference to it
+        // from being a false XT1003.
         let (_, t) = table(&[(
             "a.xtex",
             "\\begin{figure}\\caption{A figure @id(fig:c)}\\end{figure} @ref(fig:c)",
         )]);
         assert_eq!(
             t.declaration("fig:c").map(|d| d.class),
-            Some(EntityClass::UnknownOpen)
+            Some(EntityClass::Figure)
         );
         assert_eq!(t.unresolved_references().count(), 0);
     }

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -351,6 +351,12 @@ fn editor_queries_answer_project_wide_and_identically_in_both_builds() {
         wasm_inventory.contains("\"references\":"),
         "counts must be present: {wasm_inventory}"
     );
+    // An `@id` after a caption inside a figure carries the float's class
+    // (#161), and both builds say so.
+    assert!(
+        wasm_inventory.contains("\"name\":\"fig:body\",\"class\":\"figure\""),
+        "the float's class must reach the inventory: {wasm_inventory}"
+    );
 
     // Completions, which must include identifiers from every file.
     let items =

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -66,9 +66,10 @@ LaTeX can ever fail. `?O` does not mean *invalid*. It means *the compiler has no
 
 A comparison needs two sides. The declaration supplies one: `\figure(fig:main)` is a `Figure` by its
 keyword, and an `@id` takes the class of the construct it attached to — `\section` gives `Section`, or
-`Appendix` after the `\appendix` switch; `\begin{algorithm}` gives `Algorithm`; an `@id` inside a
-display-math body gives `Equation`; anything unmodelled gives `?O`. [`grammar.md`](grammar.md) §4 has the
-switch and the body rule.
+`Appendix` after the `\appendix` switch; an `@id` anywhere inside a `figure`, `table` or `algorithm`
+environment (starred or not, nested `subfigure`, `minipage` and `tabular` included) gives that float's
+class; an `@id` inside a display-math body gives `Equation`; anything unmodelled gives `?O`.
+[`grammar.md`](grammar.md) §4 has the switch and the two body rules.
 
 The reference supplies the other, and **it does so through the prefix before the first `:`**.
 `@ref(fig:main)` demands a `Figure`; pointing it at a `\table(fig:main)` is `XT1004`.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -382,6 +382,14 @@ token inside a formula stays formula. The label inventory reads `\label` in the 
 is labelled from inside its own body far more often than from the header slot — 17 references to such
 labels were reported undeclared across 6 papers in corpus E2.
 
+**A float body declares.** `@id` anywhere inside `figure`, `table` or `algorithm`, starred or not — after
+the `\caption`, after the graphics lines, at the end of the body, or inside a nested `subfigure`,
+`minipage` or `tabular` — declares that environment's class, `Figure`, `Table` or `Algorithm`. The header
+slot, a sectioning command and a display-math body keep their precedence; an `@id` in prose between two
+floats, or inside a float whose `\end` the scanner never read, is unknown-open; a verbatim or listing body
+inside a float is not live text. The environment is delimited by the scanner's own `\begin` and `\end`, so
+one inside a comment or a listing opens nothing. Fixture `checking/10`.
+
 Before checking each root builds a **label inventory**. `\label` is a built-in known command with signature
 `m`, so its mandatory argument is selectable under §8 even though its bytes are otherwise opaque. A label
 enters the inventory only when it is tokenized as `\label` under default category codes, occurs outside every
@@ -450,6 +458,10 @@ Fixtures must include:
 11. `Figure~@ref(tab:main)` on a declared table, reported as `XT1020`, beside a matching word, a plural,
     an abbreviation, a lower-case word, a word not immediately before, and an unknown-class target, each
     silent (`checking/07`).
+12. `@id` after the caption of a `figure`, a `table*` and an `algorithm`, inside a `tabular`, a `minipage`
+    and a `subfigure` inside a float, at the end of a `figure*`, right after `\begin{table}`, in prose
+    between two floats, and inside a `lstlisting`, each with a reference that reports its class or its
+    absence (`checking/10`).
 
 ### Bibliography discovery and citation checking
 

--- a/tests/fixtures/checking/10-float-bodies/checked.txt
+++ b/tests/fixtures/checking/10-float-bodies/checked.txt
@@ -1,0 +1,8 @@
+XT1003|figure|fig:listing|774|11|identifier `fig:listing` is not declared
+XT1004|figure|fig:wrong|627|9|reference `fig:wrong` requires figure, but its target is table
+XT1020|table|fig:cap|602|5|prose says `Table` but `fig:cap` is a figure
+XT1020|figure|tab:cell|638|6|prose says `Figure` but `tab:cell` is a table
+XT1020|figure|alg:cap|660|6|prose says `Figure` but `alg:cap` is an algorithm
+XT1020|table|fig:sub|681|5|prose says `Table` but `fig:sub` is a figure
+XT1020|table|fig:end|701|5|prose says `Table` but `fig:end` is a figure
+XT1020|figure|tab:opener|745|6|prose says `Figure` but `tab:opener` is a table

--- a/tests/fixtures/checking/10-float-bodies/expect.txt
+++ b/tests/fixtures/checking/10-float-bodies/expect.txt
@@ -1,0 +1,10 @@
+transport: identical
+scanner: id id id id id id id id ref ref ref ref ref ref ref ref ref
+constructs: an `@id` anywhere inside a figure, table or algorithm environment
+  takes the environment's class — after the caption, in a nested tabular,
+  subfigure or minipage, at the end of the body, and in the starred forms —
+  so the word Table before a figure and Figure before a table or an
+  algorithm are XT1020, and `fig:wrong` on a table is XT1004. The header
+  slot still classes `tab:opener`; `fig:between` in prose stays unknown-open
+  and is silent; `fig:listing` inside a listing is not live text and is
+  undeclared. Issue #161.

--- a/tests/fixtures/checking/10-float-bodies/input.xtex
+++ b/tests/fixtures/checking/10-float-bodies/input.xtex
@@ -1,0 +1,31 @@
+\begin{figure}
+\centering
+\includegraphics{y.png}
+\caption{After the caption}@id(fig:cap)
+\end{figure}
+\begin{table*}
+\caption{Wide}@id(fig:wrong)
+\begin{tabular}{cc}
+a & b @id(tab:cell)
+\end{tabular}
+\end{table*}
+\begin{algorithm}[H]
+\caption{Steps}@id(alg:cap)
+\end{algorithm}
+\begin{figure*}
+\begin{minipage}{0.5\linewidth}
+\begin{subfigure}{\linewidth}
+\caption{Left}@id(fig:sub)
+\end{subfigure}
+\end{minipage}
+@id(fig:end)
+\end{figure*}
+Prose between two floats. @id(fig:between)
+\begin{table}@id(tab:opener)
+\end{table}
+\begin{lstlisting}
+\caption{Shown as code}@id(fig:listing)
+\end{lstlisting}
+Table~@ref(fig:cap) @ref(fig:wrong) Figure~@ref(tab:cell) Figure~@ref(alg:cap)
+Table~@ref(fig:sub) Table~@ref(fig:end) Table~@ref(fig:between) Figure~@ref(tab:opener)
+@ref(fig:listing)

--- a/tests/fixtures/wasm/project/main.xtex
+++ b/tests/fixtures/wasm/project/main.xtex
@@ -17,5 +17,10 @@ la figura~@ref(fig:plot) lo ilustra; ver @Cref(sec:model, sec:intro).
 
 El literal \verb|sec:model| queda como transporte.
 
+\begin{figure}[t]
+  \centering
+  \caption{Un pie seguido de su identificador.}@id(fig:body)
+\end{figure}
+
 \bibliography{refs}
 \end{document}


### PR DESCRIPTION
Closes #161

## What

An `@id` anywhere inside a `figure`, `figure*`, `table`, `table*`, `algorithm` or `algorithm*` environment takes that environment's class — after the `\caption`, after the graphics lines, at the end of the body, or inside a nested `subfigure`, `minipage` or `tabular`. The header slot, a sectioning command and a display-math body keep their precedence; an `@id` in prose between two floats stays unknown-open; a verbatim or listing body inside a float is not live text.

## Why

The issue: the label of a real float follows its caption or closes the environment, and only the header slot was read, so after `xtex adopt` every `fig:`/`tab:`/`alg:` identifier was `?O` in the identity rail and took no part in `XT1004`.

## The rule, as code

- `scanner::closed_environments` (new, `queries.rs`) lists every environment the scanner read both ends of, from the scanner's own pieces: `\begin{…}`/`\end{…}` command pieces, and the display-math bodies that carry their own `\end`. A `\begin{figure}` inside a comment, a listing or a macro body opens nothing; an environment whose `\end` was never read (never written, or past a quarantine) is left out. The body ends at the `}` closing the name — `\end` has no signature, so its piece also claims a braced group that follows it (found by the decorrelated review below).
- `symbols::attached_class` now reads, after the display-math, sectioning and header-slot rules, the innermost closed float around the construct (`float_bodies`, `enclosing_float`), computed once per document beside the `\appendix` switch. The lookback code moved into `header_class`, unchanged.
- One existing test changed its expectation: `an_id_inside_a_caption_is_declared` asserted the class was open "because the caption's float is not read"; the float is read now, and the `XT1003` half of the test is unchanged.

## Evidence

Fixture `tests/fixtures/checking/10-float-bodies` covers every case the issue lists: `@id` after the caption of a `figure`, a `table*` and an `algorithm`; inside a `tabular`, a `minipage` and a `subfigure` inside a float; at the end of a `figure*`; right after `\begin{table}` (the header slot, unchanged); in prose between two floats (silent); inside a `lstlisting` (undeclared). The expected codes and classes were written from the rule before the harness ran, and the harness produced the same eight lines; each offset was checked against the input bytes. Its `checked.txt`:

```
XT1003|figure|fig:listing|774|11|identifier `fig:listing` is not declared
XT1004|figure|fig:wrong|627|9|reference `fig:wrong` requires figure, but its target is table
XT1020|table|fig:cap|602|5|prose says `Table` but `fig:cap` is a figure
XT1020|figure|tab:cell|638|6|prose says `Figure` but `tab:cell` is a table
XT1020|figure|alg:cap|660|6|prose says `Figure` but `alg:cap` is an algorithm
XT1020|table|fig:sub|681|5|prose says `Table` but `fig:sub` is a figure
XT1020|table|fig:end|701|5|prose says `Table` but `fig:end` is a figure
XT1020|figure|tab:opener|745|6|prose says `Figure` but `tab:opener` is a table
```

Unit tests: `symbols::tests::an_id_anywhere_inside_a_float_takes_the_floats_class` (six classed cases including the header slot and a display body inside a table; four unknown-open controls: prose between floats, an unclosed float, a commented `\begin{figure}`, a `\begin{figure}` inside a listing; one construct inside a listing that is not declared at all) and `scanner::tests::closed_environments_are_the_ones_the_scanner_read_both_ends_of` (nesting, a display body closing, a comment, an unclosed environment, a verbatim body, a braced group after `\end`).

Parity: `tests/fixtures/wasm/project/main.xtex` gains a `figure` whose `@id(fig:body)` follows its caption, and `editor_queries_answer_project_wide_and_identically_in_both_builds` asserts the native and wasm inventories both carry `"name":"fig:body","class":"figure"`.

### E5 census over the corpus twins

Not the static `census.py` (it reads `\label` in the unmodified sources and never runs the compiler). The count below is the compiler's own inventory over the E2 twins on commit 69338b6 (`E2-annotation-cost/work-69338b6`, 50 papers, the root named in `manifest.csv`), produced by a scratch program linking `xtex-core` by path and calling `project::analyse` then `SymbolTable::declarations()` — once against `main` (308a465) and once against this branch. Same 1,411 identifiers on both sides.

| prefix | identifiers | unknown-open on main | classed on this branch | still unknown-open |
|---|---|---|---|---|
| `fig:` | 320 | 318 | 314 → figure | 4 |
| `tab:` | 84 | 82 | 81 → table | 1 |
| `alg:` | 4 | 4 | 4 → algorithm | 0 |

**399 `fig:`/`tab:`/`alg:` identifiers move from `?O` to a class** (of 404 unknown-open on main). The other 2 + 2 are classed `equation` on both sides — the known `\verb|\[|` residual in 2212.14129 recorded in `E5-prefix-census/RESULTS-69338b6.md`. The five that stay `?O` are outside the six environments: `\captionof{figure}` inside a `minipage` or `center` (2301.00688 ×2, 2512.24941) and `wrapfigure`/`wraptable` (2601.02404 ×2). Over every prefix, 516 identifiers in 47 papers move, among them 34 `table:`, 41 unprefixed, 15 `lst:` on figures (2501.00655's listing-as-figure convention), 12 `supp_fig:`, 6 `figure:`, 5 `tbl:`. No moved `fig:`/`tab:`/`alg:` identifier disagrees with its float; the 13 `fig:` labels on `table` floats that E5 found in 2212.12035 are not `@id` constructs in that twin (the ramp converted only 2 `fig:` identifiers there), so they are not reachable by this count.

The program and its two output tables are not committed and nothing under the paper's experiment folders was written; the number is reproducible from the description above and from the count of `declarations()` per class.

## Test plan

Local, with the CI invocations (`RUSTFLAGS=-D warnings`):

```
cargo fmt --all --check                                      ok
cargo clippy --workspace --all-targets -- -D warnings        ok
cargo test --workspace -- --nocapture (pipefail)             exit 0; 0 lines matching ^skipped:; 0 failed results
cargo +1.88 build --workspace --all-targets                  ok
```

The extended scanner test fails on the committed query without the span fix (`{claimed}` inside the returned body) and passes with it.

## Invariants

- [x] Untouched LaTeX still comes out byte-identical — no emission path is touched; the fixture suites (`fixtures_without_constructs_transport_byte_identical`, truncation, emission) ran in the workspace test.
- [ ] No annotation changes the rendered PDF or the build status — not re-rendered; no emission change.
- [x] Nothing is injected into the emitted output — no emitter change.
- [x] No hard error can originate outside an explicit ExactTeX construct — the class only ever reaches a comparison through an `@id` and an `@ref`; `checking/10` keeps a plain-prose `@id` silent.
- [x] Every diagnostic this PR adds names its blame side — no new diagnostic; `XT1004`/`XT1020` are unchanged.

## Decorrelated review

Codex (gpt-5.6-sol, read-only) over the diff and the surrounding scanner code. Two low findings, both adopted: (1) the environment span ran to the end of the `\end` command's piece, which claims a braced group after `\end{name}` — fixed to end at the name's `}`, with the reproducer added to the scanner test; (2) "an extent the scanner can vouch for" in a doc comment — reworded. Found sound: exclusion of `\begin` inside comments, verbatim, `\newcommand` bodies and `\iffalse`; `\begin {figure}`, CRLF and next-line arguments; nesting and the innermost-float choice; top-level `tabular` stays open; precedence order; no reachable panic; one source per parsed document; the fixture follows the documented rule.

## Dependencies

None

## Docs

- [x] `docs/grammar.md` §4: "A float body declares" beside the display-body rule, and inline fixture 12 (`checking/10`).
- [x] `docs/checking.md` §2: the declaration side of the comparison names the float rule.

## Notes for the reviewer

- A float whose `\end` is in another file (`\begin{figure} \input{body} \end{figure}`) or past a quarantine is not read as closed, so an `@id` in that body stays `?O`. Same per-file limit as the `\appendix` switch; the census shows no such case among the 399.
- `wrapfigure`, `wraptable`, `sidewaysfigure` and `\captionof` are not in the list, by the issue's wording; they are the five census residuals above and would be a separate decision.
