### PR TITLE
The float rule reaches the rotated, wrapped and captioned-by-hand floats

### DIFF
--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -649,6 +649,11 @@ fn inside_display_math(bytes: &[u8], at: usize) -> bool {
 /// declared that way was never `XT1004` (issue #161). Nested `subfigure`,
 /// `minipage` and `tabular` bodies belong to the float around them; a
 /// display body inside a float keeps its own class.
+///
+/// The rotated (`rotating`), wrapped (`wrapfig`) and long (`longtable`)
+/// floats are floats in practice and carry the class of the counter they
+/// step; five census identifiers stayed unknown-open with only the three
+/// standard names listed (issue #163).
 const FLOAT_ENVIRONMENTS: &[(&str, EntityClass)] = &[
     ("figure", EntityClass::Figure),
     ("figure*", EntityClass::Figure),
@@ -656,6 +661,14 @@ const FLOAT_ENVIRONMENTS: &[(&str, EntityClass)] = &[
     ("table*", EntityClass::Table),
     ("algorithm", EntityClass::Algorithm),
     ("algorithm*", EntityClass::Algorithm),
+    ("sidewaysfigure", EntityClass::Figure),
+    ("sidewaysfigure*", EntityClass::Figure),
+    ("sidewaystable", EntityClass::Table),
+    ("sidewaystable*", EntityClass::Table),
+    ("wrapfigure", EntityClass::Figure),
+    ("wraptable", EntityClass::Table),
+    ("longtable", EntityClass::Table),
+    ("longtable*", EntityClass::Table),
 ];
 
 /// Every closed float in `bytes`, with the class it gives and its span.
@@ -685,9 +698,9 @@ fn enclosing_float(floats: &[(EntityClass, Span)], at: usize) -> Option<EntityCl
 ///
 /// In order: a display-math body around it; the construct it attaches
 /// backwards to within the bounded whitespace of `docs/grammar.md` §4 — a
-/// sectioning command, a closed display, an environment header; then the
-/// float whose body holds it. An `@id` on nothing the compiler models is
-/// unknown-open.
+/// sectioning command, a caption written by hand, a closed display, an
+/// environment header; then the float whose body holds it. An `@id` on
+/// nothing the compiler models is unknown-open.
 fn attached_class(
     sources: &Sources,
     source: SourceId,
@@ -737,6 +750,20 @@ fn header_class(bytes: &[u8], at: usize, in_appendix: bool) -> Option<EntityClas
             } else {
                 EntityClass::Section
             });
+        }
+    }
+    // `\captionof{figure}{…}` steps the figure counter wherever it is
+    // written, so the kind in its first argument is the class, and the
+    // construct attaches to the second argument as it does to a section
+    // title. A figure set in a `minipage` or `center` with no float around
+    // it is classed by this rule alone.
+    for (kind, class) in [
+        ("figure", EntityClass::Figure),
+        ("table", EntityClass::Table),
+    ] {
+        if last_command_with_balanced_argument(before, format!("\\captionof{{{kind}}}").as_bytes())
+        {
+            return Some(class);
         }
     }
     for (environment, class) in [
@@ -1209,6 +1236,84 @@ mod tests {
             "\\begin{figure}\n\\begin{lstlisting}\n@id(x)\n\\end{lstlisting}\n\\end{figure}",
         )]);
         assert!(t.declaration("x").is_none());
+    }
+
+    #[test]
+    fn the_rotated_wrapped_and_long_floats_and_a_caption_by_hand_class_an_id() {
+        // Five census identifiers stayed unknown-open with only `figure`,
+        // `table` and `algorithm` listed: their float is one a package
+        // adds, or their caption is `\captionof` (issue #163).
+        for (text, class) in [
+            (
+                "\\begin{sidewaysfigure}\n\\includegraphics{y.png}\n\\caption{A}@id(x)\n\\end{sidewaysfigure}",
+                EntityClass::Figure,
+            ),
+            (
+                "\\begin{sidewaysfigure*}\n\\caption{A}\n@id(x)\n\\end{sidewaysfigure*}",
+                EntityClass::Figure,
+            ),
+            (
+                "\\begin{sidewaystable}\n\\caption{A}@id(x)\n\\begin{tabular}{cc}\na & b\n\\end{tabular}\n\\end{sidewaystable}",
+                EntityClass::Table,
+            ),
+            (
+                "\\begin{sidewaystable*}\n\\caption{A}@id(x)\n\\end{sidewaystable*}",
+                EntityClass::Table,
+            ),
+            (
+                "\\begin{wrapfigure}{r}{0.5\\textwidth}\n\\includegraphics{y.png}\n\\caption{A}@id(x)\n\\end{wrapfigure}",
+                EntityClass::Figure,
+            ),
+            (
+                "\\begin{wraptable}{l}{0.4\\textwidth}\n\\caption{A}@id(x)\n\\end{wraptable}",
+                EntityClass::Table,
+            ),
+            (
+                "\\begin{longtable}{cc}\n\\caption{A}@id(x) \\\\\na & b \\\\\n\\end{longtable}",
+                EntityClass::Table,
+            ),
+            (
+                "\\begin{longtable*}{cc}\n\\caption{A}@id(x) \\\\\n\\end{longtable*}",
+                EntityClass::Table,
+            ),
+            // The caption written by hand attaches as a section title does:
+            // right after it, or on the next line.
+            (
+                "\\begin{minipage}{\\linewidth}\n\\includegraphics{y.png}\n\\captionof{figure}{A}@id(x)\n\\end{minipage}",
+                EntityClass::Figure,
+            ),
+            (
+                "\\begin{center}\n\\captionof{table}{A}\n@id(x)\n\\end{center}",
+                EntityClass::Table,
+            ),
+            // Its kind is the class even inside a float of the other kind,
+            // as the header rules keep their precedence over the body.
+            (
+                "\\begin{figure}\n\\captionof{table}{A}@id(x)\n\\end{figure}",
+                EntityClass::Table,
+            ),
+            // The header slot of a package float.
+            (
+                "\\begin{sidewaystable}@id(x)\n\\caption{A}\n\\end{sidewaystable}",
+                EntityClass::Table,
+            ),
+        ] {
+            let (_, t) = table(&[("a.xtex", text)]);
+            assert_eq!(t.declaration("x").map(|d| d.class), Some(class), "{text}");
+        }
+        // Prose between two package floats, and a `\captionof` two blank
+        // lines back, class nothing.
+        for text in [
+            "\\begin{wrapfigure}{r}{1in}\\caption{A}\\end{wrapfigure}\n@id(x)\n\\begin{longtable}{c}\\caption{B}\\end{longtable}",
+            "\\captionof{figure}{A}\n\n\n@id(x)",
+        ] {
+            let (_, t) = table(&[("a.xtex", text)]);
+            assert_eq!(
+                t.declaration("x").map(|d| d.class),
+                Some(EntityClass::UnknownOpen),
+                "{text}"
+            );
+        }
     }
 
     #[test]

--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -785,12 +785,66 @@ fn header_class(bytes: &[u8], at: usize, in_appendix: bool) -> Option<EntityClas
     None
 }
 
+/// Whether `bytes` ends with `command` followed by one balanced braced
+/// argument.
+///
+/// The argument's `{` is found by walking back from the end over the
+/// groups inside it, so a title or caption holding `\textbf{…}`,
+/// `\cite{…}` or `$x^{2}$` attaches; the last `{` in the prefix, which is
+/// what was read before, is that inner group's. The forward scan then
+/// confirms the group, with its own rule for `%`. The last `{` stays as
+/// the second reading, so that nothing that attached before stops
+/// attaching: it is what reaches a command on a line that a `%` opens.
 fn last_command_with_balanced_argument(bytes: &[u8], command: &[u8]) -> bool {
-    let Some(open) = bytes.iter().rposition(|byte| *byte == b'{') else {
-        return false;
+    let attaches = |open: usize| {
+        bytes[..open].ends_with(command)
+            && crate::scanner::balanced_end(bytes, open) == Some(bytes.len())
     };
-    bytes[..open].ends_with(command)
-        && crate::scanner::balanced_end(bytes, open) == Some(bytes.len())
+    argument_opening(bytes).is_some_and(attaches)
+        || bytes
+            .iter()
+            .rposition(|byte| *byte == b'{')
+            .is_some_and(attaches)
+}
+
+/// The `{` opening the braced group `bytes` ends with, if it ends with one.
+///
+/// Walked back one line at a time, and on each line only the part before
+/// an unescaped `%` counts, since the forward scan that confirms the group
+/// drops a comment too; an escaped brace is text.
+fn argument_opening(bytes: &[u8]) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut end = bytes.len();
+    loop {
+        let start = bytes[..end]
+            .iter()
+            .rposition(|byte| *byte == b'\n')
+            .map_or(0, |at| at + 1);
+        let live = bytes[start..end]
+            .iter()
+            .enumerate()
+            .position(|(offset, byte)| {
+                *byte == b'%' && !crate::scanner::is_escaped(bytes, start + offset)
+            })
+            .map_or(end, |offset| start + offset);
+        for at in (start..live).rev() {
+            match bytes[at] {
+                b'}' if !crate::scanner::is_escaped(bytes, at) => depth += 1,
+                b'{' if !crate::scanner::is_escaped(bytes, at) => {
+                    depth = depth.checked_sub(1)?;
+                    if depth == 0 {
+                        return Some(at);
+                    }
+                }
+                _ if depth == 0 => return None,
+                _ => {}
+            }
+        }
+        if start == 0 || depth == 0 {
+            return None;
+        }
+        end = start - 1;
+    }
 }
 
 /// The span between `(` and `)` of a construct covering `construct`.
@@ -1306,6 +1360,46 @@ mod tests {
         for text in [
             "\\begin{wrapfigure}{r}{1in}\\caption{A}\\end{wrapfigure}\n@id(x)\n\\begin{longtable}{c}\\caption{B}\\end{longtable}",
             "\\captionof{figure}{A}\n\n\n@id(x)",
+        ] {
+            let (_, t) = table(&[("a.xtex", text)]);
+            assert_eq!(
+                t.declaration("x").map(|d| d.class),
+                Some(EntityClass::UnknownOpen),
+                "{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_argument_with_a_braced_group_inside_still_attaches() {
+        // The last `{` in the prefix was taken as the argument's, so a title
+        // or caption holding `\textbf{…}` or `\cite{…}` never attached.
+        for (text, class) in [
+            ("\\section{A \\textbf{b}}@id(x)", EntityClass::Section),
+            (
+                "\\subsection{Growth as $n^{2}$ and \\emph{more}}\n@id(x)",
+                EntityClass::Section,
+            ),
+            (
+                "\\captionof{figure}{A \\cite{k} figure}@id(x)",
+                EntityClass::Figure,
+            ),
+            // An escaped brace is text, not a group, and a brace inside a
+            // comment is not one either.
+            ("\\section{A \\} b}@id(x)", EntityClass::Section),
+            ("\\section{A % }\nB}@id(x)", EntityClass::Section),
+            ("\\section{A \\% b}@id(x)", EntityClass::Section),
+        ] {
+            let (_, t) = table(&[("a.xtex", text)]);
+            assert_eq!(t.declaration("x").map(|d| d.class), Some(class), "{text}");
+        }
+        // Braces that do not balance attach nothing. (An unclosed group
+        // runs to the line's end and takes the `@id` with it before this
+        // rule is reached, so the unbalanced case here is a stray `}`.)
+        for text in [
+            "\\section{A}}@id(x)",
+            "\\captionof{figure}{A} b}@id(x)",
+            "\\section{A} % }\n@id(x)",
         ] {
             let (_, t) = table(&[("a.xtex", text)]);
             assert_eq!(

--- a/crates/xtex-wasm/tests/parity.rs
+++ b/crates/xtex-wasm/tests/parity.rs
@@ -357,6 +357,11 @@ fn editor_queries_answer_project_wide_and_identically_in_both_builds() {
         wasm_inventory.contains("\"name\":\"fig:body\",\"class\":\"figure\""),
         "the float's class must reach the inventory: {wasm_inventory}"
     );
+    // A `sidewaystable` is a float too (#163), in both builds.
+    assert!(
+        wasm_inventory.contains("\"name\":\"tab:rotated\",\"class\":\"table\""),
+        "the rotated float's class must reach the inventory: {wasm_inventory}"
+    );
 
     // Completions, which must include identifiers from every file.
     let items =

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -68,8 +68,10 @@ A comparison needs two sides. The declaration supplies one: `\figure(fig:main)` 
 keyword, and an `@id` takes the class of the construct it attached to — `\section` gives `Section`, or
 `Appendix` after the `\appendix` switch; an `@id` anywhere inside a `figure`, `table` or `algorithm`
 environment (starred or not, nested `subfigure`, `minipage` and `tabular` included) gives that float's
-class; an `@id` inside a display-math body gives `Equation`; anything unmodelled gives `?O`.
-[`grammar.md`](grammar.md) §4 has the switch and the two body rules.
+class, and so do the floats packages add — `sidewaysfigure`, `sidewaystable`, `wrapfigure`, `wraptable`
+and `longtable`; an `@id` after `\captionof{figure}{…}` or `\captionof{table}{…}` gives the kind named in
+the first argument; an `@id` inside a display-math body gives `Equation`; anything unmodelled gives `?O`.
+[`grammar.md`](grammar.md) §4 has the switch, the two body rules and the caption written by hand.
 
 The reference supplies the other, and **it does so through the prefix before the first `:`**.
 `@ref(fig:main)` demands a `Figure`; pointing it at a `\table(fig:main)` is `XT1004`.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -390,6 +390,14 @@ floats, or inside a float whose `\end` the scanner never read, is unknown-open; 
 inside a float is not live text. The environment is delimited by the scanner's own `\begin` and `\end`, so
 one inside a comment or a listing opens nothing. Fixture `checking/10`.
 
+**The floats packages add are floats.** The same body rule reads `sidewaysfigure` and `sidewaystable`
+(`rotating`, starred or not) and `wrapfigure` and `wraptable` (`wrapfig`) as `Figure` and `Table`, and
+`longtable` (starred or not) as `Table`; nesting is as above, the enclosing float wins. **A caption written
+by hand declares.** `@id` attached to `\captionof{figure}{…}` declares `Figure` and to `\captionof{table}{…}`
+declares `Table` — the attachment is the sectioning rule's, read on the second argument, with the class
+taken from the first — so a figure set in a `minipage` or `center` with no float around it is classed, and
+a `\captionof` inside a float keeps its own kind. Fixture `checking/11`.
+
 Before checking each root builds a **label inventory**. `\label` is a built-in known command with signature
 `m`, so its mandatory argument is selectable under §8 even though its bytes are otherwise opaque. A label
 enters the inventory only when it is tokenized as `\label` under default category codes, occurs outside every
@@ -462,6 +470,10 @@ Fixtures must include:
     and a `subfigure` inside a float, at the end of a `figure*`, right after `\begin{table}`, in prose
     between two floats, and inside a `lstlisting`, each with a reference that reports its class or its
     absence (`checking/10`).
+13. `@id` after the caption of a `sidewaysfigure`, a `sidewaysfigure*`, a `sidewaystable`, a
+    `sidewaystable*`, a `wrapfigure`, a `wraptable`, a `longtable` and a `longtable*`, after
+    `\captionof{figure}` inside a `minipage` and `\captionof{table}` inside a `center`, and in prose between
+    two of them, each with a reference that reports its class or its absence (`checking/11`).
 
 ### Bibliography discovery and citation checking
 

--- a/tests/fixtures/checking/11-package-floats-and-captionof/checked.txt
+++ b/tests/fixtures/checking/11-package-floats-and-captionof/checked.txt
@@ -1,0 +1,10 @@
+XT1004|figure|fig:turned|1009|10|reference `fig:turned` requires figure, but its target is table
+XT1020|table|fig:rot|960|5|prose says `Table` but `fig:rot` is a figure
+XT1020|table|fig:rotwide|980|5|prose says `Table` but `fig:rotwide` is a figure
+XT1020|figure|tab:turnedwide|1021|6|prose says `Figure` but `tab:turnedwide` is a table
+XT1020|table|fig:wrap|1049|5|prose says `Table` but `fig:wrap` is a figure
+XT1020|figure|tab:wrap|1070|6|prose says `Figure` but `tab:wrap` is a table
+XT1020|figure|tab:long|1092|6|prose says `Figure` but `tab:long` is a table
+XT1020|figure|tab:longwide|1114|6|prose says `Figure` but `tab:longwide` is a table
+XT1020|table|fig:hand|1140|5|prose says `Table` but `fig:hand` is a figure
+XT1020|figure|tab:hand|1161|6|prose says `Figure` but `tab:hand` is a table

--- a/tests/fixtures/checking/11-package-floats-and-captionof/expect.txt
+++ b/tests/fixtures/checking/11-package-floats-and-captionof/expect.txt
@@ -1,0 +1,11 @@
+transport: identical
+scanner: id id id id id id id id id id id ref ref ref ref ref ref ref ref ref ref ref
+constructs: the floats packages add class an `@id` inside them as the
+  standard three do — sidewaysfigure and sidewaystable (starred or not)
+  from rotating, wrapfigure and wraptable from wrapfig, longtable (starred
+  or not) — and a caption written by hand attaches: `\captionof{figure}`
+  in a minipage declares a figure, `\captionof{table}` in a center a
+  table. So the word Table before a rotated, wrapped or hand-captioned
+  figure and Figure before a turned, wrapped, long or hand-captioned table
+  are XT1020, and `fig:turned` on a sidewaystable is XT1004. `fig:between`
+  in prose stays unknown-open and is silent. Issue #163.

--- a/tests/fixtures/checking/11-package-floats-and-captionof/input.xtex
+++ b/tests/fixtures/checking/11-package-floats-and-captionof/input.xtex
@@ -1,0 +1,42 @@
+\begin{sidewaysfigure}
+\includegraphics{a.png}
+\caption{Rotated}@id(fig:rot)
+\end{sidewaysfigure}
+\begin{sidewaysfigure*}
+\caption{Rotated wide}@id(fig:rotwide)
+\end{sidewaysfigure*}
+\begin{sidewaystable}
+\caption{Turned}@id(fig:turned)
+\begin{tabular}{cc}
+a & b
+\end{tabular}
+\end{sidewaystable}
+\begin{sidewaystable*}
+\caption{Turned wide}@id(tab:turnedwide)
+\end{sidewaystable*}
+\begin{wrapfigure}{r}{0.5\textwidth}
+\includegraphics{b.png}
+\caption{Wrapped}@id(fig:wrap)
+\end{wrapfigure}
+\begin{wraptable}{l}{0.4\textwidth}
+\caption{Wrapped table}@id(tab:wrap)
+\end{wraptable}
+\begin{longtable}{cc}
+\caption{Long}@id(tab:long) \\
+a & b \\
+\end{longtable}
+\begin{longtable*}{cc}
+\caption{Long wide}@id(tab:longwide) \\
+\end{longtable*}
+\begin{minipage}{\linewidth}
+\includegraphics{c.png}
+\captionof{figure}{By hand}@id(fig:hand)
+\end{minipage}
+\begin{center}
+\captionof{table}{By hand}
+@id(tab:hand)
+\end{center}
+Prose between two of them. @id(fig:between)
+Table~@ref(fig:rot) Table~@ref(fig:rotwide) @ref(fig:turned) Figure~@ref(tab:turnedwide)
+Table~@ref(fig:wrap) Figure~@ref(tab:wrap) Figure~@ref(tab:long) Figure~@ref(tab:longwide)
+Table~@ref(fig:hand) Figure~@ref(tab:hand) Table~@ref(fig:between)

--- a/tests/fixtures/wasm/project/main.xtex
+++ b/tests/fixtures/wasm/project/main.xtex
@@ -22,5 +22,9 @@ El literal \verb|sec:model| queda como transporte.
   \caption{Un pie seguido de su identificador.}@id(fig:body)
 \end{figure}
 
+\begin{sidewaystable}
+  \caption{Una tabla girada.}@id(tab:rotated)
+\end{sidewaystable}
+
 \bibliography{refs}
 \end{document}


### PR DESCRIPTION
Closes #163
Closes #165

## What

An `@id` inside the floats packages add takes the float's class, as it does inside `figure`, `table` and `algorithm` since #162; and an `@id` attached to `\captionof{figure}{…}` or `\captionof{table}{…}` takes the kind named in the caption's first argument, so a figure set in a `minipage` or `center` with no float around it is classed too.

## Why

#162 left five census identifiers unknown-open (2301.00688 ×2, 2512.24941, 2601.02404 ×2), and the director's survey hit the first of them at once: `@id(tab:eval)` declared inside `\begin{sidewaystable}` showed `?` in the identity rail and took no part in `XT1004`.

## A defect fixed on the way (#165)

The `\captionof` rule depends on the helper the sectioning rule uses, `last_command_with_balanced_argument`, and that helper took the **last** `{` in the prefix as the argument's. A title or caption with a braced group inside never attached — `\section{A \textbf{b}}@id(x)` was unknown-open on `main` — and a caption holding `\cite{…}`, `\emph{…}` or `$x^{2}$` is the common case, not the edge. So the helper is fixed here rather than inherited: `argument_opening` walks back from the end to the `{` that balances to the end, over nested groups, with an escaped brace as text and, per line, only the part before an unescaped `%` counted; the forward `balanced_end` still confirms the group. The last `{` stays as the second reading so that nothing that attached before stops attaching. Unit test `an_argument_with_a_braced_group_inside_still_attaches`: `\section{A \textbf{b}}`, a `\subsection` with `$n^{2}$` and `\emph{…}` and the `@id` on the next line, `\captionof{figure}{A \cite{k} figure}`, an escaped `\}`, a `}` inside a `%` comment, an escaped `\%`; negatives: a stray `}` after `\section{A}` and after `\captionof{figure}{A}`, and a commented `}` after the title.

## The rule, as code

- `symbols::FLOAT_ENVIRONMENTS` gains eight names. The body rule (`float_bodies`, `enclosing_float`, `scanner::closed_environments`) is unchanged: the innermost closed float wins, and a `\begin` inside a comment, a listing or a macro body opens nothing.
- `symbols::header_class` gains one command rule after the sectioning commands: `last_command_with_balanced_argument(before, "\captionof{figure}")` / `"\captionof{table}"`. `\captionof` has two braced arguments, the kind then the caption, so the attachment reads the second argument and the class comes from the first. It sits with the header rules, so it keeps their precedence over the enclosing float: `\captionof{table}{…}@id(x)` inside a `figure` is a `Table`, which is the counter LaTeX steps there.

| environment | package | class |
|---|---|---|
| `sidewaysfigure`, `sidewaysfigure*` | rotating | Figure |
| `sidewaystable`, `sidewaystable*` | rotating | Table |
| `wrapfigure` | wrapfig | Figure |
| `wraptable` | wrapfig | Table |
| `longtable`, `longtable*` | longtable | Table |
| `\captionof{figure}{…}` | caption / capt-of | Figure |
| `\captionof{table}{…}` | caption / capt-of | Table |

## Evidence

Fixture `tests/fixtures/checking/11-package-floats-and-captionof`: `@id` after the caption of every environment in the table (starred where it exists), `\captionof{figure}` inside a `minipage` with the `@id` right after it, `\captionof{table}` inside a `center` with the `@id` on the next line, and an `@id` in prose between two of them that stays unknown-open. The expected codes, classes and offsets were written from the rule before the harness ran (offsets computed from the input bytes by a script), and the harness produced the same ten lines. Its `checked.txt`:

```
XT1004|figure|fig:turned|1009|10|reference `fig:turned` requires figure, but its target is table
XT1020|table|fig:rot|960|5|prose says `Table` but `fig:rot` is a figure
XT1020|table|fig:rotwide|980|5|prose says `Table` but `fig:rotwide` is a figure
XT1020|figure|tab:turnedwide|1021|6|prose says `Figure` but `tab:turnedwide` is a table
XT1020|table|fig:wrap|1049|5|prose says `Table` but `fig:wrap` is a figure
XT1020|figure|tab:wrap|1070|6|prose says `Figure` but `tab:wrap` is a table
XT1020|figure|tab:long|1092|6|prose says `Figure` but `tab:long` is a table
XT1020|figure|tab:longwide|1114|6|prose says `Figure` but `tab:longwide` is a table
XT1020|table|fig:hand|1140|5|prose says `Table` but `fig:hand` is a figure
XT1020|figure|tab:hand|1161|6|prose says `Figure` but `tab:hand` is a table
```

Unit test `symbols::tests::the_rotated_wrapped_and_long_floats_and_a_caption_by_hand_class_an_id`: the eight environments, `\captionof{figure}` right after and `\captionof{table}` on the next line, `\captionof{table}` inside a `figure` (Table), the header slot of a `sidewaystable`; two unknown-open controls (prose between a `wrapfigure` and a `longtable`, a `\captionof` two blank lines back). No scanner change, so no scanner test.

Parity: `tests/fixtures/wasm/project/main.xtex` gains a `sidewaystable` whose `@id(tab:rotated)` follows its caption, and `editor_queries_answer_project_wide_and_identically_in_both_builds` asserts both inventories carry `"name":"tab:rotated","class":"table"`.

### E5 census over the corpus twins

Same method as #162: a scratch program linking `xtex-core` by path, calling `project::analyse` on each twin's root (`main_file` from `corpus/manifest.csv`, `.xtex`) under `E2-annotation-cost/work-69338b6` (50 papers), then `SymbolTable::declarations()` — once against `main` (dafbd78, a worktree) and once against this branch at its final commit. Same 1,411 identifiers on both sides; no identifier already classed on `main` changes class.

| prefix | identifiers | unknown-open on main | classed on this branch | still unknown-open |
|---|---|---|---|---|
| `fig:` | 320 | 4 | 4 → figure | 0 |
| `tab:` | 84 | 1 | 1 → table | 0 |
| `alg:` | 4 | 0 | — | 0 |

The five from #162 are all classed now (the float rule alone, before the helper fix, already classed them): 2301.00688 `fig:NMT_1`, `fig:NMT_2` (`\captionof{figure}` in a `minipage`, `@id` right after) → figure; 2512.24941 `fig:1` (`\captionof{figure}` in a `center`, `@id` on the next line) → figure; 2601.02404 `fig:physical_circuit_impact` (`wrapfigure`) → figure and `tab:dataset_summary_stats` (`wraptable`) → table. Over every prefix, 24 identifiers in 15 papers move. Seven by the float rule: the five above, 2212.14882 `app:tab:questionnaire_answers` (`longtable`) → table, and 2304.01373 `table:name_change` → figure — a `tabular` set inside a `wrapfigure`, so the figure counter is what LaTeX steps and the author's `table:` prefix disagrees with their own float, which is the disagreement the rule exists to surface. Seventeen by the helper fix (#165): 15 → section and 2 → appendix, every one a sectioning title with a braced group inside, e.g. 2212.14779 `\section{Combining \jbmc{} and \bluecov{} }`, 2401.00515 `\subsubsection{\textbf{Absent Patch Version Releases}}`, 2412.19463 `\section{A ZX-Calculus Proof of Example~\ref{exam:circuit opt}}`, 2301.00303 `\subsection{Implementation Details for the Two Variants of \NAME{}}`.

**New residual for `fig:`/`tab:`/`alg:`: 0 unknown-open.** The 2 + 2 classed `equation` on both sides are the known `\verb|\[|` residual in 2212.14129 (`E5-prefix-census/RESULTS-69338b6.md`). Over every prefix 283 identifiers stay unknown-open, none of them a float: 98 unprefixed, 41 `prop:`, 38 `def:`, 35 `sec:`, 23 `thm:`, then `ex:`, `lem:`, `section:` and smaller — theorem-like environments and sectioning cases outside the bounded lookback.

The program and its two output tables are not committed and nothing under the paper's experiment folders was written.

## Test plan

Local, with the CI invocations (`RUSTFLAGS=-D warnings`):

```
cargo fmt --all --check                                      ok
cargo clippy --workspace --all-targets -- -D warnings        ok
cargo test --workspace -- --nocapture (pipefail)             exit 0; 0 lines matching ^skipped:; 22 "test result: ok", 0 failed
cargo +1.88 build --workspace --all-targets                  ok
```

## Invariants

- [x] Untouched LaTeX still comes out byte-identical — no emission path is touched; the fixture suites ran in the workspace test.
- [ ] No annotation changes the rendered PDF or the build status — not re-rendered; no emission change.
- [x] Nothing is injected into the emitted output — no emitter change.
- [x] No hard error can originate outside an explicit ExactTeX construct — the class only ever reaches a comparison through an `@id` and an `@ref`; `checking/11` keeps a plain-prose `@id` silent.
- [x] Every diagnostic this PR adds names its blame side — no new diagnostic; `XT1004`/`XT1020` are unchanged.

## Decorrelated review

Codex (gpt-5.6-sol, read-only), three passes. Over the float list, the `\captionof` rule, the fixture and the surrounding code: no findings; found sound the class mapping including the starred forms, innermost-float and header precedence, `\captionof` over an enclosing float, indexing and spans (no reachable panic), the fixture's order, classes, messages, offsets and lengths (reproduced by the binary), `fig:between` silent, the unit-test cases, the docs, wording. Over the first helper fix: one medium finding, adopted — a `}` inside a `%` comment in the title (`\section{A % }\nB}@id(x)`) attached before and stopped attaching under a comment-blind backward walk; fixed by the per-line `%` bound and the fallback to the previous reading, with the reproducer in the unit test. Over the final helper: found sound that every input the previous reading attached still attaches, the line walk, `\%` and `%` after `\\`, CRLF, no panic or underflow; one note not adopted — a pathological nesting of long arguments with an `@id` after each can make the per-`@id` scans overlap into quadratic work, which the previous reading (`rposition` plus a forward scan) shared, so it is not a regression and is recorded here.

## Dependencies

None

## Docs

- [x] `docs/grammar.md` §4: "The floats packages add are floats" and "A caption written by hand declares" beside the float-body rule, and inline fixture 13 (`checking/11`).
- [x] `docs/checking.md` §2: the declaration side of the comparison names the environments and the `\captionof` rule.

## Notes for the reviewer

- The helper reads bytes, so a `\section{X}` on a line opened by `%` attached an `@id` on the next line before this PR, and still does: the previous reading is kept as the fallback so that nothing that attached stops attaching, and four census identifiers depend on it (2212.12035 `ch:guided-rewriting`, `ch:imgproc`; 2312.17127 `sec:nom-monad`, `sec:probthy`, each an `@id` after a commented-out sectioning line under a live one of the same class). The commented-out case is uneven: a commented-out title with a braced group inside does not attach (2212.12035 `sec:matmul-opt-parallel-guided` stays unknown-open). A command that sits in a comment attaching nothing is the follow-up issue.
- `\captionof*` and the `\captionof{kind}[short]{long}` form are not read, by the issue's wording.
