### PR TITLE
A command on a commented-out line attaches nothing

### DIFF
--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -792,19 +792,14 @@ fn header_class(bytes: &[u8], at: usize, in_appendix: bool) -> Option<EntityClas
 /// groups inside it, so a title or caption holding `\textbf{…}`,
 /// `\cite{…}` or `$x^{2}$` attaches; the last `{` in the prefix, which is
 /// what was read before, is that inner group's. The forward scan then
-/// confirms the group, with its own rule for `%`. The last `{` stays as
-/// the second reading, so that nothing that attached before stops
-/// attaching: it is what reaches a command on a line that a `%` opens.
+/// confirms the group, with its own rule for `%`. A command on a line
+/// that a `%` opens is a comment, and attaches nothing (issue #166).
 fn last_command_with_balanced_argument(bytes: &[u8], command: &[u8]) -> bool {
-    let attaches = |open: usize| {
-        bytes[..open].ends_with(command)
-            && crate::scanner::balanced_end(bytes, open) == Some(bytes.len())
+    let Some(open) = argument_opening(bytes) else {
+        return false;
     };
-    argument_opening(bytes).is_some_and(attaches)
-        || bytes
-            .iter()
-            .rposition(|byte| *byte == b'{')
-            .is_some_and(attaches)
+    bytes[..open].ends_with(command)
+        && crate::scanner::balanced_end(bytes, open) == Some(bytes.len())
 }
 
 /// The `{` opening the braced group `bytes` ends with, if it ends with one.
@@ -1393,13 +1388,17 @@ mod tests {
             let (_, t) = table(&[("a.xtex", text)]);
             assert_eq!(t.declaration("x").map(|d| d.class), Some(class), "{text}");
         }
-        // Braces that do not balance attach nothing. (An unclosed group
+        // Braces that do not balance attach nothing (an unclosed group
         // runs to the line's end and takes the `@id` with it before this
-        // rule is reached, so the unbalanced case here is a stray `}`.)
+        // rule is reached, so the unbalanced case here is a stray `}`),
+        // and neither does a command on a commented-out line.
         for text in [
             "\\section{A}}@id(x)",
             "\\captionof{figure}{A} b}@id(x)",
             "\\section{A} % }\n@id(x)",
+            "% \\section{A}\n@id(x)",
+            "\\section{A}\n%\\subsection{B}\n@id(x)",
+            "text % \\captionof{figure}{A}\n@id(x)",
         ] {
             let (_, t) = table(&[("a.xtex", text)]);
             assert_eq!(


### PR DESCRIPTION
Closes #166

## What

A command on a commented-out line attaches nothing. `\section{A}` behind a `%`, with an `@id` on the next line, made that identifier a `Section` — attached to text TeX never reads.

## Why

#165 replaced the argument reading in `symbols::last_command_with_balanced_argument` with a walk back to the `{` that balances to the end, comments dropped per line, and kept the previous reading — the last `{` in the prefix — as a second reading so that nothing that attached before would stop attaching. The decorrelated review of that change confirmed the second reading differs from the first in one case only: a command on a commented-out line, and only when its title holds no braced group (a commented-out title with a group inside did not attach either way). That is the case #166 records; a comment is not an attachable construct under `docs/grammar.md` §4, so the second reading goes.

## The rule, as code

`last_command_with_balanced_argument` reads `argument_opening` alone: the `{` found by walking back from the end, one line at a time, counting only the part of each line before an unescaped `%`, then the forward `balanced_end` confirmation. The `rposition` fallback and its doc sentence are removed; nothing else changes.

## Evidence

`symbols::tests::an_argument_with_a_braced_group_inside_still_attaches` gains three unknown-open cases: a commented-out `\section` on the previous line, a commented-out `\subsection` under a live `\section` (the live heading is beyond the whitespace-only gap §4 allows, so the `@id` attaches to nothing), and a `\captionof` after a `%` mid-line. Its positive cases (nested groups, escaped braces, a `}` inside a comment in the title, `\%`) are unchanged and pass.

### E5 census over the corpus twins

Same method as #162 and #164: a scratch program linking `xtex-core` by path, `project::analyse` on each twin's root from `corpus/manifest.csv` under `E2-annotation-cost/work-69338b6` (50 papers), `SymbolTable::declarations()`, once against `main` (c3aeecb, a worktree) and once against this branch. Same 1,411 identifiers on both sides. Exactly four change, each `section` → unknown-open, each an `@id` under a commented-out heading: 2212.12035 `ch:guided-rewriting` and `ch:imgproc` (three commented-out `\chapter` lines above the `@id`), 2312.17127 `sec:nom-monad` and `sec:probthy` (a commented-out `\subsubsection` or `\subsection` between the live heading and the `@id`). No `fig:`, `tab:` or `alg:` identifier changes. Unknown-open over every prefix: 287.

The program and its output tables are not committed; nothing under the paper's experiment folders was written.

## Test plan

Local, with the CI invocations (`RUSTFLAGS=-D warnings`):

```
cargo fmt --all --check                                      ok
cargo clippy --workspace --all-targets -- -D warnings        ok
cargo test --workspace -- --nocapture (pipefail)             exit 0; 0 lines matching ^skipped:; 22 "test result: ok", 0 failed
cargo +1.88 build --workspace --all-targets                  ok
```

## Invariants

- [x] Untouched LaTeX still comes out byte-identical — no emission path is touched.
- [ ] No annotation changes the rendered PDF or the build status — not re-rendered; no emission change.
- [x] Nothing is injected into the emitted output — no emitter change.
- [x] No hard error can originate outside an explicit ExactTeX construct — the change only ever turns a class into unknown-open, which is consistent with every class.
- [x] Every diagnostic this PR adds names its blame side — no new diagnostic.

## Decorrelated review

Codex (gpt-5.6-sol, read-only) reviewed the line-walking helper and the fallback in #164 and reported the fallback as the only difference from the previous reading, in the commented-out case; this PR removes exactly that, and the three negatives plus the census are the check that nothing else moved. Not re-run over this diff: it is the removal the earlier pass described.

## Dependencies

None

## Docs

None: the documented rule (`docs/grammar.md` §4, whitespace only between the construct and the `@id`) already excludes a comment.

## Notes for the reviewer

- The four census identifiers sit under a live heading of the right class with a comment line in between. Reading a full-line comment as skippable whitespace would class them, and would be a grammar change; it is not taken here.
