### PR TITLE
A full-line comment in the gap does not break the attachment

### DIFF
--- a/crates/xtex-core/src/symbols.rs
+++ b/crates/xtex-core/src/symbols.rs
@@ -722,18 +722,7 @@ fn attached_class(
 /// The class of the attachable construct within the bounded whitespace
 /// before `at`, if there is one.
 fn header_class(bytes: &[u8], at: usize, in_appendix: bool) -> Option<EntityClass> {
-    let mut start = at;
-    let mut lines = 0usize;
-    while start > 0 && at - start < 256 && bytes[start - 1].is_ascii_whitespace() {
-        start -= 1;
-        if bytes[start] == b'\n' {
-            lines += 1;
-            if lines > 2 {
-                return None;
-            }
-        }
-    }
-    let before = &bytes[..start];
+    let before = &bytes[..attachment_gap_start(bytes, at)?];
     if before.ends_with(b"\\]") || before.ends_with(b"$$") {
         return Some(EntityClass::Equation);
     }
@@ -783,6 +772,50 @@ fn header_class(bytes: &[u8], at: usize, in_appendix: bool) -> Option<EntityClas
         }
     }
     None
+}
+
+/// Where the gap before the construct at `at` begins, or `None` when the
+/// gap runs past its bounds.
+///
+/// The gap is whitespace: at most two line endings and 256 bytes, as
+/// `docs/grammar.md` §4 bounds it. A line that is wholly a comment is
+/// skipped with its own line ending and counts toward neither bound — TeX
+/// does not read it, so it separates nothing (issue #168: four corpus
+/// identifiers sat under their heading with only commented-out lines
+/// between). A comment that shares a line with live text is not skipped.
+fn attachment_gap_start(bytes: &[u8], at: usize) -> Option<usize> {
+    let mut start = at;
+    let mut skipped = 0usize;
+    let mut lines = 0usize;
+    while start > 0 && skipped < 256 && bytes[start - 1].is_ascii_whitespace() {
+        if bytes[start - 1] == b'\n' {
+            if let Some(line) = comment_line_start(bytes, start - 1) {
+                start = line;
+                continue;
+            }
+            lines += 1;
+            if lines > 2 {
+                return None;
+            }
+        }
+        start -= 1;
+        skipped += 1;
+    }
+    Some(start)
+}
+
+/// The start of the line ending at `newline`, when that line is nothing
+/// but blanks and a comment.
+fn comment_line_start(bytes: &[u8], newline: usize) -> Option<usize> {
+    let line = bytes[..newline]
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |at| at + 1);
+    let content = line
+        + bytes[line..newline]
+            .iter()
+            .position(|byte| !matches!(byte, b' ' | b'\t'))?;
+    (bytes[content] == b'%' && !crate::scanner::is_escaped(bytes, content)).then_some(line)
 }
 
 /// Whether `bytes` ends with `command` followed by one balanced braced
@@ -1391,13 +1424,14 @@ mod tests {
         // Braces that do not balance attach nothing (an unclosed group
         // runs to the line's end and takes the `@id` with it before this
         // rule is reached, so the unbalanced case here is a stray `}`),
-        // and neither does a command on a commented-out line.
+        // and neither does a command on a commented-out line. (One under
+        // a live heading attaches to that heading, across the comment:
+        // `a_line_that_is_wholly_a_comment_does_not_separate_an_id_from_its_construct`.)
         for text in [
             "\\section{A}}@id(x)",
             "\\captionof{figure}{A} b}@id(x)",
             "\\section{A} % }\n@id(x)",
             "% \\section{A}\n@id(x)",
-            "\\section{A}\n%\\subsection{B}\n@id(x)",
             "text % \\captionof{figure}{A}\n@id(x)",
         ] {
             let (_, t) = table(&[("a.xtex", text)]);
@@ -1406,6 +1440,69 @@ mod tests {
                 Some(EntityClass::UnknownOpen),
                 "{text}"
             );
+        }
+    }
+
+    #[test]
+    fn a_line_that_is_wholly_a_comment_does_not_separate_an_id_from_its_construct() {
+        // Four corpus identifiers sat under their heading with only
+        // commented-out lines between, and only whitespace was skipped
+        // (issue #168). The comment lines count toward neither bound.
+        let long = format!(
+            "\\chapter{{A}}\n{}@id(x)",
+            "% a commented-out line\n".repeat(20)
+        );
+        for (text, class) in [
+            ("\\section{A}\n% note\n@id(x)", EntityClass::Section),
+            (
+                "\\section{A}\n  %\\subsection{B}\n\t% c\n@id(x)",
+                EntityClass::Section,
+            ),
+            ("\\section{A}\n\n% note\n@id(x)", EntityClass::Section),
+            ("\\section{A}\r\n% note\r\n@id(x)", EntityClass::Section),
+            (long.as_str(), EntityClass::Section),
+            (
+                "\\captionof{figure}{A}\n% note\n@id(x)",
+                EntityClass::Figure,
+            ),
+            // The opener alone, with no `\end` for the body rule to read.
+            (
+                "\\begin{table}\n% note\n@id(x)\n\\caption{A}",
+                EntityClass::Table,
+            ),
+        ] {
+            let (_, t) = table(&[("a.xtex", text)]);
+            assert_eq!(t.declaration("x").map(|d| d.class), Some(class), "{text}");
+        }
+        // A commented-out heading is still not a heading; the live line
+        // endings are still bounded at two; `\%` opens no comment; and a
+        // comment beside live text is not skipped.
+        for text in [
+            "% \\section{A}\n% note\n@id(x)",
+            "\\section{A}\n\n% note\n\n@id(x)",
+            "\\section{A}\n\\% b\n@id(x)",
+            "\\section{A} % note\n@id(x)",
+        ] {
+            let (_, t) = table(&[("a.xtex", text)]);
+            assert_eq!(
+                t.declaration("x").map(|d| d.class),
+                Some(EntityClass::UnknownOpen),
+                "{text}"
+            );
+        }
+        // The 256-byte bound counts the live whitespace, line endings
+        // included, and a comment line moves it by nothing: with the
+        // heading's own line ending, 255 spaces are the last that attach.
+        for (spaces, class) in [(255, EntityClass::Section), (256, EntityClass::UnknownOpen)] {
+            for comment in ["", "% note\n"] {
+                let text = format!("\\section{{A}}\n{comment}{}@id(x)", " ".repeat(spaces));
+                let (_, t) = table(&[("a.xtex", &text)]);
+                assert_eq!(
+                    t.declaration("x").map(|d| d.class),
+                    Some(class),
+                    "{spaces} spaces, comment {comment:?}"
+                );
+            }
         }
     }
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -283,9 +283,12 @@ The skipped region is bounded by both of these limits:
 - no more than two line endings; and
 - no more than 256 bytes.
 
-The first limit reached ends the search. Comments, commands and non-whitespace bytes are not skipped. If no
-attachable construct occurs within the bounded region, `@id` is an explicit but unattached annotation and
-produces a hard error blamed on that annotation.
+The first limit reached ends the search. A line that is wholly a comment — blanks, then `%` to the end of
+the line — is skipped together with its line ending and counts toward neither limit, since TeX does not
+read it and it separates nothing; a commented-out command is still not a command (fixture `checking/12`).
+Other comments, commands and non-whitespace bytes are not skipped. If no attachable construct occurs within
+the bounded region, `@id` is an explicit but unattached annotation and produces a hard error blamed on
+that annotation.
 
 The two-line, 256-byte bound is a locality decision. The corpus establishes that same-line attachment is
 insufficient: 442 of 479 measured labels follow their captions on the next line, while 9 share the caption
@@ -474,6 +477,11 @@ Fixtures must include:
     `sidewaystable*`, a `wrapfigure`, a `wraptable`, a `longtable` and a `longtable*`, after
     `\captionof{figure}` inside a `minipage` and `\captionof{table}` inside a `center`, and in prose between
     two of them, each with a reference that reports its class or its absence (`checking/11`).
+14. `@id` under a `\section`, a `\captionof{figure}` and a `\begin{table}` with a line that is wholly a
+    comment between, under a `\section` with two comment lines and with a comment line after a blank line,
+    under a `\section` with a comment line between two blank lines (past the bound), and under a
+    commented-out `\section` and `\captionof` with a comment line between, each with a reference that
+    reports its class or its absence (`checking/12`).
 
 ### Bibliography discovery and citation checking
 

--- a/tests/fixtures/checking/12-comment-in-the-gap/checked.txt
+++ b/tests/fixtures/checking/12-comment-in-the-gap/checked.txt
@@ -1,0 +1,5 @@
+XT1020|figure|sec:one|615|6|prose says `Figure` but `sec:one` is a section
+XT1020|figure|sec:two|636|6|prose says `Figure` but `sec:two` is a section
+XT1020|figure|sec:three|657|6|prose says `Figure` but `sec:three` is a section
+XT1020|table|fig:six|724|5|prose says `Table` but `fig:six` is a figure
+XT1020|figure|tab:eight|766|6|prose says `Figure` but `tab:eight` is a table

--- a/tests/fixtures/checking/12-comment-in-the-gap/expect.txt
+++ b/tests/fixtures/checking/12-comment-in-the-gap/expect.txt
@@ -1,0 +1,11 @@
+transport: identical
+scanner: id id id id id id id id ref ref ref ref ref ref ref ref
+constructs: a line that is wholly a comment between a construct and its
+  `@id` is skipped and counts toward neither bound, so sec:one (one comment
+  line), sec:two (a commented-out title and a note) and sec:three (a blank
+  line, then a comment line) are sections, fig:six is a figure by its
+  `\captionof` and tab:eight a table by its opener, and the words Figure and
+  Table before them are XT1020. sec:four has a comment line between two
+  blank lines, three live line endings, past the bound; sec:five and
+  fig:seven sit under a commented-out `\section` and `\captionof`; all
+  three stay unknown-open and silent. Issue #168.

--- a/tests/fixtures/checking/12-comment-in-the-gap/input.xtex
+++ b/tests/fixtures/checking/12-comment-in-the-gap/input.xtex
@@ -1,0 +1,36 @@
+\section{One}
+% a note between the heading and its identifier
+@id(sec:one)
+\section{Two}
+%\section{An earlier title}
+% and a second note
+@id(sec:two)
+\section{Three}
+
+% a note after a blank line
+@id(sec:three)
+\section{Four}
+
+% a note between two blank lines
+
+@id(sec:four)
+% \section{Five, commented out}
+% a note
+@id(sec:five)
+\begin{minipage}{\linewidth}
+\captionof{figure}{Six}
+% a note under the caption
+@id(fig:six)
+\end{minipage}
+\begin{center}
+% \captionof{figure}{Seven, commented out}
+% a note
+@id(fig:seven)
+\end{center}
+\begin{table}
+% a note under the opener
+@id(tab:eight)
+\caption{Eight}
+\end{table}
+Figure~@ref(sec:one) Figure~@ref(sec:two) Figure~@ref(sec:three) Figure~@ref(sec:four)
+Figure~@ref(sec:five) Table~@ref(fig:six) Table~@ref(fig:seven) Figure~@ref(tab:eight)


### PR DESCRIPTION
Closes #168

## What

A line that is wholly a comment — blanks, then `%` to the end of the line — no longer separates a construct from the `@id` that declares it. It is skipped with its own line ending and counts toward neither of the gap's bounds. Four corpus identifiers under a live heading with only commented-out lines between come back to `Section`.

## Why

Grammar §4 lets only whitespace, at most two line endings and 256 bytes, sit between a construct and its `@id`. Until #167 a last-brace reading had reached a heading across such lines by accident; removing it left the four identifiers unknown-open. The heading is real and the identifier is its own; only text TeX never reads separates them.

## The rule, as code

- `symbols::attachment_gap_start` (new; the lookback that opened `header_class`, moved out unchanged in its bounds) walks back over whitespace as before and, at each line ending, asks `comment_line_start` whether the line that ends there is nothing but blanks and an unescaped `%`. Such a line is skipped whole, its line ending included, and neither `lines` nor `skipped` moves. A `%` escaped as `\%` opens no comment; the check uses `scanner::is_escaped`, so `\\%` does.
- **Recorded decision** (the issue asked for one): a comment line counts as **none** of the two permitted line endings, and its bytes count toward neither bound. The conservative reading — one line ending per comment line — would leave two of the four identifiers unknown-open (2212.12035 `ch:imgproc` has five commented-out `\chapter` lines in its gap, `ch:guided-rewriting` four), so the fixtures and the census settled it. The gap stays bounded in what TeX reads: two live line endings and 256 live whitespace bytes, line endings included, exactly as before.
- Out of scope and unchanged: a commented-out command attaches nothing (#166), and a comment that shares a line with live text — `\section{A} % note` — is not skipped.
- One existing negative moved: `an_argument_with_a_braced_group_inside_still_attaches` asserted that a commented-out `\subsection` under a live `\section` left the `@id` unknown-open; the `@id` now attaches to the live `\section` across the comment, which is this issue, so the case lives in the new test as a positive.

## Evidence

Fixture `tests/fixtures/checking/12-comment-in-the-gap`: `@id` under a `\section` with one comment line between; with a commented-out title and a note (two comment lines); with a blank line then a comment line (two live line endings, at the bound); with a comment line between two blank lines (three live line endings, past the bound, unknown-open); under a commented-out `\section` with a note (unknown-open); under `\captionof{figure}` in a `minipage` with a note; under a commented-out `\captionof` with a note (unknown-open); under a `\begin{table}` opener with a note. The expected codes and offsets were written from the rule before the harness ran (offsets computed from the input bytes by a script), and the harness produced the same five lines:

```
XT1020|figure|sec:one|615|6|prose says `Figure` but `sec:one` is a section
XT1020|figure|sec:two|636|6|prose says `Figure` but `sec:two` is a section
XT1020|figure|sec:three|657|6|prose says `Figure` but `sec:three` is a section
XT1020|table|fig:six|724|5|prose says `Table` but `fig:six` is a figure
XT1020|figure|tab:eight|766|6|prose says `Figure` but `tab:eight` is a table
```

Unit test `symbols::tests::a_line_that_is_wholly_a_comment_does_not_separate_an_id_from_its_construct`: one comment line; a tab- and space-indented pair; a blank line then a comment; CRLF; twenty comment lines under a `\chapter`; `\captionof{figure}`; a `\begin{table}` opener with no `\end` (so the body rule cannot supply the class). Negatives: a commented-out heading with a note, a comment between two blank lines, `\%` at the start of a line, a comment beside the heading on its own line. A boundary pair: with the heading's own line ending, 255 spaces attach and 256 do not, with and without a comment line between — the byte bound counts live whitespace only and a comment line moves it by nothing.

### E5 census over the corpus twins

Same method as #162, #164 and #167: a scratch program linking `xtex-core` by path, `project::analyse` on each twin's root from `corpus/manifest.csv` under `E2-annotation-cost/work-69338b6` (50 papers), `SymbolTable::declarations()`, once against `main` (173cc9a, a worktree) and once against this branch. Same 1,411 identifiers on both sides. **Ten** change, every one unknown-open → a class, every one an `@id` under a live heading with only comment lines between:

| paper | identifier | gap | class |
|---|---|---|---|
| 2212.12035 | `ch:imgproc` | five commented-out `\chapter` lines | section |
| 2212.12035 | `ch:guided-rewriting` | a note and three commented-out `\chapter` lines | section |
| 2212.12035 | `sec:matmul-opt-parallel-guided` | one commented-out `\section` | appendix |
| 2312.17127 | `sec:nom-monad` | one commented-out `\subsubsection` | section |
| 2312.17127 | `sec:probthy` | one commented-out `\subsection` | section |
| 2301.00301 | `sec:gen_ptr`, `sec:introduction`, `sec:preliminaries`, `sec:related_work`, `sections:applications` | one `%\vspace{-1em}` line each | section |

The four the issue names are among them. The other six were never classed on any earlier `main`: the last-brace reading only reached a commented-out line whose last braced group followed a sectioning command, and `%\vspace{-1em}` and `%\section{Example of Discovered \Rise{} Programs}` (a nested group) never did. They are the issue's shape exactly. Nothing else moves; unknown-open over every prefix drops from 287 to 277.

The program and its output tables are not committed; nothing under the paper's experiment folders was written.

## Test plan

Local, with the CI invocations (`RUSTFLAGS=-D warnings`):

```
cargo fmt --all --check                                      ok
cargo clippy --workspace --all-targets -- -D warnings        ok
cargo test --workspace -- --nocapture (pipefail)             exit 0; 0 lines matching ^skipped:; 22 "test result: ok", 0 failed
cargo +1.88 build --workspace --all-targets                  ok
```

## Invariants

- [x] Untouched LaTeX still comes out byte-identical — no emission path is touched; the fixture suites ran in the workspace test.
- [ ] No annotation changes the rendered PDF or the build status — not re-rendered; no emission change.
- [x] Nothing is injected into the emitted output — no emitter change.
- [x] No hard error can originate outside an explicit ExactTeX construct — the class only ever reaches a comparison through an `@id` and an `@ref`; `checking/12` keeps three unattached `@id`s silent.
- [x] Every diagnostic this PR adds names its blame side — no new diagnostic.

## Decorrelated review

Codex (gpt-5.6-sol, read-only) over the diff, the fixture and the surrounding code, before the push. One medium finding, **not adopted**: that a comment line followed by exactly 256 spaces fails to attach "although the 256 spaces are within the documented bound". The bound counts every live whitespace byte, line endings included, and the heading's own line ending is one of them, so 256 spaces make 257 and do not attach with or without the comment line, as before this PR; the boundary pair in the unit test (255 attach, 256 do not, with and without a comment line) records this. Found sound: no input that attached before stops attaching; the `lines` and `skipped` accounting; CRLF; a comment as the first line; tab-indented, over-long and many consecutive comment lines; `\%` and `\\%`; no underflow or out-of-bounds; the walk linear in the bytes it passes over with no quadratic case across many `@id`s; the fixture's five diagnostics (order, entity, message, offsets 615/636/657/724/766, lengths) against the harness; fixture item 14 and `expect.txt`; wording.

## Dependencies

None

## Docs

- [x] `docs/grammar.md` §4: one sentence after the two limits, and inline fixture 14 (`checking/12`).

## Notes for the reviewer

- A comment beside live text on the construct's own line (`\caption{…} % note`, `\section{A} % note`) is still not skipped: the line has live content, so it is outside this issue. The corpus shape it would serve is a caption with a trailing note; that is a separate decision.
