### PR TITLE
The closed list was not closed: document the record family, and pin it with a test

### DIFF
--- a/crates/xtex-core/tests/docs_parity.rs
+++ b/crates/xtex-core/tests/docs_parity.rs
@@ -25,7 +25,9 @@ fn codes_in_sources(dir: &Path) -> BTreeSet<String> {
     let mut found = BTreeSet::new();
     let mut stack = vec![dir.to_path_buf()];
     while let Some(here) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&here) else { continue };
+        let Ok(entries) = std::fs::read_dir(&here) else {
+            continue;
+        };
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {
@@ -63,7 +65,8 @@ fn every_code_the_compiler_emits_is_documented() {
     let root = root();
     let emitted = codes_in_sources(&root.join("crates"));
     let documented = codes_in(
-        &std::fs::read_to_string(root.join("docs/checking.md")).expect("docs/checking.md is readable"),
+        &std::fs::read_to_string(root.join("docs/checking.md"))
+            .expect("docs/checking.md is readable"),
     );
     let undocumented: Vec<&String> = emitted.difference(&documented).collect();
     assert!(

--- a/crates/xtex-core/tests/docs_parity.rs
+++ b/crates/xtex-core/tests/docs_parity.rs
@@ -1,0 +1,79 @@
+//! The closed list is only closed if the document says what the code says.
+//!
+//! `docs/checking.md` §3 claims its table of hard errors is closed: a
+//! condition absent from the list is not a hard error. That claim was false
+//! for four codes at once — the record family, `XT1016`–`XT1019`, lived in
+//! `verification.rs` and in no document — and a reader who checked the code
+//! against the prose would have found it before we did. This test makes the
+//! claim mechanical: every diagnostic code the crates can emit is named in
+//! the document, and every code the document names still exists in the
+//! crates.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("the workspace root is two levels above the crate")
+        .to_path_buf()
+}
+
+/// Every `"XTnnnn"` literal in a tree of Rust sources.
+fn codes_in_sources(dir: &Path) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(here) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&here) else { continue };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|n| n == "target") {
+                    continue;
+                }
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                // Tests assert on codes they do not emit; sources emit them.
+                if path.components().any(|c| c.as_os_str() == "tests") {
+                    continue;
+                }
+                let text = std::fs::read_to_string(&path).unwrap_or_default();
+                found.extend(codes_in(&text));
+            }
+        }
+    }
+    found
+}
+
+fn codes_in(text: &str) -> BTreeSet<String> {
+    let bytes = text.as_bytes();
+    let mut found = BTreeSet::new();
+    for (i, _) in text.match_indices("XT") {
+        let digits = &bytes[(i + 2).min(bytes.len())..(i + 6).min(bytes.len())];
+        if digits.len() == 4 && digits.iter().all(u8::is_ascii_digit) {
+            found.insert(format!("XT{}", String::from_utf8_lossy(digits)));
+        }
+    }
+    found
+}
+
+#[test]
+fn every_code_the_compiler_emits_is_documented() {
+    let root = root();
+    let emitted = codes_in_sources(&root.join("crates"));
+    let documented = codes_in(
+        &std::fs::read_to_string(root.join("docs/checking.md")).expect("docs/checking.md is readable"),
+    );
+    let undocumented: Vec<&String> = emitted.difference(&documented).collect();
+    assert!(
+        undocumented.is_empty(),
+        "these codes are emitted by the crates and named in no table of docs/checking.md: {undocumented:?}. \
+         The document claims its list is closed, so a code that is not in it makes the claim false."
+    );
+    let gone: Vec<&String> = documented.difference(&emitted).collect();
+    assert!(
+        gone.is_empty(),
+        "docs/checking.md names codes the crates no longer emit: {gone:?}"
+    );
+}

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -142,6 +142,7 @@ error.
 | `XT1012` | A sidecar record whose revision construct no longer exists | any |
 | `XT1013` | A sidecar that cannot be read, or that names a different document | any |
 | `XT1014` | An explicit inline construct (`@id`, a reference or citation command, `@import`) whose closing `)` is not found before line end | any |
+| `XT1018` | Under `--verified` only: a recorded verdict of `mismatch`, or a `partial` whose difference is high severity, on an entry that an `@cite(k)` demands | `Citation` |
 | `XT1020` | An entity-kind word immediately before a reference construct names class A, and the target's known class is B, A ≠ B | both known |
 
 Two properties hold across the whole table and are tested as properties, not as examples:
@@ -152,6 +153,25 @@ Two properties hold across the whole table and are tested as properties, not as 
 2. **Every row requires both sides known.** `XT1004` and `XT1020` cannot fire when either side is `?O`,
    and `XT1005` cannot fire when the bibliography is `Unavailable`. Uncertainty on either side means
    silence.
+
+`XT1018` is the only row that depends on a file outside the document, and it is the one row with a double
+opt-in. All three conditions must hold together:
+
+- the record exists and the author passed `--verified` (without the flag the check is byte-for-byte what it
+  always was);
+- the entry is demanded by an explicit `@cite(k)`, never by a plain `\cite{k}`;
+- the recorded verdict is `mismatch` — the source answers with a different work — or `partial` with a
+  high-severity difference, which today means the author list.
+
+Everything else the record can say is advisory and cannot change the exit code: a dead address, an address
+that answered from elsewhere, an entry the verifier could not settle, a verdict older than the window, an
+entry edited since it was verified, and a `partial` whose differences are all medium (year, pages, venue).
+The same is true of a `mismatch` on an entry no `@cite` demands.
+
+This is the gradual policy applied to the world outside the document, and it is deliberate: a `.tex` file
+renamed to `.xtex` can never fail because of the network, and the hard error is reserved for the case
+verification exists to catch — an entry that names a work the source does not have. It is also `xtex check`
+that fails, never `xtex build`: the build does not read the record, so the PDF is produced either way.
 
 ### Exit codes
 
@@ -184,12 +204,18 @@ The class of things that are advisory and not errors:
 |---|---|---|
 | `XT2001` | The document contains `@cite`, and the bibliography is `Unavailable` (see §7) — the advisory is about the file, never about a key | by default |
 | `XT2002` | An `@word(…)` in prose that no construct claims and that reads like a command — `@eqref(eq:x)`, `@citeyear(k)`. The bytes are transported, so they reach the PDF as literal text with exit 0; the advisory names the reference or citation commands that are checked | by default |
+| `XT1015` | Under `--verified`: the record itself cannot be read, so nothing in it is replayed | by default |
+| `XT1016` | Under `--verified`: the claim was edited after it was verified, so the recorded verdict no longer speaks for it | by default |
+| `XT1017` | Under `--verified`: the verdict is older than the window, or carries a date that cannot be read | by default |
+| `XT1018` | Under `--verified`: the verdicts of the hard-error row, where no `@cite` demands the entry, or where the differences are all medium — a year, a page range, a venue | by default |
+| `XT1019` | Under `--verified`: the verifier could not settle the entry, an address did not answer, or an address answered from somewhere else | by default |
 | — | An unresolved `\ref` or `\cite` written in plain LaTeX | `--strict-tex` |
 | — | A `\label` in an opaque region that appears to collide with an `@id` | `--strict-tex` |
 | — | A region that entered quarantine early, which is a coverage signal rather than a defect | `--strict-tex` |
 
-Codes are assigned in two ranges that do not overlap: `XT1nnn` is a hard error, `XT2nnn` an advisory. A row
-without a code is not implemented yet.
+Codes are assigned in two ranges: `XT2nnn` is always an advisory, and `XT1nnn` is a hard error **except in
+the record family**, `XT1015`–`XT1019`, where the severity is stated per row above and only `XT1018` can
+reach the exit code. A row without a code is not implemented yet.
 
 `XT2002` is printed by default rather than behind `--strict-tex` for one reason: the shape it reports is
 ExactTeX's own entry-token shape, not plain LaTeX. Measured on 2026-09-01 with

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -115,9 +115,15 @@ its findings as ordinary diagnostics at the claim's own span — a mismatch on t
 on the URL's line, each wording dated. Without `--verified`, the check is byte-for-byte what it always
 was.
 
-Severity follows the gradual policy of the rest of the language: a finding is a hard error only where the
-author opted in (an `@cite` demanding the entry, met by a `mismatch` or a high-severity diff); everything
-else — reachability, expiry, drift — is advisory. The WebAssembly surface exposes the same two calls
+Severity follows the gradual policy of the rest of the language, with the codes named so a reader can find
+them: `XT1018` for a verdict about the entry itself, `XT1019` for one about reaching an address, `XT1017`
+for a verdict older than the window, `XT1016` for a claim edited since it was verified. Of those only
+`XT1018` can reach the exit code, and only when the author opted in twice — the record passed with
+`--verified`, and the entry demanded by an explicit `@cite(k)` — and the verdict is `mismatch` or a
+`partial` whose difference is high severity, which today means the author list. Everything else —
+reachability, expiry, drift, a medium difference in year or pages, a mismatch on an entry no `@cite`
+demands — is advisory, and no advisory changes the exit code. `xtex build` never reads the record:
+the failure, when there is one, belongs to `xtex check`. [`checking.md`](checking.md) §3 carries the rows. The WebAssembly surface exposes the same two calls
 (`xtex_claims`, `xtex_check_with_record`), so an editor in a browser replays the same record with the
 same answers; the parity suite holds it to that.
 


### PR DESCRIPTION
`docs/checking.md` §3 states that its table of hard errors is closed: if a condition is not on the list, it is not a hard error. Five codes contradicted that. `XT1015` to `XT1019` are emitted by `verification.rs` and `project.rs` and appeared in no document, and one of them — `XT1018` — is a hard error. A reader who checked the prose against the code would have caught it.

**What this changes**

- `XT1018` joins the hard-error table, with the condition stated exactly: under `--verified` only, a recorded verdict of `mismatch`, or a `partial` whose difference is high severity, on an entry demanded by an explicit `@cite(k)`.
- A paragraph after the table names the double opt-in, because this is the one row whose severity depends on a file outside the document, and says what stays advisory: reachability, expiry, drift, medium differences, and a mismatch on an entry no `@cite` demands. It also says the failure belongs to `xtex check`; `xtex build` does not read the record.
- `XT1015`–`XT1017` and `XT1019` join the advisory table.
- The sentence claiming the code ranges are exhaustive (`XT1nnn` hard, `XT2nnn` advisory) was false for the record family, and now says so.
- `verification.md` §4 names the codes so a reader can find them.

**What keeps it true**

`crates/xtex-core/tests/docs_parity.rs`: every `XTnnnn` literal the crates emit must be named in `docs/checking.md`, and every code the document names must still exist in the crates. It failed on the first run over `XT1015`, which this change had missed.

Test plan:

```
$ cargo test -p xtex-core --test docs_parity
test result: FAILED
  these codes are emitted by the crates and named in no table of docs/checking.md: ["XT1015"]

$ cargo test -p xtex-core --test docs_parity   # after documenting XT1015
test result: ok. 1 passed; 0 failed

$ cargo test -p xtex-core
test result: ok. 9 passed · 4 passed · 9 passed · 1 passed
```

https://claude.ai/code/session_015bh8Uk58HPaeuxAUrxSgPK
