### PR TITLE
A refusal carries its reason out of the wasm surface

### DIFF
--- a/crates/xtex-wasm/src/lib.rs
+++ b/crates/xtex-wasm/src/lib.rs
@@ -627,7 +627,12 @@ pub unsafe extern "C" fn xtex_revise(pointer: *const u8, len: usize) -> *mut u8 
         return result(&[]);
     };
 
-    let outcome: Result<Resolved, ()> = match action.as_str() {
+    // The reason travels with the refusal. A surface that answers "no" and
+    // keeps the reason to itself leaves its caller to invent one, and an
+    // invented reason is worse than none: on 2026-09-03 an editor told its
+    // author the sidecar was unreadable when the truth was that a construct
+    // written inside a command's argument is invisible to the compiler.
+    let outcome: Result<Resolved, xtex_core::review::ReviewError> = match action.as_str() {
         "accept" | "reject" => {
             let resolution = if action == "accept" {
                 Resolution::Accept
@@ -636,7 +641,6 @@ pub unsafe extern "C" fn xtex_revise(pointer: *const u8, len: usize) -> *mut u8 
             };
             resolve(&source, &id, resolution)
                 .map(|(rewritten, removed)| (rewritten, vec![(id.clone(), resolution, removed)]))
-                .map_err(|_| ())
         }
         "accept-all" => {
             let mut current = source.clone();
@@ -651,7 +655,7 @@ pub unsafe extern "C" fn xtex_revise(pointer: *const u8, len: usize) -> *mut u8 
                         current = rewritten;
                         events.push((next, Resolution::Accept, removed));
                     }
-                    Err(_) => break Err(()),
+                    Err(error) => break Err(error),
                 }
             }
         }
@@ -661,13 +665,14 @@ pub unsafe extern "C" fn xtex_revise(pointer: *const u8, len: usize) -> *mut u8 
             }
             return match prune_sidecar(&sidecar, &source, &by, &stamp) {
                 Ok(pruned) => result(&pair(&source, &pruned)),
-                Err(_) => result(&[]),
+                Err(error) => result(&refusal(&error)),
             };
         }
         _ => return result(&[]),
     };
-    let Ok((rewritten, events)) = outcome else {
-        return result(&[]);
+    let (rewritten, events) = match outcome {
+        Ok(answer) => answer,
+        Err(error) => return result(&refusal(&error)),
     };
     let updated_sidecar = if sidecar.is_empty() {
         Vec::new()
@@ -676,7 +681,7 @@ pub unsafe extern "C" fn xtex_revise(pointer: *const u8, len: usize) -> *mut u8 
         for (event_id, resolution, removed) in &events {
             match resolve_sidecar(&records, event_id, *resolution, &by, &stamp, removed) {
                 Ok(next) => records = next,
-                Err(_) => return result(&[]),
+                Err(error) => return result(&refusal(&error)),
             }
         }
         records
@@ -760,6 +765,14 @@ fn bundle_file(bundle: &Bundle, name: &str) -> Option<Vec<u8>> {
 }
 
 /// Two length-prefixed fields in one result.
+/// A refusal, in the shape a caller already knows how to read: an empty
+/// first item — there is no rewritten document — and the reason in the
+/// second, as `CODE: message`. A caller that only checks the first item
+/// still behaves as it did; one that reads the second can say why.
+fn refusal(error: &xtex_core::review::ReviewError) -> Vec<u8> {
+    pair(&[], format!("{}: {}", error.code, error.message).as_bytes())
+}
+
 fn pair(first: &[u8], second: &[u8]) -> Vec<u8> {
     let mut out = Vec::with_capacity(8 + first.len() + second.len());
     out.extend_from_slice(&u32::try_from(first.len()).unwrap_or(u32::MAX).to_le_bytes());

--- a/crates/xtex-wasm/tests/record_surface.rs
+++ b/crates/xtex-wasm/tests/record_surface.rs
@@ -5,7 +5,7 @@ use xtex_core::verification::{
     BibVerdict, ClaimKind, DiffSeverity, FieldDiff, Verdict, VerificationRecord, VerifiedClaim,
     write_record,
 };
-use xtex_wasm::{xtex_check_with_record, xtex_claims};
+use xtex_wasm::{xtex_check_with_record, xtex_claims, xtex_revise};
 
 fn push_text(out: &mut Vec<u8>, text: &str) {
     out.extend_from_slice(&u32::try_from(text.len()).expect("fits").to_le_bytes());
@@ -136,4 +136,35 @@ fn an_unreadable_record_is_an_advisory_not_a_silent_skip() {
     let answer = call(xtex_check_with_record, &input);
     assert!(answer.contains("XT1015"), "{answer}");
     assert!(answer.contains("unreadable"), "{answer}");
+}
+
+/// A refusal says why. The editor that consumes this surface printed its own
+/// guess — "rejecting needs the sidecar" — for every failure, including the
+/// one that had nothing to do with a sidecar: a construct written inside a
+/// command's argument, which the compiler does not read. A surface that keeps
+/// the reason to itself invites exactly that invention.
+#[test]
+fn a_refused_resolution_answers_with_its_reason() {
+    let source = "\\documentclass{article}\n\\begin{document}\nplain\n\\end{document}\n";
+    let mut input = Vec::new();
+    for field in [
+        "accept",
+        "change:absent",
+        "camilochs",
+        "2026-09-03T00:00:00Z",
+        "",
+    ] {
+        push_text(&mut input, field);
+    }
+    input.extend_from_slice(&bundle("main.xtex", &[("main.xtex", source)]));
+    let answer = call(xtex_revise, &input);
+    let bytes = answer.as_bytes();
+    let rewritten = u32::from_le_bytes(bytes[..4].try_into().expect("length")) as usize;
+    assert_eq!(rewritten, 0, "a refusal rewrites nothing: {answer}");
+    let reason_len = u32::from_le_bytes(bytes[4..8].try_into().expect("length")) as usize;
+    let reason = &answer[8..8 + reason_len];
+    assert!(
+        reason.starts_with("XT1002") && reason.contains("change:absent"),
+        "the reason names the code and the revision: {reason}"
+    );
 }


### PR DESCRIPTION
`xtex_revise` answered every failure with an empty payload, discarding the `ReviewError` that `xtex_core::review::resolve` had already produced with a code and a message. The CLI prints that error; the WebAssembly surface threw it away.

**Why it matters, from a real failure (2026-09-03)**

An editor built on this surface could not accept or reject two revisions. Having no reason from the compiler, it printed the only one it had been written to guess: *"rejecting needs the sidecar so removed text stays recoverable"*. The sidecar was intact. The real cause was `XT1012`: both constructs sat inside the third argument of `\resizebox`, which the scanner carries through as opaque bytes and never reads, so there was no construct to resolve.

The invented reason sent the repair in the wrong direction for an hour. A surface that says "no" without saying why invites its caller to invent a cause, and an invented cause is worse than none.

**What changes**

- `xtex_revise` returns a refusal in the shape the caller already decodes: an empty first item, because nothing was rewritten, and `CODE: message` in the second. Callers that check only the first item behave exactly as before, so this is additive.
- The `accept`, `reject`, `accept-all` and `prune` paths all carry their error; nothing maps an error to `()` any more.

Test plan:

```
$ cargo test -p xtex-wasm --test record_surface
test result: ok. 5 passed; 0 failed
  a_refused_resolution_answers_with_its_reason: XT1002 names the missing revision

$ cargo test --workspace
test result: ok. 16 · 11 · 5 · 1 passed; 0 failed

$ cargo clippy --all-targets --all-features -- -D warnings
(no warnings)
```

The editor side is a separate change: it must print what the compiler says and never a reason of its own.

https://claude.ai/code/session_015bh8Uk58HPaeuxAUrxSgPK
